### PR TITLE
[MAINTENANCE] Convert to python built in warning categories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,36 +430,36 @@ filterwarnings = [
     # pytest
     # Example Actual Warning:
     # pytest.PytestCollectionWarning: cannot collect test class 'TestConnectionError' because it has a __init__ constructor (from: tests/datasource/fluent/test_pandas_azure_blob_storage_datasource.py)
-    "ignore: cannot collect test class 'TestConnectionError' because it has a __init__ constructor:pytest.PytestCollectionWarning",
+    "ignore: cannot collect test class 'TestConnectionError' because it has a __init__ constructor:UserWarning",
     # Example Actual Warning:
     # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
-    "ignore: Exception ignored in:pytest.PytestUnraisableExceptionWarning",
+    "ignore: Exception ignored in:UserWarning",
 
     # SQLAlchemy
     # SQLAlchemy warnings. These warnings should be addressed.
-    'ignore: Implicit coercion of SELECT and textual SELECT constructs into FROM clauses is deprecated; please call .subquery\(\) on any Core select or ORM Query object in order to produce a subquery object.:sqlalchemy.exc.SADeprecationWarning',
+    'ignore: Implicit coercion of SELECT and textual SELECT constructs into FROM clauses is deprecated; please call .subquery\(\) on any Core select or ORM Query object in order to produce a subquery object.:DeprecationWarning',
     # Example Actual Warning: (from test_table_column_reflection_fallback)
     # sqlalchemy.exc.SADeprecationWarning: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.  Please execute the underlying select() statement directly.
-    'ignore: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.  Please execute the underlying select() statement directly.:sqlalchemy.exc.SADeprecationWarning',
+    'ignore: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.  Please execute the underlying select() statement directly.:DeprecationWarning',
     # Example Actual Warning: (from mssql tests, tests/test_definitions/test_expectations_v2_api.py)
     # sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "UnexpectedCountSubquery" and FROM element "ElementAndNullCountsSubquery".  Apply join condition(s) between each element to resolve.
-    'ignore: SELECT statement has a cartesian product between FROM element\(s\):sqlalchemy.exc.SAWarning',
+    'ignore: SELECT statement has a cartesian product between FROM element\(s\):RuntimeWarning',
     # Example Actual Warning: (from trino tests, test_table_column_reflection_fallback)
     # sqlalchemy.exc.SADeprecationWarning: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.  Please execute the underlying select() statement directly.
-    'ignore: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.:sqlalchemy.exc.SADeprecationWarning',
+    'ignore: Executing a subquery object is deprecated and will raise ObjectNotExecutableError in an upcoming release.:DeprecationWarning',
     # Example Actual Warning: Found by running pytest tests/datasource/fluent/integration/test_integration_datasource.py (with SA-backed fluent datasources).
     # sqlalchemy.exc.SADeprecationWarning: The Engine.run_callable() method is deprecated and will be removed in a future release.  Use the Engine.begin() context manager instead. (deprecated since: 1.4)
-    'ignore: The Engine.run_callable\(\) method is deprecated and will be removed in a future release:sqlalchemy.exc.SADeprecationWarning',
+    'ignore: The Engine.run_callable\(\) method is deprecated and will be removed in a future release:DeprecationWarning',
     # Example Actual Warning: (tests/datasource/fluent/integration/conftest.py)
     # sqlalchemy.exc.SADeprecationWarning: Table.tometadata() is renamed to Table.to_metadata() (deprecated since: 1.4)
-    'ignore: Table.tometadata\(\) is renamed to Table.to_metadata\(\):sqlalchemy.exc.SADeprecationWarning',
+    'ignore: Table.tometadata\(\) is renamed to Table.to_metadata\(\):DeprecationWarning',
 
     # SQLAlchemy 2.x support warnings. These warnings should be ignored until sqlalchemy 2.x is fully supported.
     # To get SQLAlchemy 2.x supported, remove one of these ignores and then fix the resulting errors.
-    'ignore: The legacy calling style of select\(\) is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select\(\).:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The current statement is being autocommitted using implicit autocommit, which will be removed in SQLAlchemy 2.0. Use the .begin\(\) method of Engine or Connection in order to use an explicit transaction for DML and DDL statements.:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The "whens" argument to case\(\), when referring to a sequence of items, is now passed as a series of positional elements, rather than as a list.:sqlalchemy.exc.RemovedIn20Warning',
-    'ignore: The Engine.execute\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. All statement execution in SQLAlchemy 2.0 is performed by the Connection.execute\(\) method of Connection, or in the ORM by the Session.execute\(\) method of Session.:sqlalchemy.exc.RemovedIn20Warning',
+    'ignore: The legacy calling style of select\(\) is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select\(\).:DeprecationWarning',
+    'ignore: The current statement is being autocommitted using implicit autocommit, which will be removed in SQLAlchemy 2.0. Use the .begin\(\) method of Engine or Connection in order to use an explicit transaction for DML and DDL statements.:DeprecationWarning',
+    'ignore: The "whens" argument to case\(\), when referring to a sequence of items, is now passed as a series of positional elements, rather than as a list.:DeprecationWarning',
+    'ignore: The Engine.execute\(\) method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. All statement execution in SQLAlchemy 2.0 is performed by the Connection.execute\(\) method of Connection, or in the ORM by the Session.execute\(\) method of Session.:DeprecationWarning',
     # Error with link to docs: sqlalchemy.exc.RemovedIn20Warning: The Connection.connect() method is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
     # Found so far in pytest tests/test_ge_utils.py, which is a v2 API reference. We won't fix this since the v2 API
     # code will be deleted soon.


### PR DESCRIPTION
Changes proposed in this pull request:
- We should use the built in warning that is the parent class of any library specific warning. This ensures that we won't run into issues with optional packages not having been installed. Please keep the original warning in an explanatory comment so it is easier to look up, but in the actual ignore statement use one of the built in warning categories: https://docs.python.org/3/library/warnings.html#warning-categories

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code