### PR TITLE
[BUGFIX] Fix bug with case sensitive execution env

### DIFF
--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -101,7 +101,7 @@ class GXExecutionEnvironment:
         if not self._all_installed_packages:
             # Only retrieve once
             self._all_installed_packages = [
-                item.metadata.get("Name")
+                item.metadata.get("Name").lower()
                 for item in metadata.distributions()
                 if item.metadata.get("Name") is not None
             ]

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -234,11 +234,11 @@ class GXDependencies:
 
     def get_required_dependency_names(self) -> List[str]:
         """Sorted list of required GX dependencies"""
-        return self.GX_REQUIRED_DEPENDENCIES
+        return [name.lower() for name in self.GX_REQUIRED_DEPENDENCIES]
 
     def get_dev_dependency_names(self) -> Set[str]:
         """Set of dev GX dependencies"""
-        return self.GX_DEV_DEPENDENCIES
+        return {name.lower() for name in self.GX_DEV_DEPENDENCIES}
 
     def get_required_dependency_names_from_requirements_file(self) -> List[str]:
         """Get unique names of required dependencies.

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -241,21 +241,22 @@ class GXDependencies:
         return {name.lower() for name in self.GX_DEV_DEPENDENCIES}
 
     def get_required_dependency_names_from_requirements_file(self) -> List[str]:
-        """Get unique names of required dependencies.
+        """Get unique names of required dependencies. Lowercase names.
 
         Returns:
             List of string names of required dependencies.
         """
         return sorted(
-            set(
-                self._get_dependency_names_from_requirements_file(
+            {
+                name.lower()
+                for name in self._get_dependency_names_from_requirements_file(
                     self._requirements_paths[self.PRIMARY_REQUIREMENTS_FILE]
                 )
-            )
+            }
         )
 
     def get_dev_dependency_names_from_requirements_file(self) -> List[str]:
-        """Get unique names of dependencies from all dev requirements files.
+        """Get unique lowercase names of dependencies from all dev requirements files.
         Returns:
             List of string names of dev dependencies.
         """
@@ -272,7 +273,7 @@ class GXDependencies:
                 dev_dependency_path.absolute()
             )
             dev_dependency_names.update(dependency_names)
-        return sorted(dev_dependency_names)
+        return sorted(name.lower() for name in dev_dependency_names)
 
     def _get_dependency_names_from_requirements_file(
         self, filepath: pathlib.Path

--- a/tests/core/usage_statistics/test_package_dependencies.py
+++ b/tests/core/usage_statistics/test_package_dependencies.py
@@ -60,7 +60,7 @@ def test_required_dependency_names_match_requirements_file():
     """
     ge_dependencies = GXDependencies()
     assert (
-        ge_dependencies.get_required_dependency_names()
+        sorted(ge_dependencies.get_required_dependency_names())
         == ge_dependencies.get_required_dependency_names_from_requirements_file()
     )
 
@@ -74,4 +74,7 @@ def test_dev_dependency_names_match_requirements_file():
     ge_dependencies = GXDependencies()
     assert ge_dependencies.get_dev_dependency_names() == set(
         ge_dependencies.get_dev_dependency_names_from_requirements_file()
-    ) - set(GXDependencies.GX_DEV_DEPENDENCIES_EXCLUDED_FROM_TRACKING)
+    ) - {
+        name.lower()
+        for name in GXDependencies.GX_DEV_DEPENDENCIES_EXCLUDED_FROM_TRACKING
+    }


### PR DESCRIPTION
Changes proposed in this pull request:
- Package names are not case sensitive but we are treating them as they are. This caused issues since SQLAlchemy is listed in our requirements as sqlalchemy. Now we convert every package name to lowercase before comparing to see if it is installed before getting the version number. This will help us find a better lower bound for SQLAlchemy.


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code