### PR TITLE
[MAINTENANCE] Allow for include/exclude column name args in DataAssistant `run`

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -420,6 +420,13 @@ class DataAssistant(metaclass=MetaDataAssistant):
             batch_list=list(self._batches.values()),
             batch_request=None,
         )
+
+        if include_column_names or exclude_column_names:
+            data_assistant_result.filter_expectation_configurations_by_column_names(
+                include_column_names=include_column_names,
+                exclude_column_names=exclude_column_names,
+            )
+
         return self._build_data_assistant_result(
             data_assistant_result=data_assistant_result
         )

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -389,6 +389,8 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
+        include_column_names: Optional[List[str]] = None,
+        exclude_column_names: Optional[List[str]] = None,
     ) -> DataAssistantResult:
         """
         Run the DataAssistant as it is currently configured.
@@ -400,6 +402,11 @@ class DataAssistant(metaclass=MetaDataAssistant):
         Returns:
             DataAssistantResult: The result object for the DataAssistant
         """
+        if include_column_names is not None and exclude_column_names is not None:
+            raise ValueError(
+                "You may either use `include_column_names` or `exclude_column_names` (but not both)."
+            )
+
         data_assistant_result: DataAssistantResult = DataAssistantResult(
             batch_id_to_batch_identifier_display_name_map=self.batch_id_to_batch_identifier_display_name_map(),
             execution_time=0.0,

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -424,13 +424,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
             rules=rules,
             batch_list=list(self._batches.values()),
             batch_request=None,
+            include_column_names=include_column_names,
+            exclude_column_names=exclude_column_names,
         )
-
-        if include_column_names or exclude_column_names:
-            data_assistant_result.filter_expectation_configurations_by_column_names(
-                include_column_names=include_column_names,
-                exclude_column_names=exclude_column_names,
-            )
 
         return self._build_data_assistant_result(
             data_assistant_result=data_assistant_result
@@ -582,6 +578,8 @@ def run_profiler_on_data(
     rules: Optional[Dict[str, Dict[str, Any]]] = None,
     batch_list: Optional[List[Batch]] = None,
     batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+    include_column_names: Optional[List[str]] = None,
+    exclude_column_names: Optional[List[str]] = None,
 ) -> None:
     """
     This method executes "run()" of effective "RuleBasedProfiler" and fills "DataAssistantResult" object with outputs.
@@ -609,6 +607,8 @@ def run_profiler_on_data(
         batch_request=batch_request,
         recompute_existing_parameter_values=False,
         reconciliation_directives=DEFAULT_RECONCILATION_DIRECTIVES,
+        include_column_names=include_column_names,
+        exclude_column_names=exclude_column_names,
     )
     result: DataAssistantResult = data_assistant_result
     result.profiler_config = profiler.config

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -398,9 +398,14 @@ class DataAssistant(metaclass=MetaDataAssistant):
         Args:
             variables: attribute name/value pairs (overrides), commonly-used in Builder objects
             rules: name/(configuration-dictionary) (overrides)
+            include_column_names: Explicitly specified desired columns (if None, it is computed based on active Batch).
+            exclude_column_names: If provided, these columns are pre-filtered and excluded from consideration.
 
         Returns:
             DataAssistantResult: The result object for the DataAssistant
+
+        Raises:
+            ValueError if both include_column_names and exclude_column_names have been provided.
         """
         if include_column_names is not None and exclude_column_names is not None:
             raise ValueError(

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from great_expectations.core.batch import BatchRequestBase
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
@@ -37,6 +37,8 @@ class DataAssistantRunner:
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        include_column_names: Optional[List[str]] = None,
+        exclude_column_names: Optional[List[str]] = None,
     ) -> DataAssistantResult:
         data_assistant_name: str = self._data_assistant_cls.data_assistant_type
         validator: Validator = get_validator_with_expectation_suite(
@@ -53,5 +55,7 @@ class DataAssistantRunner:
         data_assistant_result: DataAssistantResult = data_assistant.run(
             variables=variables,
             rules=rules,
+            include_column_names=include_column_names,
+            exclude_column_names=exclude_column_names,
         )
         return data_assistant_result

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -131,10 +131,10 @@ class DataAssistantResult(SerializableDictDot):
         for expectation_configuration in self.expectation_configurations:
             kwargs: dict = expectation_configuration.get("kwargs", {})
             column: Optional[str] = kwargs.get("column")
-            if column is None:
-                continue
-            if (include_column_names and column in include_column_names) or (
-                exclude_column_names and column not in exclude_column_names
+            if (
+                (column is None)
+                or (include_column_names and column in include_column_names)
+                or (exclude_column_names and column not in exclude_column_names)
             ):
                 filtered_expectation_configurations.append(expectation_configuration)
 

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -118,6 +118,28 @@ class DataAssistantResult(SerializableDictDot):
         }
         return metrics_attributed_values_by_domain
 
+    def filter_expectation_configurations_by_column_names(
+        self,
+        include_column_names: Optional[List[str]] = None,
+        exclude_column_names: Optional[List[str]] = None,
+    ) -> None:
+        if self.expectation_configurations is None:
+            return
+
+        filtered_expectation_configurations: List[ExpectationConfiguration] = []
+
+        for expectation_configuration in self.expectation_configurations:
+            kwargs: dict = expectation_configuration.get("kwargs", {})
+            column: Optional[str] = kwargs.get("column")
+            if column is None:
+                continue
+            if (include_column_names and column in include_column_names) or (
+                exclude_column_names and column not in exclude_column_names
+            ):
+                filtered_expectation_configurations.append(expectation_configuration)
+
+        self.expectation_configurations = filtered_expectation_configurations
+
     @staticmethod
     def display(
         charts: Union[List[alt.Chart], List[alt.VConcatChart]],

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -123,6 +123,20 @@ class DataAssistantResult(SerializableDictDot):
         include_column_names: Optional[List[str]] = None,
         exclude_column_names: Optional[List[str]] = None,
     ) -> None:
+        """Modify the expectation configuration attribute of the result object based on input column lists (performed in-place).
+
+        Args:
+            include_column_names: Explicitly specified desired columns (if None, it is computed based on active Batch).
+            exclude_column_names: If provided, these columns are pre-filtered and excluded from consideration.
+
+        Raises:
+            ValueError if both include_column_names and exclude_column_names have been provided.
+        """
+        if include_column_names is not None and exclude_column_names is not None:
+            raise ValueError(
+                "You may either use `include_column_names` or `exclude_column_names` (but not both)."
+            )
+
         if self.expectation_configurations is None:
             return
 
@@ -132,9 +146,7 @@ class DataAssistantResult(SerializableDictDot):
             kwargs: dict = expectation_configuration.get("kwargs", {})
             column: Optional[str] = kwargs.get("column")
             if (
-                (
-                    column is None
-                )  # Lack of column kwarg denotes a table-domain configuration
+                (column is None)
                 or (include_column_names and column in include_column_names)
                 or (exclude_column_names and column not in exclude_column_names)
             ):

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -132,7 +132,9 @@ class DataAssistantResult(SerializableDictDot):
             kwargs: dict = expectation_configuration.get("kwargs", {})
             column: Optional[str] = kwargs.get("column")
             if (
-                (column is None)
+                (
+                    column is None
+                )  # Lack of column kwarg denotes a table-domain configuration
                 or (include_column_names and column in include_column_names)
                 or (exclude_column_names and column not in exclude_column_names)
             ):

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -118,42 +118,6 @@ class DataAssistantResult(SerializableDictDot):
         }
         return metrics_attributed_values_by_domain
 
-    def filter_expectation_configurations_by_column_names(
-        self,
-        include_column_names: Optional[List[str]] = None,
-        exclude_column_names: Optional[List[str]] = None,
-    ) -> None:
-        """Modify the expectation configuration attribute of the result object based on input column lists (performed in-place).
-
-        Args:
-            include_column_names: Explicitly specified desired columns (if None, it is computed based on active Batch).
-            exclude_column_names: If provided, these columns are pre-filtered and excluded from consideration.
-
-        Raises:
-            ValueError if both include_column_names and exclude_column_names have been provided.
-        """
-        if include_column_names is not None and exclude_column_names is not None:
-            raise ValueError(
-                "You may either use `include_column_names` or `exclude_column_names` (but not both)."
-            )
-
-        if self.expectation_configurations is None:
-            return
-
-        filtered_expectation_configurations: List[ExpectationConfiguration] = []
-
-        for expectation_configuration in self.expectation_configurations:
-            kwargs: dict = expectation_configuration.get("kwargs", {})
-            column: Optional[str] = kwargs.get("column")
-            if (
-                (column is None)
-                or (include_column_names and column in include_column_names)
-                or (exclude_column_names and column not in exclude_column_names)
-            ):
-                filtered_expectation_configurations.append(expectation_configuration)
-
-        self.expectation_configurations = filtered_expectation_configurations
-
     @staticmethod
     def display(
         charts: Union[List[alt.Chart], List[alt.VConcatChart]],

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2506,7 +2506,7 @@ def test_volume_data_assistant_run_include_columns_filters_expectation_configura
         "data_asset_name": "my_reports",
     }
 
-    include_column_names: List[str] = ["extra", "passenger_count", "rate_code"]
+    include_column_names: List[str] = ["extra", "passenger_count", "RatecodeID"]
     data_assistant_result: DataAssistantResult = context.assistants.volume.run(
         batch_request=batch_request, include_column_names=include_column_names
     )
@@ -2515,7 +2515,7 @@ def test_volume_data_assistant_run_include_columns_filters_expectation_configura
         List[ExpectationConfiguration]
     ] = data_assistant_result.expectation_configurations
     assert (
-        expectation_configurations is not None and len(expectation_configurations) == 3
+        expectation_configurations is not None and len(expectation_configurations) == 4
     )
 
     for expectation_configuration in expectation_configurations:
@@ -2536,7 +2536,7 @@ def test_volume_data_assistant_run_both_include_and_exclude_columns_raises_value
         "data_asset_name": "my_reports",
     }
 
-    include_column_names: List[str] = ["extra", "passenger_count", "rate_code"]
+    include_column_names: List[str] = ["extra", "passenger_count", "RatecodeID"]
     exclude_column_names: List[str] = ["VendorID", "pickup_datetime"]
 
     with pytest.raises(ValueError) as e:

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2495,7 +2495,7 @@ def test_batch_id_order_consistency_in_attributed_metrics_by_domain_using_explic
     )
 
 
-def test_volume_data_assistant_run_include_columns_filters_expectation_configurations(
+def test_volume_data_assistant_run_include_columns_filters_data_assistant_result_attrs(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     context: DataContext = bobby_columnar_table_multi_batch_deterministic_data_context
@@ -2524,35 +2524,11 @@ def test_volume_data_assistant_run_include_columns_filters_expectation_configura
         if column:
             assert column in include_column_names
 
-
-def test_volume_data_assistant_run_both_include_and_exclude_columns_raises_value_error(
-    bobby_columnar_table_multi_batch_deterministic_data_context,
-):
-    context: DataContext = bobby_columnar_table_multi_batch_deterministic_data_context
-
-    batch_request: dict = {
-        "datasource_name": "taxi_pandas",
-        "data_connector_name": "monthly",
-        "data_asset_name": "my_reports",
-    }
-
-    include_column_names: List[str] = ["extra", "passenger_count", "RatecodeID"]
-    exclude_column_names: List[str] = ["VendorID", "pickup_datetime"]
-
-    with pytest.raises(ValueError) as e:
-        context.assistants.volume.run(
-            batch_request=batch_request,
-            include_column_names=include_column_names,
-            exclude_column_names=exclude_column_names,
-        )
-
-    assert (
-        str(e.value)
-        == "You may either use `include_column_names` or `exclude_column_names` (but not both)."
-    )
+    metrics_by_domain: Optional[dict] = data_assistant_result.metrics_by_domain
+    assert metrics_by_domain is not None and len(metrics_by_domain) == 4
 
 
-def test_volume_data_assistant_run_exclude_columns_filters_expectation_configurations(
+def test_volume_data_assistant_run_exclude_columns_filters_data_assistant_result_attrs(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     context: DataContext = bobby_columnar_table_multi_batch_deterministic_data_context
@@ -2580,6 +2556,36 @@ def test_volume_data_assistant_run_exclude_columns_filters_expectation_configura
         column: Optional[str] = kwargs.get("column")
         if column:
             assert column not in exclude_column_names
+
+    metrics_by_domain: Optional[dict] = data_assistant_result.metrics_by_domain
+    assert metrics_by_domain is not None and len(metrics_by_domain) == 17
+
+
+def test_volume_data_assistant_run_both_include_and_exclude_columns_raises_value_error(
+    bobby_columnar_table_multi_batch_deterministic_data_context,
+):
+    context: DataContext = bobby_columnar_table_multi_batch_deterministic_data_context
+
+    batch_request: dict = {
+        "datasource_name": "taxi_pandas",
+        "data_connector_name": "monthly",
+        "data_asset_name": "my_reports",
+    }
+
+    include_column_names: List[str] = ["extra", "passenger_count", "RatecodeID"]
+    exclude_column_names: List[str] = ["VendorID", "pickup_datetime"]
+
+    with pytest.raises(ValueError) as e:
+        context.assistants.volume.run(
+            batch_request=batch_request,
+            include_column_names=include_column_names,
+            exclude_column_names=exclude_column_names,
+        )
+
+    assert (
+        str(e.value)
+        == "You may either use `include_column_names` or `exclude_column_names` (but not both)."
+    )
 
 
 def test_volume_data_assistant_plot_descriptive_notebook_execution_fails(


### PR DESCRIPTION
Changes proposed in this pull request:
- Enable include/exclude column behavior from the RBP and the assistant.
  - Allows for additional customization - can now do column filtering at the Result level and the plotting level.

Previous Design Review notes:
- JIRA: https://superconductive.atlassian.net/browse/GREAT-905
- Loom: https://www.loom.com/share/bf7708e293714916ad9d511956ff9046


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
