### PR TITLE
Docs/revamp style guides

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -24,7 +24,7 @@ Alternatively, for small changes that don’t need to be tested locally (e.g. do
 * Our [Levels of maturity grid](/docs/contributing/contributing_maturity) provides guidelines for how the maintainers of Great Expectations evaluate levels of maturity of a feature.
 
 #### 4. Start developing
-* Make sure to reference the [Style Guide](/docs/contributing/contributing_style) and instructions on [Testing](/docs/contributing/contributing_test) when developing your code. When your changes are ready, run through our [Contribution checklist](/docs/contributing/contributing_checklist) for pull requests.
+* Make sure to reference the style guides for [code](/docs/contributing/style_guides/code_style) and [docs](/docs/contributing/style_guides/docs_style) and instructions on [Testing](/docs/contributing/contributing_test) when developing your code. When your changes are ready, run through our [Contribution checklist](/docs/contributing/contributing_checklist) for pull requests.
 
 Note that if it’s your first contribution, there is a standard Contributor license agreement (CLA) you will need to sign :
 * [Individual Contributor License Agreement v1.0](https://docs.google.com/forms/d/e/1FAIpQLSdA-aWKQ15yBzp8wKcFPpuxIyGwohGU1Hx-6Pa4hfaEbbb3fg/viewform?usp=sf_link)

--- a/docs/contributing/contributing_checklist.md
+++ b/docs/contributing/contributing_checklist.md
@@ -18,7 +18,7 @@ Once your code is ready, please go through the following checklist before submit
 
 #### 2. Have you followed the Style Guide for code and comments?
 
-* The [Style Guide](/docs/contributing/contributing_style) is here.
+* The [Style Guide](/docs/contributing/style_guides/code_style) is here.
 
 * Thanks for helping us keep the codebase and documentation clean and consistent, so that it’s easier to maintain it as a community!
 

--- a/docs/contributing/contributing_github.md
+++ b/docs/contributing/contributing_github.md
@@ -24,7 +24,7 @@ If you want to change documentation, but not code, we suggest using the GitHub m
 
 * Make your edits and use the Preview tab to preview changes.
 
-* Please pay close attention to the [Style Guide](/docs/contributing/contributing_style).
+* Please pay close attention to the [Style Guide](/docs/contributing/style_guides/docs_style).
 
 ### Submit a pull request
 

--- a/docs/contributing/style_guides/cli_and_notebooks_style.md
+++ b/docs/contributing/style_guides/cli_and_notebooks_style.md
@@ -8,24 +8,15 @@ This style guide will be enforced for all incoming PRs. However, certain legacy 
 
 ### The CLI
 
-The [CLI](docs/guides/miscellaneous/how_to_use_the_great_expectations_cli) has some conventions of its own.
+The [CLI](../../guides/miscellaneous/how_to_use_the_great_expectations_cli) has some conventions of its own.
 
 * The CLI never writes to disk without asking first.
-
 * Questions are always phrased as conversational sentences.
-
 * Sections are divided by headers: “========== Profiling ==========”
-
 * We use punctuation: Please finish sentences with periods, questions marks, or an occasional exclamation point.
-
 * Keep indentation and line spacing consistent! (We’re pythonistas, natch.)
-
 * Include exactly one blank line after every question.
-
 * Within those constraints, shorter is better. When in doubt, shorten.
-
 * Clickable links (usually to documentation) are blue.
-
 * Copyable bash commands are green.
-
 * All top-level bash commands must be nouns: “docs build”, not “build docs”

--- a/docs/contributing/style_guides/cli_and_notebooks_style.md
+++ b/docs/contributing/style_guides/cli_and_notebooks_style.md
@@ -1,0 +1,31 @@
+---
+title: CLI and Notebook style guide
+---
+
+:::info Note
+This style guide will be enforced for all incoming PRs. However, certain legacy areas within the repo do not yet fully adhere to the style guide. We welcome PRs to bring these areas up to code.
+:::
+
+### The CLI
+
+The [CLI](docs/guides/miscellaneous/how_to_use_the_great_expectations_cli) has some conventions of its own.
+
+* The CLI never writes to disk without asking first.
+
+* Questions are always phrased as conversational sentences.
+
+* Sections are divided by headers: “========== Profiling ==========”
+
+* We use punctuation: Please finish sentences with periods, questions marks, or an occasional exclamation point.
+
+* Keep indentation and line spacing consistent! (We’re pythonistas, natch.)
+
+* Include exactly one blank line after every question.
+
+* Within those constraints, shorter is better. When in doubt, shorten.
+
+* Clickable links (usually to documentation) are blue.
+
+* Copyable bash commands are green.
+
+* All top-level bash commands must be nouns: “docs build”, not “build docs”

--- a/docs/contributing/style_guides/code_style.md
+++ b/docs/contributing/style_guides/code_style.md
@@ -6,7 +6,7 @@ title: Code style guide
 This style guide will be enforced for all incoming PRs. However, certain legacy areas within the repo do not yet fully adhere to the style guide. We welcome PRs to bring these areas up to code.
 :::
 
-### code
+### Code
 
 * **Methods are almost always named using snake_case.**
 

--- a/docs/contributing/style_guides/code_style.md
+++ b/docs/contributing/style_guides/code_style.md
@@ -1,0 +1,51 @@
+---
+title: Code style guide
+---
+
+:::info Note
+This style guide will be enforced for all incoming PRs. However, certain legacy areas within the repo do not yet fully adhere to the style guide. We welcome PRs to bring these areas up to code.
+:::
+
+### code
+
+* **Methods are almost always named using snake_case.**
+
+* **Methods that behave as operators (e.g. comparison or equality) are named using camelCase.** These methods are rare and should be changed with great caution. Please reach out to us if you see the need for a change of this kind.
+
+* **Experimental methods should log an experimental warning when called:** “Warning: some_method is experimental. Methods, APIs, and core behavior may change in the future.”
+
+* **Experimental classes should log an experimental warning when initialized:** “Warning: great_expectations.some_module.SomeClass is experimental. Methods, APIs, and core behavior may change in the future.”
+
+* **Docstrings are highly recommended.** We use the Sphinx’s [Napoleon extension](http://www.sphinx-doc.org/en/master/ext/napoleon.html) to build documentation from Google-style docstrings.
+
+* **Lint your code.** Our CI system will check using `black`, `isort`, `flake8` and `pyupgrade`. - Linting with `isort` MUST occur from a virtual environment that has all required packages installed, and pre-commit uses the virtual environment from which it was installed, whether or not that environment is active when making the commit. So, **before running ``pre-commit install`` ensure you have activated a virtual environment that has all development requirements installed.**
+
+````console
+pre-commit uninstall
+# ACTIVATE ENV, e.g.: conda activate pre_commit_env OR source pre_commit_env/bin/activate
+pip install -r requirements-dev.txt
+pre-commit install --install-hooks
+````
+
+	* If you have already committed files but are seeing errors during the continuous integration tests, you can run tests manually:
+
+````console
+black .
+isort . --check-only --skip docs
+flake8 great_expectations/core
+pyupgrade --py3-plus
+````
+
+### Expectations
+
+* **Use unambiguous Expectation names**, even if they’re a bit longer, e.g. `expect_columns_to_match_ordered_list` instead of `expect_columns_to_be`.
+
+* **Avoid abbreviations**, e.g. `column_index` instead of `column_idx`.
+
+* ((Expectation names should reflect their decorators:**
+
+	* `expect_table_...` for methods decorated directly with `@expectation`
+	* `expect_column_values_...` for `@column_map_expectation`
+	* `expect_column_...` for `@column_aggregate_expectation`
+	* `expect_column_pair_values...` for `@column_pair_map_expectation`
+

--- a/docs/contributing/style_guides/docs_style.md
+++ b/docs/contributing/style_guides/docs_style.md
@@ -2,11 +2,33 @@
 title: Documentation style guide
 ---
 
+### Organization
+
+Within the table of contents, each section has specific role to play. Broadly speaking, we follow Divio’s excellent [Documentation System](https://documentation.divio.com/), with the caveat that our “Core concepts section is their “Explanation” section, and our API Reference” section is their “Reference section”.
+
+* **Introduction** explains the Why of Great Expectations, so that potential users can quickly decide whether or not the library can help them.
+
+* **Getting Started with Great Expectations** help users and contributors get started quickly. Along the way they orient new users to concepts that will be important to know later.
+
+* **How-to guides** help users accomplish specific goals that go beyond the generic tutorials. Article titles within this section always start with “How to”: “How to create custom Expectations”. They often reference specific tools or infrastructure: “How to validate Expectations from within a notebook”, “How to build Data Docs in S3.”
+
+* **Deployment patterns** explains how to deploy Great Expectations alongside other data tools.
+
+* **Reference** articles explain the architecture of Great Expectations. Within this section, Core Concepts articles explain the essential elements of the project, discuss alternatives and options, and provide context, history, and direction for the project. Reference articles avoid giving specific technical advice. They also avoid implementation details that can be captured in docstrings instead. Docstrings themselves are surfaced in the API Reference.
+
+* **Community resources** helps expand the Great Expectations community by explaining how to get in touch to ask questions, make contributions, etc.
+
+* **Contributing** is all about how to improve Great Expectations as a contributor.
+
+* **Changelog** contains the changelog for the project.
+
+
+### General conventions
+
 :::info Note
 This style guide will be enforced for all incoming PRs. However, certain legacy areas within the repo do not yet fully adhere to the style guide. We welcome PRs to bring these areas up to code.
 :::
 
-### General conventions
 
 * The **project name “Great Expectations” is always spaced and capitalized.** Good: “Great Expectations”. Bad: “great_expectations”, “great expectations”, “GE.”
 
@@ -16,36 +38,29 @@ This style guide will be enforced for all incoming PRs. However, certain legacy 
 
 * **We reserve the word “should” for strong directives, not just helpful guidance.**
 
-### Organization
 
-Within the table of contents, each section has specific role to play. Broadly speaking, we follow Divio’s excellent Documentation System, with the caveat that our “Reference” section is their “Explanation” section, and our “Module docs” section is their “Reference section”.
-
-* **Introduction** explains the Why of Great Expectations, so that potential users can quickly decide whether or not the library can help them.
-
-* **Tutorials** help users and contributors get started quickly. Along the way they orient new users to concepts that will be important to know later.
-
-* **How-to guides** help users accomplish specific goals that go beyond the generic tutorials. Article titles within this section always start with “How to”: “How to create custom Expectations”. They often reference specific tools or infrastructure: “How to validate Expectations from within a notebook”, “How to build Data Docs in S3.”
-
-* **Reference** articles explain the architecture of Great Expectations. These articles explain core concepts, discuss alternatives and options, and provide context, history, and direction for the project. Reference articles avoid giving specific technical advice. They also avoid implementation details that can be captured in docstrings instead.
-
-* **Community** helps expand the Great Expectations community by explaining how to get in touch to ask questions, make contributions, etc.
-
-* **Module docs** link through to module docstrings themselves.
 
 ### Titles
 
-* **Headers are capitalized like sentences**. Yep: “Installing within a project.” Nope: “Installing Within a Project.”
+* **Titles and headers are capitalized like sentences**.
 
-* **For sections within “how to”-type guides, titles should be short, imperative sentences**. Avoid extra words. Good: “Configure data documentation”. Nope: “Configuring data documentation”. Avoid: “Configure documentation for your data”
+	* Yep: “Installing within a project.”
+	* Nope: “Installing Within a Project.”
 
-* **Please follow the Sphinx guide for sections to determine which of the many, confusing .rst underlining conventions to use**: [Sphinx guide for sections](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections)
+* **For sections within “how to”-type guides, titles should be short, imperative sentences**.
+
+	Avoid extra words. Good: “Configure data documentation”. Nope: “Configuring data documentation”. Avoid: “Configure documentation for your data”
+
+
 
 ### Core concepts and classes
 
-* **Core concepts are always capitalized, and always are linked on first reference within each page**. Pretend the docs are a fantasy novel, and core concepts are magic.
+* **Core concepts are always capitalized, and always are linked on first reference within each page.**
+
+	If it's important enough to show up in the Core Concepts section, it should be capitalized when it occurs in text. Pretend the docs are a fantasy novel, and core concepts are magic.
 
 	* Wrong: “You can create expectation suites as follows…”
-	* Better: “You can create [Expectation Suites](http://localhost:3000/docs/reference/glossary_of_expectations) as follows…”
+	* Better: “You can create Expectation Suites as follows…”
 	* Avoid: “You can create suites of Expectations as follows…”
 
 * **Class names are written in upper camel case, and always linked on first reference.** 
@@ -53,44 +68,11 @@ Within the table of contents, each section has specific role to play. Broadly sp
 	* Good: “ValidationOperator.” 
 	* Bad: “validationOperator”, “validation operator”. 
 
-If a word is both a core concept and a class name, prefer the core concept unless the text refers specifically to the class.
+	If a word is both a core concept and a class name, prefer the core concept unless the text refers specifically to the class.
 
-### File names, RST refs, and links
+* **Core concepts and class names are always linked on first reference within each page&mdash;except within the Getting Started guides**.
 
-* **File names should parallel titles, so that URLs and titles are similar**. For example: the page titled `Initialize a project` has this filename: `initialize_a_project.rst`, which produces this URL: `initialize_a_project.html`
+	The first time a given core concept or class name shows up on any given page, it should be linked to the appropriate page. Additional references within that page should not be linked, unless the point of the text is specifically to link to the concept.
 
-* **Use snake case for file names.**
+	Within the Getting Started section, we make an exception for this rule, to avoid distracting new users with many extraneous links.
 
-* **Refs are \``_{filename}\`` or \``_{folder_name}__{filename}\``**. Ex: `_getting_started__initialize_a_project`
-
-* **Links to docs in the API Reference section**
-
-	* Link to a module: `:mod:great_expectations.data_context.data_context` `great_expectations.data_context.data_context`
-
-	* Abbreviated link to a module: :mod:`~great_expectations.data_context.data_context` data_context
-
-	* Link to a class: :py:class:`great_expectations.data_context.data_context.BaseDataContext` great_expectations.data_context.data_context.BaseDataContext
-
-	* Abbreviated link to a class: :py:class:`~great_expectations.data_context.data_context.BaseDataContext` BaseDataContext
-
-	* Link to a method in a class: :py:meth:`great_expectations.data_context.data_context.BaseDataContext.validate_config` great_expectations.data_context.data_context.BaseDataContext.validate_config()
-
-	* Abbreviated link to a method in a class: :py:meth:`~great_expectations.data_context.data_context.BaseDataContext.validate_config` validate_config()
-
-	* Link to an attribute in a class: :py:attr:`great_expectations.data_context.data_context.BaseDataContext.GE_DIR` great_expectations.data_context.data_context.BaseDataContext.GE_DIR
-
-	* Abbreviated link to an attribute in a class: :py:attr:`~great_expectations.data_context.data_context.BaseDataContext.GE_DIR` GE_DIR
-
-	* Link to a function in a module: :py:attr:`great_expectations.jupyter_ux.display_column_evrs_as_section` great_expectations.jupyter_ux.display_column_evrs_as_section
-
-	* Abbreviated to a function in a module: :py:attr:`~great_expectations.jupyter_ux.display_column_evrs_as_section` display_column_evrs_as_section
-
-### Code formatting
-
-* **For inline code in RST, make sure to use double backticks**. 
-
-	* Yep: The `init` command will walk you through setting up a new project and connecting to your data.
-
-	* Nope: The *init* command will walk you through setting up a new project and connecting to your data.
-
-	* **For inline bash blocks, do not include a leading $.** It makes it hard for users to copy-paste code blocks.

--- a/docs/contributing/style_guides/docs_style.md
+++ b/docs/contributing/style_guides/docs_style.md
@@ -10,7 +10,7 @@ Within the table of contents, each section has specific role to play. Broadly sp
 
 * **Getting Started with Great Expectations** help users and contributors get started quickly. Along the way they orient new users to concepts that will be important to know later.
 
-* **How-to guides** help users accomplish specific goals that go beyond the generic tutorials. Article titles within this section always start with “How to”: “How to create custom Expectations”. They often reference specific tools or infrastructure: “How to validate Expectations from within a notebook”, “How to build Data Docs in S3.”
+* **How-to guides** help users accomplish specific goals that go beyond the generic tutorials. Article titles within this section always start with “How to”: “How to create custom Expectations”. They often reference specific tools or infrastructure: “How to validate Expectations from within a notebook”, “How to build Data Docs in S3.” For additional information, please see [How to write a how-to-guide](../../guides/miscellaneous/how_to_write_a_how_to_guide).
 
 * **Deployment patterns** explains how to deploy Great Expectations alongside other data tools.
 

--- a/docs/contributing/style_guides/docs_style.md
+++ b/docs/contributing/style_guides/docs_style.md
@@ -1,8 +1,6 @@
 ---
-title: Contributing Style Guide
+title: Documentation style guide
 ---
-
-### Style Guide
 
 :::info Note
 This style guide will be enforced for all incoming PRs. However, certain legacy areas within the repo do not yet fully adhere to the style guide. We welcome PRs to bring these areas up to code.
@@ -18,76 +16,7 @@ This style guide will be enforced for all incoming PRs. However, certain legacy 
 
 * **We reserve the word “should” for strong directives, not just helpful guidance.**
 
-#### code
-
-* **Methods are almost always named using snake_case.**
-
-* **Methods that behave as operators (e.g. comparison or equality) are named using camelCase.** These methods are rare and should be changed with great caution. Please reach out to us if you see the need for a change of this kind.
-
-* **Experimental methods should log an experimental warning when called:** “Warning: some_method is experimental. Methods, APIs, and core behavior may change in the future.”
-
-* **Experimental classes should log an experimental warning when initialized:** “Warning: great_expectations.some_module.SomeClass is experimental. Methods, APIs, and core behavior may change in the future.”
-
-* **Docstrings are highly recommended.** We use the Sphinx’s [Napoleon extension](http://www.sphinx-doc.org/en/master/ext/napoleon.html) to build documentation from Google-style docstrings.
-
-* **Lint your code.** Our CI system will check using `black`, `isort`, `flake8` and `pyupgrade`. - Linting with `isort` MUST occur from a virtual environment that has all required packages installed, and pre-commit uses the virtual environment from which it was installed, whether or not that environment is active when making the commit. So, **before running ``pre-commit install`` ensure you have activated a virtual environment that has all development requirements installed.**
-
-````console
-pre-commit uninstall
-# ACTIVATE ENV, e.g.: conda activate pre_commit_env OR source pre_commit_env/bin/activate
-pip install -r requirements-dev.txt
-pre-commit install --install-hooks
-````
-
-	* If you have already committed files but are seeing errors during the continuous integration tests, you can run tests manually:
-
-````console
-black .
-isort . --check-only --skip docs
-flake8 great_expectations/core
-pyupgrade --py3-plus
-````
-
-#### Expectations
-
-* **Use unambiguous Expectation names**, even if they’re a bit longer, e.g. `expect_columns_to_match_ordered_list` instead of `expect_columns_to_be`.
-
-* **Avoid abbreviations**, e.g. `column_index` instead of `column_idx`.
-
-* ((Expectation names should reflect their decorators:**
-
-	* `expect_table_...` for methods decorated directly with `@expectation`
-	* `expect_column_values_...` for `@column_map_expectation`
-	* `expect_column_...` for `@column_aggregate_expectation`
-	* `expect_column_pair_values...` for `@column_pair_map_expectation`
-
-#### The CLI
-
-The [CLI](docs/guides/miscellaneous/how_to_use_the_great_expectations_cli) has some conventions of its own.
-
-* The CLI never writes to disk without asking first.
-
-* Questions are always phrased as conversational sentences.
-
-* Sections are divided by headers: “========== Profiling ==========”
-
-* We use punctuation: Please finish sentences with periods, questions marks, or an occasional exclamation point.
-
-* Keep indentation and line spacing consistent! (We’re pythonistas, natch.)
-
-* Include exactly one blank line after every question.
-
-* Within those constraints, shorter is better. When in doubt, shorten.
-
-* Clickable links (usually to documentation) are blue.
-
-* Copyable bash commands are green.
-
-* All top-level bash commands must be nouns: “docs build”, not “build docs”
-
-#### .rst files
-
-##### Organization
+### Organization
 
 Within the table of contents, each section has specific role to play. Broadly speaking, we follow Divio’s excellent Documentation System, with the caveat that our “Reference” section is their “Explanation” section, and our “Module docs” section is their “Reference section”.
 
@@ -103,7 +32,7 @@ Within the table of contents, each section has specific role to play. Broadly sp
 
 * **Module docs** link through to module docstrings themselves.
 
-#### Titles
+### Titles
 
 * **Headers are capitalized like sentences**. Yep: “Installing within a project.” Nope: “Installing Within a Project.”
 
@@ -111,7 +40,7 @@ Within the table of contents, each section has specific role to play. Broadly sp
 
 * **Please follow the Sphinx guide for sections to determine which of the many, confusing .rst underlining conventions to use**: [Sphinx guide for sections](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections)
 
-#### Core concepts and classes
+### Core concepts and classes
 
 * **Core concepts are always capitalized, and always are linked on first reference within each page**. Pretend the docs are a fantasy novel, and core concepts are magic.
 
@@ -126,7 +55,7 @@ Within the table of contents, each section has specific role to play. Broadly sp
 
 If a word is both a core concept and a class name, prefer the core concept unless the text refers specifically to the class.
 
-#### File names, RST refs, and links
+### File names, RST refs, and links
 
 * **File names should parallel titles, so that URLs and titles are similar**. For example: the page titled `Initialize a project` has this filename: `initialize_a_project.rst`, which produces this URL: `initialize_a_project.html`
 

--- a/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
+++ b/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
@@ -68,7 +68,7 @@ Recently we introduced a fast-track release process for community contributed Ex
 	* Class declaration (search for `class Expect`)
 	* A call to `run_diagnostic` in the very end of the template (search for ``diagnostics_report = ``). Next section explains the role this code plays.
 	
-	For more style conventions that your code should follow consult our [Style Guide](/docs/contributing/contributing_style)
+	For more style conventions that your code should follow consult our [Style Guide](/docs/contributing/style_guides/code_style)
 
 #### 4. Run diagnostics on your Expectation.
 

--- a/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
+++ b/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
@@ -143,7 +143,7 @@ Once a draft of your guide is written, you can see it rendered on a `localhost` 
 
 7. If needed, add content to Additional Notes and/or Additional Resources. These sections supplement the article with information that would be distracting to include in Steps. It’s fine for them to be empty.
 
-8. Scan your article to make sure it follows the [Style guide](../../contributing/contributing_style). If you’re not familiar with the Style Guide, that’s okay: your PR reviewer will also check for style and let you know if we find any issues.
+8. Scan your article to make sure it follows the [Style guide](../../contributing/style_guides/docs_style). If you’re not familiar with the Style Guide, that’s okay: your PR reviewer will also check for style and let you know if we find any issues.
 
 9. Locally run integration tests for any code that was included as part of the guide. Also see our guide on [Testing](../../contributing/contributing_test)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -368,8 +368,16 @@ module.exports = {
         { type: 'doc', id: 'contributing/contributing_github' },
         { type: 'doc', id: 'contributing/contributing_test' },
         { type: 'doc', id: 'contributing/contributing_maturity' },
-        { type: 'doc', id: 'contributing/contributing_style' },
-        { type: 'doc', id: 'contributing/contributing_misc' }
+        { type: 'doc', id: 'contributing/contributing_misc' },
+        {
+          type: 'category',
+          label: 'Style guides',
+          items: [
+            { type: 'doc', id: 'contributing/style_guides/docs_style' },
+            { type: 'doc', id: 'contributing/style_guides/code_style' },
+            { type: 'doc', id: 'contributing/style_guides/cli_and_notebooks_style' },
+          ]
+        },
       ]
     },
     {

--- a/static/_redirects
+++ b/static/_redirects
@@ -167,3 +167,6 @@
 /en/latest/reference/spare_parts/data_context_reference.html https://legacy.docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html
 /en/latest/reference/spare_parts/profiling_reference.html https://legacy.docs.greatexpectations.io/en/latest/reference/spare_parts/profiling_reference.html
 /en/latest/reference/core_concepts.html https://legacy.docs.greatexpectations.io/en/latest/reference/core_concepts.html
+
+# Redirects for old style guides
+/docs/contributing/contributing_style https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style


### PR DESCRIPTION
Changes proposed in this pull request:
- Switches the Style Guide page for a Style Guides section in the ToC
- Redistributes and cleans up the content within that section.
- Adds a redirect so that links to the old style guide won't break

Explanation via loom: https://www.loom.com/share/929a050788ad4c5090815a42d959c1d9