### PR TITLE
[MAINTENANCE] Remove deprecated code from `Validator`

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -100,9 +100,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch as FluentBatch
     from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.expectations.expectation import Expectation
-    from great_expectations.rule_based_profiler import (
-        RuleBasedProfilerResult,
-    )
+    from great_expectations.rule_based_profiler import RuleBasedProfilerResult
     from great_expectations.rule_based_profiler.expectation_configuration_builder import (
         ExpectationConfigurationBuilder,
     )
@@ -114,9 +112,7 @@ if TYPE_CHECKING:
     )
     from great_expectations.rule_based_profiler.rule import Rule
     from great_expectations.validator.computed_metric import MetricValue
-    from great_expectations.validator.metric_configuration import (
-        MetricConfiguration,
-    )
+    from great_expectations.validator.metric_configuration import MetricConfiguration
 
 
 @dataclass
@@ -1264,51 +1260,6 @@ class Validator:
 
         return evrs
 
-    def append_expectation(self, expectation_config: ExpectationConfiguration) -> None:
-        """This method is a thin wrapper for ExpectationSuite.append_expectation"""
-        # deprecated-v0.13.0
-        warnings.warn(
-            "append_expectation is deprecated as of v0.13.0 and will be removed in v0.16. "
-            + "Please use ExpectationSuite.add_expectation instead.",
-            DeprecationWarning,
-        )
-        self._expectation_suite.append_expectation(expectation_config)
-
-    def find_expectation_indexes(
-        self,
-        expectation_configuration: ExpectationConfiguration,
-        match_type: str = "domain",
-    ) -> List[int]:
-        """This method is a thin wrapper for ExpectationSuite.find_expectation_indexes"""
-        # deprecated-v0.13.0
-        warnings.warn(
-            "find_expectation_indexes is deprecated as of v0.13.0 and will be removed in v0.16. "
-            + "Please use ExpectationSuite.find_expectation_indexes instead.",
-            DeprecationWarning,
-        )
-        return self._expectation_suite.find_expectation_indexes(
-            expectation_configuration=expectation_configuration, match_type=match_type
-        )
-
-    def find_expectations(
-        self,
-        expectation_configuration: ExpectationConfiguration,
-        match_type: str = "domain",
-        ge_cloud_id: Optional[str] = None,
-    ) -> List[ExpectationConfiguration]:
-        """This method is a thin wrapper for ExpectationSuite.find_expectations()"""
-        # deprecated-v0.13.0
-        warnings.warn(
-            "find_expectations is deprecated as of v0.13.0 and will be removed in v0.16. "
-            + "Please use ExpectationSuite.find_expectation_indexes instead.",
-            DeprecationWarning,
-        )
-        return self._expectation_suite.find_expectations(
-            expectation_configuration=expectation_configuration,
-            match_type=match_type,
-            ge_cloud_id=ge_cloud_id,
-        )
-
     def remove_expectation(
         self,
         expectation_configuration: ExpectationConfiguration,
@@ -1391,32 +1342,6 @@ class Validator:
         """
 
         self._default_expectation_args[argument] = value
-
-    def get_expectations_config(
-        self,
-        discard_failed_expectations: bool = True,
-        discard_result_format_kwargs: bool = True,
-        discard_include_config_kwargs: bool = True,
-        discard_catch_exceptions_kwargs: bool = True,
-        suppress_warnings: bool = False,
-    ) -> ExpectationSuite:
-        """
-        Returns an expectation configuration, providing an option to discard failed expectation and discard/ include'
-        different result aspects, such as exceptions and result format.
-        """
-        # deprecated-v0.13.0
-        warnings.warn(
-            "get_expectations_config is deprecated as of v0.13.0 and will be removed in v0.16. "
-            + "Please use get_expectation_suite instead.",
-            DeprecationWarning,
-        )
-        return self.get_expectation_suite(
-            discard_failed_expectations,
-            discard_result_format_kwargs,
-            discard_include_config_kwargs,
-            discard_catch_exceptions_kwargs,
-            suppress_warnings,
-        )
 
     @public_api
     def get_expectation_suite(  # noqa: C901 - complexity 17

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -7,7 +7,7 @@ from packaging import version
 
 from great_expectations.data_context.util import file_relative_path
 
-UNNEEDED_DEPRECATION_WARNINGS_THRESHOLD = 56
+UNNEEDED_DEPRECATION_WARNINGS_THRESHOLD = 52
 
 
 @pytest.fixture


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove old code now that we're in v16


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
