### PR TITLE
[DOCS] DOC-473 Adds guides on organizing Batches in Data Assets

### DIFF
--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
@@ -1,0 +1,194 @@
+---
+title: How to organize Batches in a file-based Data Asset
+tag: [how-to, connect to data]
+description: A technical guide demonstrating how to organize Batches of data in a file-based Data Asset.
+keywords: [Great Expectations, Data Asset, Batch Request, fluent configuration method, GCS, Google Cloud Server, AWS S3, Amazon Web Services S3, Azure Blob Storage, Local Filesystem]
+---
+
+import TechnicalTag from '/docs/term_tags/_tag.mdx';
+
+
+<!-- ## Introduction -->
+
+<!-- ## Prerequisites -->
+import Prerequisites from '/docs/components/_prerequisites.jsx'
+
+<!-- ### Import GX and instantiate a Data Context -->
+import ImportGxAndInstantiateADataContext from '/docs/components/setup/data_context/_import_gx_and_instantiate_a_data_context.md'
+
+<!-- ### 1. Create a `batching_regex` -->
+import TipFilesystemDatasourceNestedSourceDataFolders from '/docs/components/connect_to_data/filesystem/_tip_filesystem_datasource_nested_source_data_folders.md'
+
+<!-- ## Next steps -->
+import AfterCreateAndConfigureDataAsset from '/docs/components/connect_to_data/next_steps/_after_create_and_configure_data_asset.md'
+
+## Introduction
+
+In this guide we will demonstrate the ways in which Batches can be organized in a file-based Data Asset.  We will discuss how to use a regular expression to indicate which files should be returned as Batches.  We will also show how to add Batch Sorters to a Data Asset in order to specify the order in which Batches are returned.
+
+## Prerequisites
+
+<Prerequisites>
+
+- A working installation of Great Expectations
+- A Datasource that connects to a location with source data files
+- A passion for data quality
+
+</Prerequisites>
+
+<!--
+<details>
+<summary>
+
+### If you still need to set up and install GX...
+
+</summary>
+
+Please reference the appropriate one of these guides:
+- [How to install GX locally](/docs/guides/setup/installation/local.md)
+- [How to set up GX to work with data on AWS S3](/docs/guides/setup/optional_dependencies/cloud/how_to_set_up_gx_to_work_with_data_on_aws_s3.md)
+- [How to set up GX to work with data in Azure Blob Storage](/docs/guides/setup/optional_dependencies/cloud/how_to_set_up_gx_to_work_with_data_in_abs.md)
+- [How to set up GX to work with data on GCS](/docs/guides/setup/optional_dependencies/cloud/how_to_set_up_gx_to_work_with_data_on_gcs.md)
+
+</details>
+
+<details>
+<summary>
+
+### If you still need to connect a Datasource to the location of your source data files...
+
+</summary>
+
+Please reference the appropriate one of these guides:
+
+#### Local Filesystems
+- [How to connect to one or more files using Pandas](/docs/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.md)
+- [How to connect to one or more files using Spark](/docs/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.md)
+
+#### Google Cloud Server
+- [How to connect to data on GCS using Pandas](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_gcs_using_pandas.md)
+- [How to connect to data on GCS using Spark](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_gcs_using_spark.md)
+
+#### Azure Blob Storage
+- [How to connect to data in Azure Blob Storage using Pandas](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_azure_blob_storage_using_pandas.md)
+- [How to connect to data in Azure Blob Storage using Spark](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_azure_blob_storage_using_spark.md)
+
+#### Amazon Web Services S3
+- [How to connect to data on Amazon Web Services S3 using Pandas](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_s3_using_pandas.md)
+- [How to connect to data on Amazon Web Services S3 using Spark](/docs/guides/connecting_to_your_data/fluent/cloud/how_to_connect_to_data_on_s3_using_spark.md)
+
+</details> -->
+
+:::caution Datasources defined with the block-config method
+
+If you are using a Datasource that was created with the advanced block-config method please follow the appropriate guide from:
+- [how to configure a Spark Datasource with the block-config method](/docs/guides/connecting_to_your_data/datasource_configuration/how_to_configure_a_spark_datasource.md)
+- [how to configure a Pandas Datasource with the block-config method](/docs/guides/connecting_to_your_data/datasource_configuration/how_to_configure_a_pandas_datasource.md)
+
+:::
+
+## Steps
+
+### 1. Import GX and instantiate a Data Context
+
+<ImportGxAndInstantiateADataContext />
+
+### 1. Retrieve a file-based Datasource
+
+For this guide, we will use a previously defined Datasource named `"MyDatasource"`.  For purposes of our demonstration, this Datasource is a Pandas Filesystem Datasource that uses a folder named "data" as its `base_folder`.
+
+To retrieve this Datasource, we will supply the `get_datasource(...)` method of our Data Context with the name of the Datasource we wish to retrieve:
+
+```python title="Python code"
+my_datasource = context.get_datasource("MyDatasource")
+```
+
+### 1. Create a `batching_regex`
+
+In a file-based Data Asset, any file that matches a provided regular expression (the `batching_regex` parameter) will be included as a Batch in the Data Asset.  Therefore, to organize multiple files into Batches in a single Data Asset we must define a regular expression that will match one or more of our source data files.
+
+For this example, our Datasource points to a folder that contains the following files:
+- "taxi_data_2019.csv"
+- "taxi_data_2020.csv"
+- "taxi_data_2021.csv"
+
+To create a `batching_regex` that matches multiple files, we will include a named group in our regular expression:
+
+```python title="Python code"
+my_batching_regex = "taxi_data_(?P<year>\d{4})\.csv"
+```
+
+In the above example, the named group "`year`" will match any four numeric characters in a file name.  This will result in each of our source data files matching the regular expression.
+
+<!-- TODO
+:::tip Why use named groups?
+
+By naming the group in your `batching_regex` you make it something you can reference in the future.  When requesting data from this Data Asset, you can use the names of your regular expression groups to limit the Batches that are returned.
+
+For more information, please see: [How to request data from a Data Asset](/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md)
+
+:::
+-->
+
+<TipFilesystemDatasourceNestedSourceDataFolders />
+
+For more information on how to format regular expressions, we recommend referencing [Python's official how-to guide for working with regular expressions](https://docs.python.org/3/howto/regex.html).
+
+### 2. Add a Data Asset using the `batching_regex`
+
+Now that we have put together a regular expression that will match one or more of the files in our Datasource's `base_folder`, we can use it to create our Data Asset.  Since the files in this particular Datasource's `base_folder` are `.csv` files, we will use the `add_pandas_csv(...)` method of our Datasource to create the new Data Asset:
+
+```python title="Python code"
+my_asset = my_datasource.add_csv_asset(name="MyTaxiDataAsset", batching_regex=my_batching_regex)
+```
+
+:::tip What if I don't provide a `batching_regex`?
+
+If you choose to omit the `batching_regex` parameter, your Data Asset will automatically use the regular expression `".*"` to match all files.
+
+:::
+
+### 3. (Optional) Add Batch Sorters to the Data Asset
+
+We will now add a Batch Sorter to our Data Asset.  This will allow us to explicitly state the order in which our Batches are returned when we request data from the Data Asset.  To do this, we will pass a list of sorters to the `add_sorters(...)` method of our Data Asset.
+
+The items in our list of sorters will correspond to the names of the groups in our `batching_regex` that we want to sort our Batches on.  The names are prefixed with a `+` or a `-` depending on if we want to sort our Batches in ascending or descending order based on the given group.
+
+If there were multiple named groups we could include multiple items in our sorter list and our Batches would be returned in the order specified by the list: sorted first according to the first item, then the second, and so forth.
+
+However, in this example we only have one named group, `"year"`, so our list of sorters will only have one element.  We will add an ascending sorter based on the contents of the regex group `"year"`:
+
+```python title="Python code"
+my_asset.add_sorters(["+year"])
+```
+
+### 4. Use a Batch Request to verify the Data Asset works as desired
+
+To verify that our Data Asset will return the desired files as Batches, we will define a quick Batch Request that will include all the Batches available in the Data asset.  Then we will use that Batch Request to get a list of the returned Batches.
+
+```python title="Python code"
+my_batch_request = my_asset.my_asset.build_batch_request()
+batches = datasource.get_batch_list_from_batch_request(my_batch_request)
+```
+
+Because a Batch List contains a lot of metadata, it will be easiest to verify which files were included in the returned Batches if we only look at the `batch_spec` of each returned Batch:
+
+```python title="Python code"
+for batch in batches:
+    print(batch.batch_spec)
+```
+
+<!-- ## Next steps
+
+Now that you have further configured a file-based Data Asset, you may want to look into:
+
+ ### Requesting Data from a Data Asset
+ - [How to request data from a Data Asset](/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md)
+ 
+ ### Using Data Assets to create Expectations
+ - [Use a Data Asset to create Expectations while interactively evaluating a set of data](/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md)
+ - [Use the Onboarding Data Assistant to evaluate one or more Batches of data and create Expectations](/docs/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant.md) -->
+
+
+
+

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -93,10 +93,11 @@ To retrieve this Datasource, we will supply the `get_datasource(...)` method of 
 ```python title="Python code"
 my_datasource = context.get_datasource("my_datasource")
 my_asset = my_datasource.get_asset("my_asset")
+```
 
 ### 2. Add a Splitter to the Data Asset
 
-Our table has a datetime column called "`pickup_datetime`" which we will use to split our TableAsset into Batches.
+Our table has a datetime column called "`pickup_datetime`" which we will use to split our Table Data Asset into Batches.
 
 ```python title="Python code"
 table_asset.add_year_and_month_splitter(column_name="pickup_datetime")
@@ -130,11 +131,11 @@ for batch in batches:
     print(batch.batch_spec)
 ```
 
-## Next steps
+<!-- ## Next steps
 
 Now that you have further configured a Data Asset, you may want to look into:
 
-<!-- ### Requesting Data from a Data Asset
+### Requesting Data from a Data Asset
  - [How to request data from a Data Asset](/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md)
  
  ### Using Data Assets to create Expectations

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -1,0 +1,142 @@
+---
+title: How to organize Batches in a SQL-based Data Asset
+tag: [how-to, connect to data]
+description: A technical guide demonstrating how to split the data returned by a SQL Data Asset into multiple Batches and explicitly sort those Batches.
+keywords: [Great Expectations, Data Asset, Batch Request, fluent configuration method, SQL]
+---
+
+import TechnicalTag from '/docs/term_tags/_tag.mdx';
+
+
+<!-- ## Introduction -->
+
+<!-- ## Prerequisites -->
+import Prerequisites from '/docs/components/_prerequisites.jsx'
+import SetupAndInstallForSqlData from '/docs/components/setup/link_lists/_setup_and_install_for_sql_data.md'
+import ConnectingToSqlDatasourcesFluently from '/docs/components/connect_to_data/link_lists/_connecting_to_sql_datasources_fluently.md'
+import ConnectingToSqlDatasourcesBlockConfig from '/docs/components/connect_to_data/link_lists/_connecting_to_sql_datasources_block_config.md'
+
+<!-- ### Import GX and instantiate a Data Context -->
+import ImportGxAndInstantiateADataContext from '/docs/components/setup/data_context/_import_gx_and_instantiate_a_data_context.md'
+
+<!-- ### 1. Create a `batching_regex` -->
+import TipFilesystemDatasourceNestedSourceDataFolders from '/docs/components/connect_to_data/filesystem/_tip_filesystem_datasource_nested_source_data_folders.md'
+
+<!-- ## Next steps -->
+import AfterCreateAndConfigureDataAsset from '/docs/components/connect_to_data/next_steps/_after_create_and_configure_data_asset.md'
+
+## Introduction
+
+In this guide we will demonstrate the ways in which Batches can be organized in a SQL-based Data Asset.  We will discuss how to use Splitters to divide the data in a table or query based on the contents of a provided field.  We will also show how to add Batch Sorters to a Data Asset in order to specify the order in which Batches are returned.
+
+## Prerequisites
+
+<Prerequisites>
+
+- A working installation of Great Expectations
+- A Data Asset in a SQL-based Datasource
+- A passion for data quality
+
+</Prerequisites>
+
+
+<!-- TODO <details>
+<summary>
+
+### If you still need to set up and install GX...
+
+</summary>
+
+Please reference the appropriate one of these guides:
+
+<SetupAndInstallForSqlData />
+
+</details>
+
+<details>
+<summary>
+
+### If you still need to connect a Datasource to a SQL database...
+
+</summary>
+
+Please reference the appropriate one of these guides:
+
+<ConnectingToSqlDatasourcesFluently />
+
+Or, for guides on using the block-config method for advanced SQL Datasource configurations, please see:
+
+<ConnectingToSqlDatasourcesBlockConfig />
+
+
+</details>
+-->
+
+:::caution Datasources defined with the block-config method
+
+If you are using a Datasource that was created with the advanced block-config method please follow our guide on [how to configure a SQL Datasource with the block-config method](/docs/guides/connecting_to_your_data/datasource_configuration/how_to_configure_a_sql_datasource.md), instead.
+
+:::
+
+## Steps
+
+### 1. Import GX and instantiate a Data Context
+
+<ImportGxAndInstantiateADataContext />
+
+### 1. Retrieve a SQL Datasource and Data Asset
+
+For this guide, we will use a previously defined Datasource named `"MyDatasource"`.  For purposes of our demonstration, this Datasource is a Pandas Filesystem Datasource that uses a folder named "data" as its `base_folder`.
+
+To retrieve this Datasource, we will supply the `get_datasource(...)` method of our Data Context with the name of the Datasource we wish to retrieve:
+
+```python title="Python code"
+my_datasource = context.get_datasource("MyDatasource")
+```
+
+### 2. Add a Splitter to the Data Asset
+
+```python title="Python code"
+table_asset.add_year_and_month_splitter(column_name="pickup_datetime")
+```
+
+### 3. (Optional) Add Batch Sorters to the Data Asset
+
+We will now add a Batch Sorter to our Data Asset.  This will allow us to explicitly state the order in which our Batches are returned when we request data from the Data Asset.  To do this, we will pass a list of sorters to the `add_sorters(...)` method of our Data Asset.
+
+The items in our list of sorters will correspond to the names of the groups in our `batching_regex` that we want to sort our Batches on.  The names are prefixed with a `+` or a `-` depending on if we want to sort our Batches in ascending or descending order based on the given group.
+
+If there were multiple named groups we could include multiple items in our sorter list and our Batches would be returned in the order specified by the list: sorted first according to the first item, then the second, and so forth.
+
+However, in this example we only have one named group, `"year"`, so our list of sorters will only have one element.  We will add an ascending sorter based on the contents of the regex group `"year"`:
+
+```python title="Python code"
+my_asset.add_sorters(["+year"])
+```
+
+### 4. Use a Batch Request to verify the Data Asset works as desired
+
+To verify that our Data Asset will return the desired files as Batches, we will define a quick Batch Request that will include all the Batches available in the Data asset.  Then we will use that Batch Request to get a list of the returned Batches.
+
+```python title="Python code"
+my_batch_request = my_asset.my_asset.build_batch_request()
+batches = datasource.get_batch_list_from_batch_request(my_batch_request)
+```
+
+Because a Batch List contains a lot of metadata, it will be easiest to verify which files were included in the returned Batches if we only look at the `batch_spec` of each returned Batch:
+
+```python title="Python code"
+for batch in batches:
+    print(batch.batch_spec)
+```
+
+## Next steps
+
+Now that you have further configured a Data Asset, you may want to look into:
+
+<!-- ### Requesting Data from a Data Asset
+ - [How to request data from a Data Asset](/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md)
+ 
+ ### Using Data Assets to create Expectations
+ - [Use a Data Asset to create Expectations while interactively evaluating a set of data](/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md)
+ - [Use the Onboarding Data Assistant to evaluate one or more Batches of data and create Expectations](/docs/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant.md) -->

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -96,10 +96,10 @@ my_asset = my_datasource.get_asset("my_asset")
 
 ### 2. Add a Splitter to the Data Asset
 
+Our table has a datetime column called "`pickup_datetime`" which we will use to split our TableAsset into Batches.
+
 ```python title="Python code"
 table_asset.add_year_and_month_splitter(column_name="pickup_datetime")
-```
-
 ### 3. (Optional) Add Batch Sorters to the Data Asset
 
 We will now add a Batch Sorter to our Data Asset.  This will allow us to explicitly state the order in which our Batches are returned when we request data from the Data Asset.  To do this, we will pass a list of sorters to the `add_sorters(...)` method of our Data Asset.

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -91,8 +91,8 @@ For this guide, we will use a previously defined SQL Datasource named `"my_datas
 To retrieve this Datasource, we will supply the `get_datasource(...)` method of our Data Context with the name of the Datasource we wish to retrieve:
 
 ```python title="Python code"
-my_datasource = context.get_datasource("MyDatasource")
-```
+my_datasource = context.get_datasource("my_datasource")
+my_asset = my_datasource.get_asset("my_asset")
 
 ### 2. Add a Splitter to the Data Asset
 

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -86,7 +86,7 @@ If you are using a Datasource that was created with the advanced block-config me
 
 ### 1. Retrieve a SQL Datasource and Data Asset
 
-For this guide, we will use a previously defined Datasource named `"MyDatasource"`.  For purposes of our demonstration, this Datasource is a Pandas Filesystem Datasource that uses a folder named "data" as its `base_folder`.
+For this guide, we will use a previously defined SQL Datasource named `"my_datasource"` with a TableAsset called `"my_asset"` which points to a table with taxi data. 
 
 To retrieve this Datasource, we will supply the `get_datasource(...)` method of our Data Context with the name of the Datasource we wish to retrieve:
 


### PR DESCRIPTION
Changes proposed in this pull request:
- adds guide "How to organize Batches in a file-based Data Asset"
- adds guide "How to organize Batches in a SQL-based Data Asset"

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.
