### PR TITLE
[MAINTENANCE] Removed warning for pandas option display.max_colwidth

### DIFF
--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -4,6 +4,7 @@
 import logging
 import sys
 from datetime import datetime
+from packaging import version
 
 import pandas as pd
 import tzlocal
@@ -13,9 +14,11 @@ pd.set_option("display.max_rows", None)
 pd.set_option("display.max_columns", None)
 pd.set_option("display.width", None)
 
-# must be -1 for Pandas 0.23 and 0.25 compatibility checks
-# ... however -1 throws a deprecation warning in current versions
-pd.set_option("display.max_colwidth", -1)
+if version.parse(pd.__version__) <= version.parse("1.0.0"):
+    # support for negative integers was deprecated in version 1.0.1
+    pd.set_option("display.max_colwidth", -1)
+else:
+    pd.set_option("display.max_colwidth", None)
 
 from great_expectations.render.renderer import (
     ExpectationSuiteColumnSectionRenderer,

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -4,11 +4,11 @@
 import logging
 import sys
 from datetime import datetime
-from packaging import version
 
 import pandas as pd
 import tzlocal
 from IPython.core.display import HTML, display
+from packaging import version
 
 pd.set_option("display.max_rows", None)
 pd.set_option("display.max_columns", None)


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed the warning from using a deprecated display option in pandas; this warning in particular was impacting the getting started guide.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
