### PR TITLE
[BUGFIX] Use `external_sqldialect` mark to skip during lightweight runs

### DIFF
--- a/azure/dev-install-matrix.yml
+++ b/azure/dev-install-matrix.yml
@@ -55,7 +55,7 @@ jobs:
         - script: |
             pip install -I pytest
             pip install pytest-cov pytest-azurepipelines
-            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "not external_sqldialect"
           displayName: 'pytest'
 
         - task: PublishTestResults@2

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ filterwarnings =
     ignore:stream argument is deprecated. Use stream parameter in request directly:DeprecationWarning
 junit_family=xunit2
 markers =
-    docs: mark a test as a docs test
-    integration: mark test as an integration test
+    docs: mark a test as a docs test.
+    integration: mark test as an integration test.
+    external_sqldialect: mark test as requiring install of an external sql dialect.
 testpaths = tests

--- a/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_sampling.py
+++ b/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_sampling.py
@@ -94,7 +94,9 @@ def dialect_name_to_sql_statement():
 @pytest.mark.parametrize(
     "dialect_name",
     [
-        pytest.param(dialect_name, id=dialect_name.value)
+        pytest.param(
+            dialect_name, id=dialect_name.value, marks=pytest.mark.external_sqldialect
+        )
         for dialect_name in GESqlDialect.get_all_dialects()
     ],
 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Our packaging tests were failing on the lightweight `dev-install-matrix.yml` version because external sqldialects are not installed for that pipeline. This PR adds an `external_sqldialect` mark and uses it to skip all of the dialects in the failing test.
- Potential future improvement is to only mark dialects that require install of more than `sqlalchemy`.



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
