### PR TITLE
[DOCS] Put data_context.md code examples under test

### DIFF
--- a/docs/docusaurus/docs/terms/data_context.md
+++ b/docs/docusaurus/docs/terms/data_context.md
@@ -80,24 +80,15 @@ Because your Data Context contains the entirety of your Great Expectations proje
 
 As a Great Expectations user, once you have created a Data Context, you will almost always start future work either by using <TechnicalTag relative="../" tag="cli" text="CLI" /> commands from your Data Context's root folder, or by instantiating a `DataContext` in Python:
 
-```python title="Python code"
-import great_expectations as gx
-context = gx.get_context()
+```python title="Import Great Expectations" name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py import gx"
 ```
 
-Alternatively, you might call:
-
-```python title="Python code"
-import great_expectations as gx
-context = gx.get_context(filepath=”something”)
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py get_context"
 ```
 
-If you’re using Great Expectations Cloud, you’d call:
+Alternatively, you can use the `context_root_dir` parameter if you want to specify a specific directory
 
-```python title="Python code"
-import great_expectations as gx
-context = gx.get_context(API_KEY=”something”)
-```
+If you’re using Great Expectations Cloud, you’d set up cloud environment variables before calling `get_context`.
 
 That’s it! You now have access to all the goodness of a DataContext.
 
@@ -113,26 +104,10 @@ Expectations) are the only ones you'll need.
 
 Here's a typical example:
 
-```python title="Python code"
-config = """
-class_name: Datasource
-execution_engine:
-    class_name: PandasExecutionEngine
-data_connectors:
-    my_data_connector:
-        class_name: InferredAssetFilesystemDataConnector
-        base_directory: {data_base_directory}
-        glob_directive: "*/*.csv"
-        default_regex:
-            pattern: (.+)/(.+)\\.csv
-            group_names:
-                - data_asset_name
-                - partition
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py yaml"
+```
 
-"""
-my_context.test_yaml_config(
-    config=config
-)
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py test_yaml_config"
 ```
 
 Running `test_yaml_config()` will show some feedback on the configuration. The helpful output can include any result 
@@ -146,30 +121,21 @@ For more detailed guidance on using the `test_yaml_config()` method, please see 
 
 #### Untyped inputs
 
-The code standards for Great Expectations strive for strongly typed inputs.  However, the Data Context's convenience functions are a noted exception to this standard.  For example, to get a Batch with typed input, you would call:
+The code standards for Great Expectations strive for strongly typed inputs.  However, the Data Context's convenience functions are a noted exception to this standard.  For example, to get a Batch with typed input, you could follow these steps:
 
-```python title="Python code"
-from great_expectations.core.batch import BatchRequest
 
-batch_request = BatchRequest(
-    datasource_name="my_azure_datasource",
-    data_connector_name="default_inferred_data_connector_name",
-    data_asset_name="<YOUR_DATA_ASSET_NAME>",
-)
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py import BatchRequest"
+```
 
-context.get_batch(
-    batch_request=batch_request
-)
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with batch request"
 ```
 
 However, we can take some of the friction out of that process by allowing untyped inputs:
 
-```python title="Python code"
-context.get_batch(
-    datasource_name="my_azure_datasource",
-    data_connector_name="default_inferred_data_connector_name",
-    data_asset_name="<YOUR_DATA_ASSET_NAME>",
-)
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with parameters data_asset_name"
+```
+
+```python name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with parameters"
 ```
 
 In this example, the `get_batch()` method takes on the responsibility for inferring your intended types, and passing it through to the correct internal methods.

--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -1477,6 +1477,30 @@ class CodeReferenceFilter:
             name="get_available_data_asset_names",
             filepath=pathlib.Path("great_expectations/datasource/datasource.py"),
         ),
+        IncludeExcludeDefinition(
+            reason="LegacyDatasource is not included in the public API",
+            name="get_batch",
+            filepath=pathlib.Path(
+                "great_expectations/datasource/sqlalchemy_datasource.py"
+            ),
+        ),
+        IncludeExcludeDefinition(
+            reason="LegacyDatasource is not included in the public API",
+            name="get_batch",
+            filepath=pathlib.Path(
+                "great_expectations/datasource/sparkdf_datasource.py"
+            ),
+        ),
+        IncludeExcludeDefinition(
+            reason="LegacyDatasource is not included in the public API",
+            name="get_batch",
+            filepath=pathlib.Path("great_expectations/datasource/pandas_datasource.py"),
+        ),
+        IncludeExcludeDefinition(
+            reason="LegacyDatasource is not included in the public API",
+            name="get_batch",
+            filepath=pathlib.Path("great_expectations/datasource/datasource.py"),
+        ),
     ]
 
     def __init__(

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1025,16 +1025,24 @@ class AbstractDataContext(ConfigPeer, ABC):
             config = self._project_config
         return DataContextConfig(**self.config_provider.substitute_config(config))
 
+    @public_api
     def get_batch(
         self, arg1: Any = None, arg2: Any = None, arg3: Any = None, **kwargs
     ) -> Union[Batch, DataAsset]:
         """Get exactly one batch, based on a variety of flexible input types.
+
         The method `get_batch` is the main user-facing method for getting batches; it supports both the new (V3) and the
         Legacy (V2) Datasource schemas.  The version-specific implementations are contained in "_get_batch_v2()" and
         "_get_batch_v3()", respectively, both of which are in the present module.
 
         For the V3 API parameters, please refer to the signature and parameter description of method "_get_batch_v3()".
         For the Legacy usage, please refer to the signature and parameter description of the method "_get_batch_v2()".
+
+        Processing Steps:
+            1. Determine the version (possible values are "v3" or "v2").
+            2. Convert the positional arguments to the appropriate named arguments, based on the version.
+            3. Package the remaining arguments as variable keyword arguments (applies only to V3).
+            4. Call the version-specific method ("_get_batch_v3()" or "_get_batch_v2()") with the appropriate arguments.
 
         Args:
             arg1: the first positional argument (can take on various types)
@@ -1045,12 +1053,6 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         Returns:
             Batch (V3) or DataAsset (V2) -- the requested batch
-
-        Processing Steps:
-        1. Determine the version (possible values are "v3" or "v2").
-        2. Convert the positional arguments to the appropriate named arguments, based on the version.
-        3. Package the remaining arguments as variable keyword arguments (applies only to V3).
-        4. Call the version-specific method ("_get_batch_v3()" or "_get_batch_v2()") with the appropriate arguments.
         """
 
         api_version: Optional[str] = self._get_data_context_version(arg1=arg1, **kwargs)

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
@@ -1,5 +1,7 @@
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py imports">
-from ruamel import yaml
+from great_expectations.core.yaml_handler import YAMLHandler
+
+yaml: YAMLHandler = YAMLHandler()
 
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py import gx">
 import great_expectations as gx

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
@@ -1,9 +1,14 @@
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py imports">
 from ruamel import yaml
 
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py import gx">
 import great_expectations as gx
+
+# </snippet>
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py import BatchRequest">
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
 
+# </snippet>
 # </snippet>
 
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py get_context">
@@ -82,6 +87,28 @@ batch_request = BatchRequest(
 # Please note this override is only to provide good UX for docs and tests.
 # In normal usage you'd set your data asset name directly in the BatchRequest above.
 batch_request.data_asset_name = "yellow_tripdata_sample_2019-01.csv"
+
+# Example using batch request to get a batch:
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with batch request">
+batch = context.get_batch(batch_request=batch_request)
+# </snippet>
+
+# Example using parameters to get a batch:
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with parameters data_asset_name">
+data_asset_name = "<YOUR_DATA_ASSET_NAME>"
+# </snippet>
+
+# Please note this override is only to provide good UX for docs and tests.
+# In normal usage you'd set your data asset name directly in the get_batch call below
+data_asset_name = "yellow_tripdata_sample_2019-01.csv"
+
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py context.get_batch with parameters">
+context.get_batch(
+    datasource_name="taxi_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name=data_asset_name,
+)
+# </snippet>
 
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py batch_request validator">
 context.add_or_update_expectation_suite(expectation_suite_name="test_suite")


### PR DESCRIPTION
Changes proposed in this pull request:
- Use and modify some existing code under test as examples for `data_context.md`
- Cloud docs will be developed separately, so do not place creating a cloud context under test in this doc at this time.
- Closes https://github.com/great-expectations/great_expectations/pull/5940

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.