### PR TITLE
[DOCS] Update docstring for SlackNotificationAction

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -8,6 +8,7 @@ Develop
 -----------------
 * Update util.convert_to_json_serializable() to handle UUID type #2805 (thanks @YFGu0618)
 * [DOCS] Remove broken links
+* [DOCS] Fix typo in SlackNotificationAction docstring
 * [BUGFIX] Allow decimals without leading zero in evaluation parameter URN
 * [ENHANCEMENT] Enable instantiation of a validator with a multiple batch BatchRequest
 * [ENHANCEMENT] Adds a batch_request_list parameter to DataContext.get_validator to enable instantiation of a Validator with batches from multiple BatchRequests

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -91,7 +91,7 @@ class SlackNotificationAction(ValidationAction):
 
         - name: send_slack_notification_on_validation_result
         action:
-          class_name: StoreValidationResultAction
+          class_name: SlackNotificationAction
           # put the actual webhook URL in the uncommitted/config_variables.yml file
           # or pass in as environment variable
           slack_webhook: ${validation_notification_slack_webhook}


### PR DESCRIPTION
Changes proposed in this pull request:
- The docstring for `SlackNotificationAction` should reference `SlackNotificationAction` instead of `StoreValidationResultAction`