### PR TITLE
[MAINTENANCE] Bump SQLAlchemy lower bound to 1.4.0

### DIFF
--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -17,4 +17,4 @@ pytest-timeout>=2.1.0
 requirements-parser>=0.2.0
 s3fs>=0.5.1
 snapshottest==0.6.0 # GX Cloud atomic renderer tests
-sqlalchemy>=1.3.18,<2.0.0
+sqlalchemy>=1.4.0,<2.0.0


### PR DESCRIPTION
Changes proposed in this pull request:
- Bump SQLAlchemy lower bound to 1.4.0 since 1.3.x is EOL (https://www.sqlalchemy.org/download.html)

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code