### PR TITLE
[BUGFIX] Custom query in RuntimeBatchRequest for expectations using table.row_count metric

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ title: Changelog
 ---
 
 ### Develop
+* [BUGFIX] runtime_parameters: query: Custom query used as subquery in table metrics (#3508)
 * [BUGFIX] runtime_parameters: batch_data: Spark DF serialization (#3502)
 * [DOCS] Added details on Anonymous Usage Statistics to the reference documentation.
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -749,6 +749,11 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             )
             assert len(query["select"]) == len(query["ids"])
             try:
+                """
+                if a custom query is passed, selectable will be TextClause and not formatted
+                as a subquery wrapped in "(subquery) alias". TextClause must first be converted
+                to TextualSelect using sa.columns() before it can be converted to type Subquery
+                """
                 if isinstance(selectable, TextClause):
                     res = self.engine.execute(
                         sa.select(query["select"]).select_from(

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -750,7 +750,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             assert len(query["select"]) == len(query["ids"])
             try:
                 """
-                if a custom query is passed, selectable will be TextClause and not formatted
+                If a custom query is passed, selectable will be TextClause and not formatted
                 as a subquery wrapped in "(subquery) alias". TextClause must first be converted
                 to TextualSelect using sa.columns() before it can be converted to type Subquery
                 """

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -749,9 +749,14 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             )
             assert len(query["select"]) == len(query["ids"])
             try:
-                res = self.engine.execute(
-                    sa.select(query["select"]).select_from(selectable)
-                ).fetchall()
+                if isinstance(selectable, TextClause):
+                    res = self.engine.execute(
+                        sa.select(query["select"]).select_from(selectable.columns().subquery())
+                    ).fetchall()
+                else:
+                    res = self.engine.execute(
+                        sa.select(query["select"]).select_from(selectable)
+                    ).fetchall()
                 logger.debug(
                     f"SqlAlchemyExecutionEngine computed {len(res[0])} metrics on domain_id {IDDict(domain_kwargs).to_id()}"
                 )

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -751,7 +751,9 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             try:
                 if isinstance(selectable, TextClause):
                     res = self.engine.execute(
-                        sa.select(query["select"]).select_from(selectable.columns().subquery())
+                        sa.select(query["select"]).select_from(
+                            selectable.columns().subquery()
+                        )
                     ).fetchall()
                 else:
                     res = self.engine.execute(

--- a/tests/expectations/core/test_expect_table_row_count_to_be_between.py
+++ b/tests/expectations/core/test_expect_table_row_count_to_be_between.py
@@ -1,8 +1,8 @@
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import DataContext
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
+from great_expectations.data_context import DataContext
 
 
 def test_expect_table_row_count_to_be_between_runtime_no_temp_table_sa(
@@ -21,27 +21,27 @@ def test_expect_table_row_count_to_be_between_runtime_no_temp_table_sa(
         batch_request=batch_request,
         create_expectation_suite_with_name="test",
     )
-    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    results = validator.expect_table_row_count_to_be_between(
+        min_value=100, max_value=2000
+    )
     assert results == ExpectationValidationResult(
         success=True,
-        result={
-            "observed_value": 1313
-        },
+        result={"observed_value": 1313},
         meta={},
         expectation_config={
             "kwargs": {
                 "min_value": 100,
                 "max_value": 2000,
-                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6",
             },
             "ge_cloud_id": None,
             "meta": {},
-            "expectation_type": "expect_table_row_count_to_be_between"
+            "expectation_type": "expect_table_row_count_to_be_between",
         },
         exception_info={
             "raised_exception": False,
             "exception_traceback": None,
-            "exception_message": None
+            "exception_message": None,
         },
     )
 
@@ -62,27 +62,27 @@ def test_expect_table_row_count_to_be_between_runtime_custom_query_no_temp_table
         batch_request=batch_request,
         create_expectation_suite_with_name="test",
     )
-    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    results = validator.expect_table_row_count_to_be_between(
+        min_value=100, max_value=2000
+    )
     assert results == ExpectationValidationResult(
         success=True,
-        result={
-            "observed_value": 462
-        },
+        result={"observed_value": 462},
         meta={},
         expectation_config={
             "kwargs": {
                 "min_value": 100,
                 "max_value": 2000,
-                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6",
             },
             "ge_cloud_id": None,
             "meta": {},
-            "expectation_type": "expect_table_row_count_to_be_between"
+            "expectation_type": "expect_table_row_count_to_be_between",
         },
         exception_info={
             "raised_exception": False,
             "exception_traceback": None,
-            "exception_message": None
+            "exception_message": None,
         },
     )
 
@@ -101,26 +101,26 @@ def test_expect_table_row_count_to_be_between_no_temp_table_sa(
         batch_request=batch_request,
         create_expectation_suite_with_name="test",
     )
-    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    results = validator.expect_table_row_count_to_be_between(
+        min_value=100, max_value=2000
+    )
     assert results == ExpectationValidationResult(
         success=True,
-        result={
-            "observed_value": 1313
-        },
+        result={"observed_value": 1313},
         meta={},
         expectation_config={
             "kwargs": {
                 "min_value": 100,
                 "max_value": 2000,
-                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6",
             },
             "ge_cloud_id": None,
             "meta": {},
-            "expectation_type": "expect_table_row_count_to_be_between"
+            "expectation_type": "expect_table_row_count_to_be_between",
         },
         exception_info={
             "raised_exception": False,
             "exception_traceback": None,
-            "exception_message": None
+            "exception_message": None,
         },
     )

--- a/tests/expectations/core/test_expect_table_row_count_to_be_between.py
+++ b/tests/expectations/core/test_expect_table_row_count_to_be_between.py
@@ -1,0 +1,126 @@
+from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
+from great_expectations.data_context import DataContext
+from great_expectations.core.expectation_validation_result import (
+    ExpectationValidationResult,
+)
+
+
+def test_expect_table_row_count_to_be_between_runtime_no_temp_table_sa(
+    titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled,
+):
+    context: DataContext = titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled
+    batch_request = RuntimeBatchRequest(
+        datasource_name="my_sqlite_db_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="titanic",
+        runtime_parameters={"query": "select * from titanic"},
+        batch_identifiers={"default_identifier_name": "test_identifier"},
+        batch_spec_passthrough={"create_temp_table": False},
+    )
+    validator = context.get_validator(
+        batch_request=batch_request,
+        create_expectation_suite_with_name="test",
+    )
+    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    assert results == ExpectationValidationResult(
+        success=True,
+        result={
+            "observed_value": 1313
+        },
+        meta={},
+        expectation_config={
+            "kwargs": {
+                "min_value": 100,
+                "max_value": 2000,
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+            },
+            "ge_cloud_id": None,
+            "meta": {},
+            "expectation_type": "expect_table_row_count_to_be_between"
+        },
+        exception_info={
+            "raised_exception": False,
+            "exception_traceback": None,
+            "exception_message": None
+        },
+    )
+
+
+def test_expect_table_row_count_to_be_between_runtime_custom_query_no_temp_table_sa(
+    titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled,
+):
+    context: DataContext = titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled
+    batch_request = RuntimeBatchRequest(
+        datasource_name="my_sqlite_db_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="titanic",
+        runtime_parameters={"query": "select * from titanic where sexcode = 1"},
+        batch_identifiers={"default_identifier_name": "test_identifier"},
+        batch_spec_passthrough={"create_temp_table": False},
+    )
+    validator = context.get_validator(
+        batch_request=batch_request,
+        create_expectation_suite_with_name="test",
+    )
+    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    assert results == ExpectationValidationResult(
+        success=True,
+        result={
+            "observed_value": 462
+        },
+        meta={},
+        expectation_config={
+            "kwargs": {
+                "min_value": 100,
+                "max_value": 2000,
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+            },
+            "ge_cloud_id": None,
+            "meta": {},
+            "expectation_type": "expect_table_row_count_to_be_between"
+        },
+        exception_info={
+            "raised_exception": False,
+            "exception_traceback": None,
+            "exception_message": None
+        },
+    )
+
+
+def test_expect_table_row_count_to_be_between_no_temp_table_sa(
+    titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled,
+):
+    context: DataContext = titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled
+    batch_request = BatchRequest(
+        datasource_name="my_sqlite_db_datasource",
+        data_connector_name="default_inferred_data_connector_name",
+        data_asset_name="titanic",
+        batch_spec_passthrough={"create_temp_table": False},
+    )
+    validator = context.get_validator(
+        batch_request=batch_request,
+        create_expectation_suite_with_name="test",
+    )
+    results = validator.expect_table_row_count_to_be_between(min_value=100, max_value=2000)
+    assert results == ExpectationValidationResult(
+        success=True,
+        result={
+            "observed_value": 1313
+        },
+        meta={},
+        expectation_config={
+            "kwargs": {
+                "min_value": 100,
+                "max_value": 2000,
+                "batch_id": "a47a711a9984cb2a482157adf54c3cb6"
+            },
+            "ge_cloud_id": None,
+            "meta": {},
+            "expectation_type": "expect_table_row_count_to_be_between"
+        },
+        exception_info={
+            "raised_exception": False,
+            "exception_traceback": None,
+            "exception_message": None
+        },
+    )

--- a/tests/expectations/core/test_expect_table_row_count_to_be_between.py
+++ b/tests/expectations/core/test_expect_table_row_count_to_be_between.py
@@ -5,7 +5,7 @@ from great_expectations.core.expectation_validation_result import (
 from great_expectations.data_context import DataContext
 
 
-def test_expect_table_row_count_to_be_between_runtime_no_temp_table_sa(
+def test_expect_table_row_count_to_be_between_runtime_custom_query_no_temp_table_sa(
     titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled,
 ):
     context: DataContext = titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled
@@ -46,7 +46,7 @@ def test_expect_table_row_count_to_be_between_runtime_no_temp_table_sa(
     )
 
 
-def test_expect_table_row_count_to_be_between_runtime_custom_query_no_temp_table_sa(
+def test_expect_table_row_count_to_be_between_runtime_custom_query_with_where_no_temp_table_sa(
     titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled,
 ):
     context: DataContext = titanic_v013_multi_datasource_multi_execution_engine_data_context_with_checkpoints_v1_with_empty_store_stats_enabled

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -1088,7 +1088,7 @@ def test_table_metric_pd(caplog):
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
     desired_metric = MetricConfiguration(
         metric_name="table.row_count",
-        metric_domain_kwargs={},
+        metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
@@ -1319,7 +1319,7 @@ def test_table_metric_sa(sa):
 
     desired_metric = MetricConfiguration(
         metric_name="table.row_count.aggregate_fn",
-        metric_domain_kwargs={"column": "a"},
+        metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -1314,6 +1314,29 @@ def test_map_column_pairs_equal_metric_pd():
     assert metrics[unexpected_values_metric.id] == [(0, 7), (1, 8), (2, 0)]
 
 
+def test_table_metric_sa(sa):
+    engine = build_sa_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}), sa)
+
+    desired_metric = MetricConfiguration(
+        metric_name="table.row_count.aggregate_fn",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
+
+    desired_metric = MetricConfiguration(
+        metric_name="table.row_count",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+        metric_dependencies={"metric_partial_fn": desired_metric},
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(desired_metric,), metrics=results
+    )
+
+    assert results == {desired_metric.id: 6}
+
+
 def test_map_column_pairs_equal_metric_sa(sa):
     engine = build_sa_engine(
         pd.DataFrame(

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2269,7 +2269,7 @@ def test_table_metric_spark(spark_session):
 
     desired_metric = MetricConfiguration(
         metric_name="table.row_count",
-        metric_domain_kwargs={"column": "a"},
+        metric_domain_kwargs={},
         metric_value_kwargs=None,
         metric_dependencies={"metric_partial_fn": desired_metric},
     )

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -1088,7 +1088,7 @@ def test_table_metric_pd(caplog):
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
     desired_metric = MetricConfiguration(
         metric_name="table.row_count",
-        metric_domain_kwargs={"column": "a"},
+        metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
@@ -1326,7 +1326,7 @@ def test_table_metric_sa(sa):
 
     desired_metric = MetricConfiguration(
         metric_name="table.row_count",
-        metric_domain_kwargs={"column": "a"},
+        metric_domain_kwargs={},
         metric_value_kwargs=None,
         metric_dependencies={"metric_partial_fn": desired_metric},
     )
@@ -2262,7 +2262,7 @@ def test_table_metric_spark(spark_session):
 
     desired_metric = MetricConfiguration(
         metric_name="table.row_count.aggregate_fn",
-        metric_domain_kwargs={"column": "a"},
+        metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))


### PR DESCRIPTION
Changes proposed in this pull request:
- DEVREL-211
- Issue #3398 

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.