### PR TITLE
[BUGFIX] Add FluentBatchRequest early exit to convert_to_json_serializable

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import datetime
 import decimal
 import logging
@@ -284,6 +285,13 @@ def convert_to_json_serializable(  # noqa: C901 - complexity 32
     """
     # If it's one of our types, we use our own conversion; this can move to full schema
     # once nesting goes all the way down
+    from great_expectations.datasource.fluent.interfaces import (
+        BatchRequest as FluentBatchRequest,
+    )
+
+    if isinstance(data, FluentBatchRequest):
+        return dataclasses.asdict(data)
+
     if isinstance(data, (SerializableDictDot, SerializableDotDict)):
         return data.to_json_dict()
 

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 
+from great_expectations.checkpoint import SimpleCheckpoint
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent import (
     PandasFilesystemDatasource,
@@ -359,3 +360,30 @@ def test_splitter(
     )
     assert len(specified_batches) == specified_batch_cnt
     assert specified_batches[-1].metadata == last_specified_batch_metadata
+
+
+def test_checkpoint_run(empty_data_context):
+    context = empty_data_context
+    path = pathlib.Path(
+        __file__,
+        "..",
+        "..",
+        "..",
+        "..",
+        "test_sets",
+        "taxi_yellow_tripdata_samples",
+        "yellow_tripdata_sample_2019-02.csv",
+    ).resolve(strict=True)
+    csv_asset = context.sources.pandas_default.add_csv_asset("my_csv_asset", path)
+    batch_request = csv_asset.build_batch_request()
+    expectation_suite_name = "my_expectation_suite"
+    context.add_expectation_suite(expectation_suite_name)
+    checkpoint = SimpleCheckpoint(
+        "my_checkpoint",
+        data_context=context,
+        expectation_suite_name=expectation_suite_name,
+        batch_request=batch_request,
+    )
+    result = checkpoint.run()
+    assert result["success"]
+    assert result["checkpoint_config"]["class_name"] == "Checkpoint"

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -362,6 +362,7 @@ def test_splitter(
     assert specified_batches[-1].metadata == last_specified_batch_metadata
 
 
+@pytest.mark.integration
 def test_checkpoint_run(empty_data_context):
     context = empty_data_context
     path = pathlib.Path(


### PR DESCRIPTION
`convert_to_json_serializable` doesn't support our fluent batch requests. This adds yet another `isinstance` check to that function.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
