### PR TITLE
[MAINTENANCE] Test against minimum SQLAlchemy versions

### DIFF
--- a/ci/azure-pipelines-sqlalchemy-compatibility.yml
+++ b/ci/azure-pipelines-sqlalchemy-compatibility.yml
@@ -1,0 +1,194 @@
+# This file is responsible for configuring the `sqlalchemy-compatibility` pipeline (https://dev.azure.com/great-expectations/great_expectations/_build)
+#
+# The pipeline is run under the following conditions:
+#   - On the develop branch whenever a commit is made to an open PR
+#
+# In this pipeline we run tests against several databases using the latest patch
+# version of currently supported sqlalchemy versions. E.g 1.3.x, 1.4.x, 2.0.x
+# where x is the latest patch. This will help ensure we are compatible with all
+# previously supported versions as we make changes to support later versions.
+
+trigger:
+  branches:
+    include:
+    - develop
+
+resources:
+  containers:
+  - container: postgres
+    image: postgres:11
+    ports:
+    - 5432:5432
+    env:
+      POSTGRES_DB: "test_ci"
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+  - container: mysql
+    image: mysql:8.0.20
+    ports:
+      - 3306:3306
+    env:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: test_ci
+  - container: mssql
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    env:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: ReallyStrongPwd1234%^&*
+      MSSQL_DB: test_ci
+      MSSQL_PID: Developer
+    ports:
+      - 1433:1433
+  - container: trino
+    image: trinodb/trino:400
+    ports:
+      - 8088:8080
+
+variables:
+  GE_USAGE_STATISTICS_URL: "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
+
+
+stages:
+  - stage: scope_check
+    pool:
+      vmImage: 'ubuntu-latest'
+    jobs:
+      - job: changes
+        steps:
+          - task: ChangedFiles@1
+            name: CheckChanges
+            inputs:
+              verbose: true
+              rules: |
+                [DocsChanged]
+                docs/**
+                tests/integration/docusaurus/**
+                tests/integration/fixtures/**
+                tests/test_sets/**
+                examples/expectations/*.py
+                static/_redirects
+                static/index.html
+                /*.js
+                /*.json
+                yarn.lock
+
+                [GXChanged]
+                great_expectations/**/*.py
+                pyproject.toml
+                setup.cfg
+                setup.py
+                MANIFEST.in
+                tests/**
+                /*.txt
+                /*.yml
+                requirements*
+                reqs/*.txt
+                ci/**/*.yml
+                assets/scripts/**
+                scripts/*.py
+                scripts/*.sh
+
+  - stage: lint
+    dependsOn: scope_check
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    jobs:
+      - job: lint
+        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GXChanged'], true)
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: 3.7
+            displayName: 'Use Python 3.7'
+
+          - script: |
+              pip install $(grep -E '^(black|invoke|ruff)' reqs/requirements-dev-contrib.txt)
+              EXIT_STATUS=0
+              invoke fmt --check || EXIT_STATUS=$?
+              invoke lint || EXIT_STATUS=$?
+              exit $EXIT_STATUS
+
+  - stage: import_ge
+    dependsOn: scope_check
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    jobs:
+      - job: import_ge
+
+        steps:
+         - task: UsePythonVersion@0
+           inputs:
+             versionSpec: '3.7'
+           displayName: 'Use Python 3.7'
+
+         - script: |
+             pip install .
+           displayName: 'Install GX and required dependencies (i.e. not sqlalchemy)'
+
+         - script: |
+             python -c "import great_expectations as gx; print('Successfully imported GX Version:', gx.__version__)"
+           displayName: 'Import Great Expectations'
+
+  - stage: sqlalchemy_compatibility
+    dependsOn: [scope_check, lint, import_ge]
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    jobs:
+      - job: sqlalchemy_compatibility_postgres
+        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GXChanged'], true)
+        strategy:
+          # This matrix is intended to run against the latest patch versions of
+          # sqlalchemy minor versions that we support.
+          # (versions as semver major.minor.patch)
+          matrix:
+            sqlalchemy_1_3_x:
+              sqlalchemy_base_version: '1.3.0'
+            sqlalchemy_1_4_x:
+              sqlalchemy_base_version: '1.4.0'
+
+        services:
+          postgres: postgres
+
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.7'
+            displayName: 'Use Python 3.7'
+
+          - script: |
+              cp constraints-dev.txt constraints-dev-temp.txt
+              echo "SQLAlchemy~=$(sqlalchemy_base_version)" >> constraints-dev-temp.txt 
+              pip install --constraint constraints-dev-temp.txt ".[dev]" pytest-azurepipelines
+            displayName: 'Install dependencies using SQLAlchemy base version $(sqlalchemy_base_version)'
+
+          - script: |
+              # Run pytest
+              pytest \
+                --postgresql \
+                --ignore 'tests/cli' \
+                --ignore 'tests/integration/usage_statistics' \
+                --napoleon-docstrings \
+                --junitxml=junit/test-results.xml \
+                --cov=. \
+                --cov-report=xml \
+                --cov-report=html \
+                -m 'not unit and not e2e'
+
+            displayName: 'pytest'
+            env:
+              GE_USAGE_STATISTICS_URL: ${{ variables.GE_USAGE_STATISTICS_URL }}
+              SQLALCHEMY_WARN_20: true
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFiles: '**/test-*.xml'
+              testRunTitle: 'Publish test results for Python $(python.version)'
+
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'

--- a/ci/azure-pipelines-sqlalchemy-compatibility.yml
+++ b/ci/azure-pipelines-sqlalchemy-compatibility.yml
@@ -22,26 +22,6 @@ resources:
     env:
       POSTGRES_DB: "test_ci"
       POSTGRES_HOST_AUTH_METHOD: "trust"
-  - container: mysql
-    image: mysql:8.0.20
-    ports:
-      - 3306:3306
-    env:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_DATABASE: test_ci
-  - container: mssql
-    image: mcr.microsoft.com/mssql/server:2019-latest
-    env:
-      ACCEPT_EULA: Y
-      MSSQL_SA_PASSWORD: ReallyStrongPwd1234%^&*
-      MSSQL_DB: test_ci
-      MSSQL_PID: Developer
-    ports:
-      - 1433:1433
-  - container: trino
-    image: trinodb/trino:400
-    ports:
-      - 8088:8080
 
 variables:
   GE_USAGE_STATISTICS_URL: "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
@@ -59,18 +39,6 @@ stages:
             inputs:
               verbose: true
               rules: |
-                [DocsChanged]
-                docs/**
-                tests/integration/docusaurus/**
-                tests/integration/fixtures/**
-                tests/test_sets/**
-                examples/expectations/*.py
-                static/_redirects
-                static/index.html
-                /*.js
-                /*.json
-                yarn.lock
-
                 [GXChanged]
                 great_expectations/**/*.py
                 pyproject.toml
@@ -144,10 +112,14 @@ stages:
           # sqlalchemy minor versions that we support.
           # (versions as semver major.minor.patch)
           matrix:
-            sqlalchemy_1_3_x:
-              sqlalchemy_base_version: '1.3.0'
+            # Uncomment if we need 1.3.x verification
+            # sqlalchemy_1_3_x:
+              # sqlalchemy_base_version: '1.3.0'
             sqlalchemy_1_4_x:
               sqlalchemy_base_version: '1.4.0'
+            # Uncomment when we are compatible with 2.0.x.
+            # sqlalchemy_2_0_x:
+            #   sqlalchemy_base_version: '2.0.0'
 
         services:
           postgres: postgres

--- a/ci/azure-pipelines-sqlalchemy-compatibility.yml
+++ b/ci/azure-pipelines-sqlalchemy-compatibility.yml
@@ -137,6 +137,7 @@ stages:
 
     jobs:
       - job: sqlalchemy_compatibility_postgres
+        timeoutInMinutes: 90
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GXChanged'], true)
         strategy:
           # This matrix is intended to run against the latest patch versions of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -444,39 +444,39 @@ filterwarnings = [
 
     # SQLAlchemy 2.x support warnings. These warnings should be ignored until sqlalchemy 2.x is fully supported.
     # To get SQLAlchemy 2.x supported, remove one of these ignores and then fix the resulting errors.
-    'ignore: The legacy calling style of select\(\) is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select\(\).:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: Passing a string to Connection.execute\(\) is deprecated and will be removed in version 2.0.  Use the text\(\) construct, or the Connection.exec_driver_sql\(\) method to invoke a driver-level SQL string.:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The current statement is being autocommitted using implicit autocommit, which will be removed in SQLAlchemy 2.0. Use the .begin\(\) method of Engine or Connection in order to use an explicit transaction for DML and DDL statements.:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The "whens" argument to case\(\), when referring to a sequence of items, is now passed as a series of positional elements, rather than as a list.:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The Engine.execute\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. All statement execution in SQLAlchemy 2.0 is performed by the Connection.execute\(\) method of Connection, or in the ORM by the Session.execute\(\) method of Session.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The legacy calling style of select\(\) is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select\(\).:DeprecationWarning',
+    'ignore: Passing a string to Connection.execute\(\) is deprecated and will be removed in version 2.0.  Use the text\(\) construct, or the Connection.exec_driver_sql\(\) method to invoke a driver-level SQL string.:DeprecationWarning',
+    'ignore: The current statement is being autocommitted using implicit autocommit, which will be removed in SQLAlchemy 2.0. Use the .begin\(\) method of Engine or Connection in order to use an explicit transaction for DML and DDL statements.:DeprecationWarning',
+    'ignore: The "whens" argument to case\(\), when referring to a sequence of items, is now passed as a series of positional elements, rather than as a list.:DeprecationWarning',
+    'ignore: The Engine.execute\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. All statement execution in SQLAlchemy 2.0 is performed by the Connection.execute\(\) method of Connection, or in the ORM by the Session.execute\(\) method of Session.:DeprecationWarning',
     # Error with link to docs: sqlalchemy.exc.RemovedIn20Warning: The Connection.connect() method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     # Found so far in pytest tests/test_ge_utils.py, which is a v2 API reference. We won't fix this since the v2 API
     # code will be deleted soon.
-    'ignore: The Connection.connect\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The Connection.connect\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0.:DeprecationWarning',
     # Example Actual Warning: sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     # Found so far in test_cli_datasource_list
-    'ignore: Deprecated API features detected!:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: Deprecated API features detected!:DeprecationWarning',
     # Example Actual Warning: Found by running pytest tests/test_definitions/test_expectations_v2_api.py (delete with v2 api code if this warning doesn't appear elsewhere).
     # sqlalchemy.exc.RemovedIn20Warning: The Row.keys() method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. Use the namedtuple standard accessor Row._fields, or for full mapping behavior use  row._mapping.keys()  (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The Row.keys\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The Row.keys\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0.:DeprecationWarning',
     # Example Actual Warning: Found by running pytest tests/test_definitions/test_expectations_v2_api.py (delete with v2 api code if this warning doesn't appear elsewhere).
     # sqlalchemy.exc.RemovedIn20Warning: Using non-integer/slice indices on Row is deprecated and will be removed in version 2.0; please use row._mapping[<key>], or the mappings() accessor on the Result object. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: Using non-integer\/slice indices on Row is deprecated and will be removed in version 2.0:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: Using non-integer\/slice indices on Row is deprecated and will be removed in version 2.0:DeprecationWarning',
     # Example Actual Warning: Found by running setup of test_validate_dataset[sqlite]
     # sqlalchemy.exc.RemovedIn20Warning: The MetaData.bind argument is deprecated and will be removed in SQLAlchemy 2.0. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The MetaData.bind argument is deprecated and will be removed in SQLAlchemy 2.0.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The MetaData.bind argument is deprecated and will be removed in SQLAlchemy 2.0.:DeprecationWarning',
     # Example Actual Warning: Found in setup of test_database_evaluation_parameter_store_basics[param_store0-test_backends0]
     # sqlalchemy.exc.RemovedIn20Warning: The autoload parameter is deprecated and will be removed in version 2.0.  Please use the autoload_with parameter, passing an engine or connection. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The autoload parameter is deprecated and will be removed in version 2.0.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The autoload parameter is deprecated and will be removed in version 2.0.:DeprecationWarning',
     # Example Actual Warning: Found in test_sample_using_limit_builds_correct_query_where_clause_none[test_backends0-hive]
     # sqlalchemy.exc.RemovedIn20Warning: The `database` package is deprecated and will be removed in v2.0 of sqlalchemy. Use the `dialects` package instead. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The `database` package is deprecated and will be removed in v2.0 of sqlalchemy. Use the `dialects` package instead.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The `database` package is deprecated and will be removed in v2.0 of sqlalchemy. Use the `dialects` package instead.:DeprecationWarning',
     # Example Actual Warning: Found in mysql test_table_column_reflection_fallback[test_backends0]
     # sqlalchemy.exc.RemovedIn20Warning: The .close() method on a so-called 'branched' connection is deprecated as of 1.4, as are 'branched' connections overall, and will be removed in a future release.  If this is a default-handling function, don't close the connection. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The .close\(\) method on a so-called:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The .close\(\) method on a so-called:DeprecationWarning',
     # Example Actual Warning: Found in setup of test_validate_dataset[sqlite]
     # sqlalchemy.exc.RemovedIn20Warning: The ``bind`` argument for schema methods that invoke SQL against an engine or connection will be required in SQLAlchemy 2.0. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
-    'ignore: The ``bind`` argument for schema methods that invoke SQL against an engine or connection will be required in SQLAlchemy 2.0.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The ``bind`` argument for schema methods that invoke SQL against an engine or connection will be required in SQLAlchemy 2.0.:DeprecationWarning',
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]
 junit_family="xunit2"


### PR DESCRIPTION
Changes proposed in this pull request:
- Add tests against previously supported versions of SQLAlchemy to ensure compatibility with them as we make changes to support later versions.
- This PR adds testing for 1.4.x where x is latest for that minor version. It also currently only tests against postgresql. We can enhance / optimize this test but I would like to have something in place to make sure we retain compatibility with earlier versions as we are working on SQLAlchemy 2.0 compatibility.
- In preparation of v1.3.x compatibility, it also changes SQLAlchemy 2.0 warnings to `DeprecationWarning` (which is a parent class of `sqlalchemy.exc.RemovedIn20Warning`) since `sqlalchemy.exc.RemovedIn20Warning` only exists starting with v1.4.x. I think this may be good practice anyway so that warning ignores don't cause errors if run in an environment without the version of the library with the specific warning.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation