### PR TITLE
Refactor branch name master->main.

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - main
     - develop
     - "/^\\d.*/"
 language: python
@@ -16,9 +16,9 @@ env:
 stages:
   - name: test
   - name: deploy
-    if: branch = master AND type != pull_request
+    if: branch = main AND type != pull_request
   - name: experimental
-    if: branch != master
+    if: branch != main
 addons:
   postgresql: '9.4'
 services:
@@ -129,7 +129,7 @@ jobs:
         provider: pypi
         edge: true
         on:
-          branch: master
+          branch: main
         distributions: sdist bdist_wheel
         skip_existing: true
         username: __token__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ discourse_url = "https://discuss.greatexpectations.io/"
 source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = "index"
+index_doc = "index"
 
 # General information about the project.
 project = u"great_expectations"
@@ -204,7 +204,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        index_doc,
         "great_expectations.tex",
         u"great\\_expectations Documentation",
         u"The Great Expectations Team",
@@ -218,7 +218,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, "great_expectations", u"great_expectations Documentation", [author], 1)
+    (index_doc, "great_expectations", u"great_expectations Documentation", [author], 1)
 ]
 
 
@@ -229,7 +229,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        index_doc,
         "great_expectations",
         u"great_expectations Documentation",
         author,

--- a/docs/contributing/miscellaneous.rst
+++ b/docs/contributing/miscellaneous.rst
@@ -50,15 +50,15 @@ GE core team members use this checklist to ship releases.
 
 * Submit this as a PR against ``develop``
 * After successful checks, get it approved and merged.
-* Update your local branches and switch to master: ``git fetch --all; git checkout master; git pull``.
-* Merge the now-updated ``develop`` branch into ``master`` and trigger the release: ``git merge origin/develop; git push``
+* Update your local branches and switch to main: ``git fetch --all; git checkout main; git pull``.
+* Merge the now-updated ``develop`` branch into ``main`` and trigger the release: ``git merge origin/develop; git push``
 * Wait for all the builds to complete (including the deploy job).
 * Check `PyPI <https://pypi.org/project/great-expectations/#history>`__ for the new release
 * Create an annotated git tag:
 
   * Run ``git tag -a <<VERSION>> -m "<<VERSION>>"`` with the correct new version
   * Push the tag up by running ``git push origin <<VERSION>>`` with the correct new version
-  * Merge ``master`` into ``develop`` so that the tagged commit becomes part of the history for ``develop``: ``git checkout develop; git pull; git merge master``
+  * Merge ``main`` into ``develop`` so that the tagged commit becomes part of the history for ``develop``: ``git checkout develop; git pull; git merge main``
   * On develop, add a new "develop" section header to changelog.rst, and push the updated file with message "Update changelog for develop"
 
 * `Create the release on GitHub <https://github.com/great-expectations/great_expectations/releases>`__ with the version number. Copy the changelog notes into the release notes, and update any rst-specific links to use github issue numbers.
@@ -68,5 +68,5 @@ GE core team members use this checklist to ship releases.
 
 Beta Release Notes
 
-* To ship a beta release, follow the above checklist, but use the branch name ``v0.11.x`` as the equivalent of ``master`` and ``v0.11.x-develop`` as the equivalent of ``master``
+* To ship a beta release, follow the above checklist, but use the branch name ``v0.11.x`` as the equivalent of ``main`` and ``v0.11.x-develop`` as the equivalent of ``develop``
 * Ship the release using beta version numbers when updating the ``.travis.yml`` and when creating the annotated tag (e.g. `0.11.0b0`)

--- a/docs/contributing/setting_up_your_dev_environment.rst
+++ b/docs/contributing/setting_up_your_dev_environment.rst
@@ -29,7 +29,7 @@ Fork and clone the repository
 
     * Click the green ``Clone`` button and choose the SSH or HTTPS URL depending on your setup.
     * Copy the URL and run ``git clone <url>`` in your local terminal.
-    * This will clone the ``develop`` branch of the great_expectations repo. Please use ``develop`` (not ``master``!) as the starting point for your work.
+    * This will clone the ``develop`` branch of the great_expectations repo. Please use ``develop`` (not ``main``!) as the starting point for your work.
     * Atlassian has a `nice tutorial for developing on a fork <https://www.atlassian.com/git/tutorials/git-forks-and-upstreams>`__.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. great_expectations documentation master file
+.. great_expectations documentation entrypoint file
 
 ##############################
 Welcome to Great Expectations!

--- a/docs/tutorials/getting_started/initialize_a_data_context.rst
+++ b/docs/tutorials/getting_started/initialize_a_data_context.rst
@@ -46,7 +46,7 @@ If you intend to develop within the Great Expectations (e.g. to contribute back 
 Download example data
 ---------------------
 
-For this tutorial, we will use a simplified version of the National Provider Identifier (NPI) database. It's a public dataset released by the `Centers of Medicare and Medicaid Services <https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/DataDissemination>`_, intended as a master list of health care providers in the United States. NPI data is famously messy---a great place to see the value of data testing and documentation in action.
+For this tutorial, we will use a simplified version of the National Provider Identifier (NPI) database. It's a public dataset released by the `Centers of Medicare and Medicaid Services <https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/DataDissemination>`_, intended as an authoritative list of health care providers in the United States. NPI data is famously messy---a great place to see the value of data testing and documentation in action.
 
 To avoid confusion during the tutorial, we recommend you set up the following directory structure before you download the data:
 


### PR DESCRIPTION
This refactor to eliminate the branch name 'master' is a way for us recognize that discrimination is a subtle but pervasive part of our cultural heritage. It is a small but concrete step that symbolizes our resolution to act in ways that empower all of our friends, neighbors, and fellow citizens to fully participate in and enjoy the benefits of our community.