### PR TITLE
[BUGFIX] Fix deprecation warning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,6 @@ title: Changelog
 ---
 
 ### Develop
-* [BUGFIX] Fix deprecation warning for importing from collections
 
 ### 0.13.38
 * [FEATURE] Atomic Renderer: Initial framework and Prescriptive renderers (#3529)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ title: Changelog
 ---
 
 ### Develop
+* [BUGFIX] Fix deprecation warning for importing from collections
 
 ### 0.13.38
 * [FEATURE] Atomic Renderer: Initial framework and Prescriptive renderers (#3529)

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 
 develop
 -----------------
+* [BUGFIX] Fix deprecation warning for importing from collections
+
 
 0.13.38
 -----------------
@@ -59,7 +61,7 @@ develop
 * [MAINTENANCE] Remove validation playground notebooks (#3467)
 * [MAINTENANCE] clean up type hints, API usage, imports, and coding style (#3444)
 * [MAINTENANCE] comments (#3457)
- 
+
 0.13.35
 -----------------
 * [FEATURE] Create ExpectationValidationGraph class to Maintain Relationship Between Expectation and Metrics and Use it to Associate Exceptions to Expectations (#3433)

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import uuid
 import warnings
-from collections import Callable
+from collections.abc import Callable
 from functools import partial
 from io import BytesIO
 

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -1,7 +1,7 @@
 import importlib
 import itertools
 import json
-from collections import Iterable
+from collections.abc import Iterable
 
 from great_expectations.marshmallow__shade import ValidationError
 


### PR DESCRIPTION
This PR fixes a deprecation warning  for importing from collections and makes it compatible with Python 3.9

`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have made corresponding changes to the documentation

Thank you for submitting!
