### PR TITLE
[MAINTENANCE] Constructor for `BatchRequest` requires "triplet", and `RuntimeBatchRequest` also requires `runtime_parameters` and `batch_identifiers`

### DIFF
--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -358,25 +358,29 @@ is illegal.
 
     @staticmethod
     def _validate_runtime_batch_request_specific_init_parameters(
-        runtime_parameters: dict = None,
-        batch_identifiers: dict = None,
+        runtime_parameters: Union[IDDict, dict],
+        batch_identifiers: Union[IDDict, dict],
         batch_spec_passthrough: Optional[dict] = None,
     ):
-        if not (runtime_parameters and isinstance(runtime_parameters, dict)):
+        if not (
+            runtime_parameters and (isinstance(runtime_parameters, (dict, IDDict)))
+        ):
             raise TypeError(
-                f"""The type for runtime_parameters must be dictionary.
+                f"""The type for runtime_parameters must be dict or IDDict.
                 The type given is "{str(type(runtime_parameters))}", which is illegal."""
             )
 
-        if not (batch_identifiers and isinstance(batch_identifiers, dict)):
+        if not (batch_identifiers and isinstance(batch_identifiers, (dict, IDDict))):
             raise TypeError(
-                f"""The type for batch_identifiers must be a dictionary, with keys being identifiers defined in the
+                f"""The type for batch_identifiers must be a dict or IDDict, with keys being identifiers defined in the
                 data connector configuration.  The type given is "{str(type(batch_identifiers))}", which is illegal."""
             )
 
-        if batch_spec_passthrough and not (isinstance(batch_spec_passthrough, dict)):
+        if batch_spec_passthrough and not (
+            isinstance(batch_spec_passthrough, (dict, IDDict))
+        ):
             raise TypeError(
-                f"""The type for batch_spec_passthrough must be a dictionary. The type given is "{str(type(batch_spec_passthrough))}", which is illegal."""
+                f"""The type for batch_spec_passthrough must be a dict or IDDict. The type given is "{str(type(batch_spec_passthrough))}", which is illegal."""
             )
 
 

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -179,9 +179,9 @@ class BatchRequestBase(DictDot):
 
     def __init__(
         self,
-        datasource_name: str = None,
-        data_connector_name: str = None,
-        data_asset_name: str = None,
+        datasource_name: str,
+        data_connector_name: str,
+        data_asset_name: str,
         data_connector_query: Optional[Union[IDDict, dict]] = None,
         limit: Optional[int] = None,
         batch_spec_passthrough: Optional[dict] = None,
@@ -290,9 +290,9 @@ class BatchRequest(BatchRequestBase):
 
     def __init__(
         self,
-        datasource_name: str = None,
-        data_connector_name: str = None,
-        data_asset_name: str = None,
+        datasource_name: str,
+        data_connector_name: str,
+        data_asset_name: str,
         data_connector_query: Optional[Union[IDDict, dict]] = None,
         limit: Optional[int] = None,
         batch_spec_passthrough: Optional[dict] = None,
@@ -383,11 +383,11 @@ is illegal.
 class RuntimeBatchRequest(BatchRequest):
     def __init__(
         self,
-        datasource_name: str = None,
-        data_connector_name: str = None,
-        data_asset_name: str = None,
-        runtime_parameters: dict = None,
-        batch_identifiers: dict = None,
+        datasource_name: str,
+        data_connector_name: str,
+        data_asset_name: str,
+        runtime_parameters: dict,
+        batch_identifiers: dict,
         batch_spec_passthrough: Optional[dict] = None,
     ):
         super().__init__(

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1503,9 +1503,9 @@ class BaseDataContext:
 
     def get_batch_list(
         self,
-        datasource_name: str,
-        data_connector_name: str,
-        data_asset_name: str,
+        datasource_name: str = None,
+        data_connector_name: str = None,
+        data_asset_name: str = None,
         *,
         batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
         batch_data: Optional[Any] = None,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1503,9 +1503,9 @@ class BaseDataContext:
 
     def get_batch_list(
         self,
-        datasource_name: Optional[str] = None,
-        data_connector_name: Optional[str] = None,
-        data_asset_name: Optional[str] = None,
+        datasource_name: str,
+        data_connector_name: str,
+        data_asset_name: str,
         *,
         batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
         batch_data: Optional[Any] = None,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1503,9 +1503,9 @@ class BaseDataContext:
 
     def get_batch_list(
         self,
-        datasource_name: str = None,
-        data_connector_name: str = None,
-        data_asset_name: str = None,
+        datasource_name: Optional[str] = None,
+        data_connector_name: Optional[str] = None,
+        data_asset_name: Optional[str] = None,
         *,
         batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
         batch_data: Optional[Any] = None,

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -104,7 +104,9 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             BatchDefinition
         ] = self._get_batch_definition_list_from_batch_request(
             batch_request=BatchRequestBase(
-                datasource_name=self.datasource_name, data_connector_name=self.name
+                datasource_name=self.datasource_name,
+                data_connector_name=self.name,
+                data_asset_name=None,
             )
         )
 

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -1915,6 +1915,7 @@ def test_suite_edit_interactive_batch_request_without_datasource_json_file_raise
     batch_request: dict = {
         "data_connector_name": "my_basic_data_connector",
         "data_asset_name": "Titanic_1911",
+        "datasource_name": None,
     }
 
     batch_request_file_path: str = os.path.join(

--- a/tests/datasource/data_connector/test_data_connector.py
+++ b/tests/datasource/data_connector/test_data_connector.py
@@ -169,16 +169,24 @@ def test__batch_definition_matches_batch_request():
     )
 
     assert batch_definition_matches_batch_request(
-        batch_definition=A, batch_request=BatchRequestBase(datasource_name="A")
+        batch_definition=A,
+        batch_request=BatchRequestBase(
+            datasource_name="A", data_connector_name=None, data_asset_name=None
+        ),
     )
 
     assert not batch_definition_matches_batch_request(
-        batch_definition=A, batch_request=BatchRequestBase(datasource_name="B")
+        batch_definition=A,
+        batch_request=BatchRequestBase(
+            datasource_name="B", data_connector_name=None, data_asset_name=None
+        ),
     )
 
     assert batch_definition_matches_batch_request(
         batch_definition=A,
-        batch_request=BatchRequestBase(datasource_name="A", data_connector_name="a"),
+        batch_request=BatchRequestBase(
+            datasource_name="A", data_connector_name="a", data_asset_name=None
+        ),
     )
 
     assert batch_definition_matches_batch_request(
@@ -210,9 +218,12 @@ def test__batch_definition_matches_batch_request():
     assert batch_definition_matches_batch_request(
         batch_definition=A,
         batch_request=BatchRequestBase(
+            datasource_name=None,
+            data_connector_name=None,
+            data_asset_name=None,
             data_connector_query={
                 "batch_filter_parameters": {"id": "A"},
-            }
+            },
         ),
     )
 


### PR DESCRIPTION
Changes proposed in this pull request:
- The triplet `datasource_name`, `data_connector_name`, and `data_asset_name` are required for GE to retrieve a `Batch`
- This PR proposes a small refactor to the constructor for `Batch`, `BatchRequest` and `RuntimeBatchRequest` to ensure they are passed in. 
- In addition,  the `RuntimeDataConnector` requires 2 more parameters, namely `runtime_parameters` and `batch_identifiers` to create a Batch, so this now reflected in the constructor for `RuntimeBatchRequest`. `runtime_parameters` provide the data itself (either as a dataframe, or query or path), and `batch_identifiers` that serve as a persistent, unique identifier for the data included in the Batch
- The work is an extension of #3304, but the scope was different enough that I would like to have it reviewed as a separate PR. 
- GDOC-221

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
