### PR TITLE
[FEATURE] Atomic Renderer:  Initial framework 

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2286,9 +2286,9 @@ class RenderedAtomicValueSchema(Schema):
 class RenderedAtomicValue(DictDot):
     def __init__(
         self,
-        template: str = None,
-        params: dict = None,
-        schema: dict = None,
+        template: Optional[str] = None,
+        params: Optional[dict] = None,
+        schema: Optional[dict] = None,
         # header: list = None,
         # header_row: str = None,
         # table: list = None,

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2262,6 +2262,50 @@ class CheckpointValidationConfigSchema(Schema):
     pass
 
 
+class RenderedAtomicValueSchema(Schema):
+    class Meta:
+        unknown = INCLUDE
+
+    # for StringType
+    template = fields.String(required=False, allow_none=True)
+    params = fields.Dict(required=False, allow_none=True)
+    schema = fields.Dict(required=False, allow_none=True)
+
+    # TODO enable TableType
+    # header = fields.List(fields.Str(), required=False, allow_none=True)
+    # header_row = fields.List(fields.Str(), required=False, allow_none=True)
+    # table: fields.List(fields.List(fields.Str()), required=False, allow_none=True)
+
+    # TODO add VegaGraph
+
+    @post_load()
+    def create_value_obj(self, data, **kwargs):
+        return RenderedAtomicValue(**data)
+
+
+class RenderedAtomicValue(DictDot):
+    def __init__(
+        self,
+        template: str = None,
+        params: dict = None,
+        schema: dict = None,
+        # header: list = None,
+        # header_row: str = None,
+        # table: list = None,
+    ):
+        # StringType
+        self.template: str = template
+        self.params: dict = params
+        self.schema: dict = schema
+
+        # TODO enable TableType
+        # self.header: list = header
+        # self.header_row: str = header_row
+        # self.table: list = table
+
+        # TODO add VegaGraph
+
+
 dataContextConfigSchema = DataContextConfigSchema()
 datasourceConfigSchema = DatasourceConfigSchema()
 dataConnectorConfigSchema = DataConnectorConfigSchema()
@@ -2271,3 +2315,4 @@ anonymizedUsageStatisticsSchema = AnonymizedUsageStatisticsConfigSchema()
 notebookConfigSchema = NotebookConfigSchema()
 checkpointConfigSchema = CheckpointConfigSchema()
 concurrencyConfigSchema = ConcurrencyConfigSchema()
+renderedAtomicValueSchema = RenderedAtomicValueSchema()

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -2922,7 +2922,7 @@ class Dataset(MetaDataset):
         quantile_value_ranges = quantile_ranges["value_ranges"]
         if len(quantiles) != len(quantile_value_ranges):
             raise ValueError(
-                "quntile_values and quantiles must have the same number of elements"
+                "quantile_values and quantiles must have the same number of elements"
             )
 
         quantile_vals = self.get_column_quantiles(
@@ -4768,16 +4768,16 @@ class Dataset(MetaDataset):
             A B C
             1 3 2
             1 5 0
-            1 1 4        
-            
+            1 1 4
+
             Pass
-            
+
             A B C
             1 3 2
             1 5 1
-            1 1 4        
-            
-            Fail on row 2     
+            1 1 4
+
+            Fail on row 2
 
         Args:
             column_list (List[str]): \

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -166,7 +166,7 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
 
         if len(quantiles) != len(quantile_value_ranges):
             raise ValueError(
-                "quntile_values and quantiles must have the same number of elements"
+                "quantile_values and quantiles must have the same number of elements"
             )
         return True
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -30,7 +30,10 @@ from great_expectations.expectations.registry import (
     register_expectation,
     register_renderer,
 )
-from great_expectations.expectations.util import legacy_method_parameters
+from great_expectations.expectations.util import (
+    legacy_method_parameters,
+    render_evaluation_parameter_string,
+)
 from great_expectations.self_check.util import (
     evaluate_json_test_cfe,
     generate_expectation_tests,
@@ -39,10 +42,13 @@ from great_expectations.validator.metric_configuration import MetricConfiguratio
 from great_expectations.validator.validator import Validator
 
 from ..core.util import convert_to_json_serializable, nested_update
+from ..data_context.types.base import renderedAtomicValueSchema
 from ..execution_engine import ExecutionEngine, PandasExecutionEngine
+from ..execution_engine.execution_engine import MetricDomainTypes
 from ..render.renderer.renderer import renderer
 from ..render.types import (
     CollapseContent,
+    RenderedAtomicContent,
     RenderedStringTemplateContent,
     RenderedTableContent,
 )
@@ -162,6 +168,56 @@ class Expectation(metaclass=MetaExpectation):
         execution_engine: ExecutionEngine = None,
     ):
         raise NotImplementedError
+
+    @classmethod
+    def _atomic_prescriptive_template(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        runtime_configuration = runtime_configuration or {}
+        styling = runtime_configuration.get("styling")
+
+        template_str = "$expectation_type(**$kwargs)"
+        params = {
+            "expectation_type": {
+                "schema": {"type": "string"},
+                "value": configuration.expectation_type,
+            },
+            "kwargs": {"schema": {"type": "string"}, "value": configuration.kwargs},
+        }
+        return (template_str, params, styling)
+
+    @classmethod
+    @renderer(renderer_type="atomic.prescriptive.summary")
+    @render_evaluation_parameter_string
+    def _prescriptive_summary(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        (template_str, params, styling) = cls._atomic_prescriptive_template(
+            configuration, result, language, runtime_configuration, **kwargs
+        )
+        value_obj = renderedAtomicValueSchema.load(
+            {
+                "template": template_str,
+                "params": params,
+                "schema": {"type": "com.superconductive.rendered.string"},
+            }
+        )
+        rendered = RenderedAtomicContent(
+            name="atomic.prescriptive.summary",
+            value=value_obj,
+            valuetype="StringValueType",
+        )
+        return rendered
 
     @classmethod
     @renderer(renderer_type="renderer.prescriptive")
@@ -1045,6 +1101,7 @@ class TableExpectation(Expectation, ABC):
         "condition_parser",
     )
     metric_dependencies = tuple()
+    domain_type = MetricDomainTypes.TABLE
 
     def get_validation_dependencies(
         self,
@@ -1169,6 +1226,7 @@ class TableExpectation(Expectation, ABC):
 
 class ColumnExpectation(TableExpectation, ABC):
     domain_keys = ("batch_id", "table", "column", "row_condition", "condition_parser")
+    domain_type = MetricDomainTypes.COLUMN
 
     def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
         # Ensuring basic configuration parameters are properly set
@@ -1184,6 +1242,7 @@ class ColumnExpectation(TableExpectation, ABC):
 class ColumnMapExpectation(TableExpectation, ABC):
     map_metric = None
     domain_keys = ("batch_id", "table", "column", "row_condition", "condition_parser")
+    domain_type = MetricDomainTypes.COLUMN
     success_keys = ("mostly",)
     default_kwarg_values = {
         "row_condition": None,
@@ -1379,6 +1438,7 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         "row_condition",
         "condition_parser",
     )
+    domain_type = MetricDomainTypes.COLUMN_PAIR
     success_keys = ("mostly",)
     default_kwarg_values = {
         "row_condition": None,
@@ -1581,6 +1641,7 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
         "condition_parser",
         "ignore_row_if",
     )
+    domain_type = MetricDomainTypes.MULTICOLUMN
     success_keys = tuple()
     default_kwarg_values = {
         "row_condition": None,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -510,15 +510,7 @@ class Expectation(metaclass=MetaExpectation):
         return unexpected_table_content_block
 
     @classmethod
-    @renderer(renderer_type="renderer.diagnostic.observed_value")
-    def _diagnostic_observed_value_renderer(
-        cls,
-        configuration=None,
-        result=None,
-        language=None,
-        runtime_configuration=None,
-        **kwargs,
-    ):
+    def _get_observed_value_from_evr(self, result: ExpectationValidationResult):
         result_dict = result.result
         if result_dict is None:
             return "--"
@@ -537,6 +529,43 @@ class Expectation(metaclass=MetaExpectation):
             )
         else:
             return "--"
+
+    @classmethod
+    @renderer(renderer_type="atomic.diagnostic.observed_value")
+    def _atomic_diagnostic_observed_value(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        observed_value = cls._get_observed_value_from_evr(result=result)
+        value_obj = renderedAtomicValueSchema.load(
+            {
+                "template": observed_value,
+                "params": {},
+                "schema": {"type": "com.superconductive.rendered.string"},
+            }
+        )
+        rendered = RenderedAtomicContent(
+            name="atomic.diagnostic.observed_value",
+            value=value_obj,
+            valuetype="StringValueType",
+        )
+        return rendered
+
+    @classmethod
+    @renderer(renderer_type="renderer.diagnostic.observed_value")
+    def _diagnostic_observed_value_renderer(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        return cls._get_observed_value_from_evr(result=result)
 
     @classmethod
     def get_allowed_config_keys(cls):

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -194,7 +194,7 @@ class Expectation(metaclass=MetaExpectation):
     @classmethod
     @renderer(renderer_type="atomic.prescriptive.summary")
     @render_evaluation_parameter_string
-    def _prescriptive_summary(
+    def _atomic_prescriptive_summary(
         cls,
         configuration=None,
         result=None,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -178,7 +178,13 @@ class Expectation(metaclass=MetaExpectation):
         runtime_configuration=None,
         **kwargs,
     ):
-        runtime_configuration = runtime_configuration or {}
+        """
+        Template function that contains the logic that is shared by atomic.prescriptive.summary (GE Cloud) and
+        renderer.prescriptive (OSS GE)
+        """
+        if runtime_configuration is None:
+            runtime_configuration = {}
+
         styling = runtime_configuration.get("styling")
 
         template_str = "$expectation_type(**$kwargs)"
@@ -202,6 +208,9 @@ class Expectation(metaclass=MetaExpectation):
         runtime_configuration=None,
         **kwargs,
     ):
+        """
+        Rendering function that is utilized by GE Cloud Front-end
+        """
         (template_str, params, styling) = cls._atomic_prescriptive_template(
             configuration, result, language, runtime_configuration, **kwargs
         )
@@ -510,7 +519,7 @@ class Expectation(metaclass=MetaExpectation):
         return unexpected_table_content_block
 
     @classmethod
-    def _get_observed_value_from_evr(self, result: ExpectationValidationResult):
+    def _get_observed_value_from_evr(self, result: ExpectationValidationResult) -> str:
         result_dict = result.result
         if result_dict is None:
             return "--"
@@ -540,6 +549,9 @@ class Expectation(metaclass=MetaExpectation):
         runtime_configuration=None,
         **kwargs,
     ):
+        """
+        Rendering function that is utilized by GE Cloud Front-end
+        """
         observed_value = cls._get_observed_value_from_evr(result=result)
         value_obj = renderedAtomicValueSchema.load(
             {

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -63,12 +63,11 @@ def register_renderer(
         return
 
 
-# <WILL> check : why was this needed?
 def get_renderer_names(object_name: str) -> List[str]:
     return list(_registered_renderers.get(object_name, {}).keys())
 
 
-def get_renderer_impls(object_name: str) -> list:
+def get_renderer_impls(object_name: str) -> List[str]:
     return list(_registered_renderers.get(object_name, {}).values())
 
 

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -63,6 +63,15 @@ def register_renderer(
         return
 
 
+# <WILL> check : why was this needed?
+def get_renderer_names(object_name: str) -> List[str]:
+    return list(_registered_renderers.get(object_name, {}).keys())
+
+
+def get_renderer_impls(object_name: str) -> list:
+    return list(_registered_renderers.get(object_name, {}).values())
+
+
 def get_renderer_impl(object_name, renderer_type):
     return _registered_renderers.get(object_name, {}).get(renderer_type)
 

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -75,6 +75,14 @@ def get_renderer_impl(object_name, renderer_type):
     return _registered_renderers.get(object_name, {}).get(renderer_type)
 
 
+def get_renderer_names(object_name: str) -> List[str]:
+    return list(_registered_renderers.get(object_name, {}).keys())
+
+
+def get_renderer_impls(object_name: str) -> list:
+    return list(_registered_renderers.get(object_name, {}).values())
+
+
 def register_expectation(expectation: Type["Expectation"]) -> None:
     expectation_type = expectation.expectation_type
     # TODO: add version to key

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -75,14 +75,6 @@ def get_renderer_impl(object_name, renderer_type):
     return _registered_renderers.get(object_name, {}).get(renderer_type)
 
 
-def get_renderer_names(object_name: str) -> List[str]:
-    return list(_registered_renderers.get(object_name, {}).keys())
-
-
-def get_renderer_impls(object_name: str) -> list:
-    return list(_registered_renderers.get(object_name, {}).values())
-
-
 def register_expectation(expectation: Type["Expectation"]) -> None:
     expectation_type = expectation.expectation_type
     # TODO: add version to key

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -58,6 +58,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                 else None
             )
             for obj_ in render_object:
+
                 expectation_type = cls._get_expectation_type(obj_)
 
                 content_block_fn = cls._get_content_block_fn(expectation_type)

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -1,6 +1,7 @@
 import json
 from copy import deepcopy
 from string import Template as pTemplate
+from typing import Optional
 
 from great_expectations.data_context.types.base import RenderedAtomicValue
 from great_expectations.render.exceptions import InvalidRenderedContentError
@@ -499,9 +500,9 @@ class RenderedSectionContent(RenderedContent):
 class RenderedAtomicContent(RenderedContent):
     def __init__(
         self,
-        name: str = None,
-        value: RenderedAtomicValue = None,
-        valuetype: str = None,
+        name: Optional[str] = None,
+        value: Optional[RenderedAtomicValue] = None,
+        valuetype: Optional[str] = None,
     ):
         self.name = name
         self.value = value

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -2,6 +2,7 @@ import json
 from copy import deepcopy
 from string import Template as pTemplate
 
+from great_expectations.data_context.types.base import RenderedAtomicValue
 from great_expectations.render.exceptions import InvalidRenderedContentError
 
 
@@ -493,3 +494,15 @@ class RenderedSectionContent(RenderedContent):
         )
         d["section_name"] = self.section_name
         return d
+
+
+class RenderedAtomicContent(RenderedContent):
+    def __init__(
+        self,
+        name: str = None,
+        value: RenderedAtomicValue = None,
+        valuetype: str = None,
+    ):
+        self.name = name
+        self.value = value
+        self.valuetype = valuetype

--- a/tests/test_fixtures/custom_sparkdf_dataset.py
+++ b/tests/test_fixtures/custom_sparkdf_dataset.py
@@ -24,7 +24,7 @@ class CustomSparkDFDataset(SparkDFDataset):
         quantile_value_ranges = quantile_ranges["value_ranges"]
         if len(quantiles) != len(quantile_value_ranges):
             raise ValueError(
-                "quntile_values and quantiles must have the same number of elements"
+                "quantile_values and quantiles must have the same number of elements"
             )
 
         quantile_vals = self.get_column_approx_quantiles(


### PR DESCRIPTION
# New Classes
The PR introduces the Atomic Renderer, a rendering framework that will be shared by both OSS and GE Cloud

The PR introduces the components needed for the first (and most common) type : `StringValueType`, with `TableType` and `ChartType` left as TODOs 

At the top level we introduce `RenderedAtomicContent`:
    - This is the object that is actually sent back to Mercury from OSS GE. 
    - It contains the following fields: 
        1. name : string that describes the renderer that the object is coming from (ie. `atomic.prescriptive.summary`)
        2. value : `RenderedAtomicValue` (a new class introduced in this PR, described in more detail below)
        3. valuetype : string that can describes `RenderedAtomicValue`. Can be `"StringValueType", or "TableType"` etc

`RenderedAtomicValue` is the object that contains the rendered content that will be transformed into its corresponding Mercury model.   Instead of having a separate class for `StringValueType`, `TableType` and `GraphType`, they are all handled together under `RenderedAtomicValue`, and the `valuetype`
string describes which model that Mercury needs to use.  Defining it in this way allows for basic a schema to be defined at the OSS level, and for the actual validation to happen at the Mercury-level. 

# New Methods

1. `_atomic_prescriptive_template()`
  - contains the core logic for generating Prescriptive rendered content, and is shared by: 
    - `_atomic_prescriptive_summary()` --> Mercury
    - `_prescriptive_renderer()` --> DataDocs
    
  - this function is defined in the base `Expectation` class and is called if the Expectation does not have its own `_atomic_prescriptive_template()` function defined. 

2. `_atomic_prescriptive_summary()`

    - called by Mercury. Will call the `_atomic_prescriptive_template()` defined in the specific Expectation, or the one that is in the base Expectation class. 

3. `_prescriptive_renderer()`

    - called by OSS GE in generating DataDocs. Has been modified to call `_atomic_prescriptive_template()` function



After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- CLOUD-250

Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.