### PR TITLE
[MAINTENANCE] PandasFilesystemDatasource stubs and Schema corrections

### DIFF
--- a/great_expectations/datasource/fluent/constants.py
+++ b/great_expectations/datasource/fluent/constants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from typing_extensions import Final
 
 # these fields must be added to `__fields_set__` before pydantic model serialization
@@ -12,3 +14,5 @@ _FIELDS_ALWAYS_SET: Final[set[str]] = {
 _ASSETS_KEY: Final[str] = "assets"
 
 _DATA_CONNECTOR_NAME: Final[str] = "fluent"
+
+MATCH_ALL_PATTERN: Final[re.Pattern] = re.compile(".*")

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -20,6 +20,7 @@ from typing import (
 import pydantic
 
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FILE_PATH_BATCH_SPEC_KEY,
 )
@@ -59,7 +60,7 @@ class _FilePathDataAsset(DataAsset):
     }
 
     # General file-path DataAsset pertaining attributes.
-    batching_regex: Pattern
+    batching_regex: Pattern = MATCH_ALL_PATTERN
 
     _unnamed_regex_param_prefix: str = pydantic.PrivateAttr(
         default="batch_request_param_"

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -30,6 +30,9 @@ from pydantic import dataclasses as pydantic_dc
 from typing_extensions import TypeAlias, TypeGuard
 
 from great_expectations.core.id_dict import BatchSpec  # noqa: TCH001
+from great_expectations.datasource.fluent.constants import (
+    MATCH_ALL_PATTERN,
+)
 from great_expectations.datasource.fluent.fluent_base_model import (
     FluentBaseModel,
 )
@@ -508,7 +511,7 @@ class Datasource(
     ) -> re.Pattern:
         pattern: re.Pattern
         if not batching_regex:
-            pattern = re.compile(".*")
+            pattern = MATCH_ALL_PATTERN
         elif isinstance(batching_regex, str):
             pattern = re.compile(batching_regex)
         elif isinstance(batching_regex, re.Pattern):

--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.pyi
@@ -49,6 +49,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_csv_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -106,6 +107,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_excel_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -136,8 +138,10 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_feather_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         columns: Union[Sequence[Hashable], None] = ...,
         use_threads: bool = ...,
         storage_options: StorageOptions = ...,
@@ -145,8 +149,10 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_hdf_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         key: typing.Any = ...,
         mode: str = "r",
         errors: str = "strict",
@@ -161,8 +167,10 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_html_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         match: Union[str, typing.Pattern] = ".+",
         flavor: typing.Union[str, None] = ...,
         header: Union[int, Sequence[int], None] = ...,
@@ -181,6 +189,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_json_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -203,14 +212,17 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_orc_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         columns: typing.Union[typing.List[str], None] = ...,
         kwargs: typing.Union[dict, None] = ...,
     ) -> ORCAsset: ...
     def add_parquet_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -223,16 +235,20 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_pickle_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         compression: CompressionOptions = "infer",
         storage_options: StorageOptions = ...,
     ) -> PickleAsset: ...
     def add_sas_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         format: typing.Union[str, None] = ...,
         index: Union[Hashable, None] = ...,
         encoding: typing.Union[str, None] = ...,
@@ -243,16 +259,20 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_spss_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         usecols: typing.Union[int, str, typing.Sequence[int], None] = ...,
         convert_categoricals: bool = ...,
     ) -> SPSSAsset: ...
     def add_stata_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         convert_dates: bool = ...,
         convert_categoricals: bool = ...,
         index_col: typing.Union[str, None] = ...,
@@ -268,8 +288,10 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
     def add_xml_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         xpath: str = "./*",
         namespaces: typing.Union[typing.Dict[str, str], None] = ...,
         elems_only: bool = ...,

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.pyi
@@ -52,6 +52,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_csv_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -109,6 +110,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_excel_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -139,8 +141,10 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_feather_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         columns: Union[Sequence[Hashable], None] = ...,
         use_threads: bool = ...,
         storage_options: StorageOptions = ...,
@@ -148,8 +152,10 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_hdf_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         key: typing.Any = ...,
         mode: str = "r",
         errors: str = "strict",
@@ -164,8 +170,10 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_html_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         match: Union[str, typing.Pattern] = ".+",
         flavor: typing.Union[str, None] = ...,
         header: Union[int, Sequence[int], None] = ...,
@@ -184,6 +192,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_json_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -206,14 +215,17 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_orc_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         columns: typing.Union[typing.List[str], None] = ...,
         kwargs: typing.Union[dict, None] = ...,
     ) -> ORCAsset: ...
     def add_parquet_asset(
         self,
         name: str,
+        *,
         batching_regex: Optional[Union[str, re.Pattern]] = ...,
         glob_directive: str = ...,
         order_by: Optional[SortersDefinition] = ...,
@@ -226,16 +238,20 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_pickle_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         compression: CompressionOptions = "infer",
         storage_options: StorageOptions = ...,
     ) -> PickleAsset: ...
     def add_sas_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         format: typing.Union[str, None] = ...,
         index: Union[Hashable, None] = ...,
         encoding: typing.Union[str, None] = ...,
@@ -246,16 +262,20 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_spss_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         usecols: typing.Union[int, str, typing.Sequence[int], None] = ...,
         convert_categoricals: bool = ...,
     ) -> SPSSAsset: ...
     def add_stata_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         convert_dates: bool = ...,
         convert_categoricals: bool = ...,
         index_col: typing.Union[str, None] = ...,
@@ -271,8 +291,10 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
     def add_xml_asset(
         self,
         name: str,
+        *,
         order_by: typing.List[Sorter] = ...,
         batching_regex: typing.Pattern = ...,
+        glob_directive: str = ...,
         xpath: str = "./*",
         namespaces: typing.Union[typing.Dict[str, str], None] = ...,
         elems_only: bool = ...,

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
@@ -86,14 +86,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -245,8 +246,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -146,8 +147,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -75,8 +76,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -137,8 +138,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -117,8 +118,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -51,8 +52,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/STATAAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/STATAAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -105,8 +106,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -101,8 +102,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
@@ -92,14 +92,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -245,8 +246,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -146,8 +147,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -75,8 +76,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -137,8 +138,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -117,8 +118,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -51,8 +52,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/STATAAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/STATAAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -105,8 +106,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -101,8 +102,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -92,14 +92,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -245,8 +246,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -146,8 +147,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -75,8 +76,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -137,8 +138,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -117,8 +118,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -51,8 +52,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/STATAAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/STATAAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -105,8 +106,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -101,8 +102,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
@@ -101,14 +101,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -245,8 +246,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -146,8 +147,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -75,8 +76,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -137,8 +138,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -117,8 +118,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -51,8 +52,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/STATAAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/STATAAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -105,8 +106,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -101,8 +102,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
@@ -101,14 +101,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -245,8 +246,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -146,8 +147,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -75,8 +76,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -137,8 +138,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -117,8 +118,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -47,8 +48,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -51,8 +52,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -57,8 +58,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/STATAAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/STATAAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -105,8 +106,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
@@ -30,6 +30,7 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         },
@@ -101,8 +102,7 @@
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -86,14 +86,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
@@ -30,13 +30,13 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "definitions": {
         "Sorter": {

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -92,14 +92,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
@@ -30,13 +30,13 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "definitions": {
         "Sorter": {

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -92,14 +92,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
@@ -30,13 +30,13 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "definitions": {
         "Sorter": {

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -101,14 +101,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
@@ -30,13 +30,13 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "definitions": {
         "Sorter": {

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -101,14 +101,14 @@
                 },
                 "batching_regex": {
                     "title": "Batching Regex",
+                    "default": ".*",
                     "type": "string",
                     "format": "regex"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "batching_regex"
+                "type"
             ]
         }
     }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
@@ -30,13 +30,13 @@
         },
         "batching_regex": {
             "title": "Batching Regex",
+            "default": ".*",
             "type": "string",
             "format": "regex"
         }
     },
     "required": [
-        "name",
-        "batching_regex"
+        "name"
     ],
     "definitions": {
         "Sorter": {


### PR DESCRIPTION
## Changes proposed in this pull request:
- fix [pandas_filesystem_datasource.pyi](https://github.com/great-expectations/great_expectations/pull/7428/files#diff-2736a0c1973043209b36d496980cc43570b465ea95d7b2eff44887b5570dc055), `pandas_dbfs` stubs
  - all methods should have a `glob_directive` keyword argument
  - add `*` keyword-only symbol to reflect that `name` is the only value that be passed positionally. 
     - https://peps.python.org/pep-3102/ 
- use a `MATCH_ALL_PATTERN` constant for `".*"` regex
- Formally give `batching_regex` a default value so that our schemas reflect the current behavior
  - re-generate schemas via `invoke schema --sync`


### Notes

Breaking this PR up from our DataSource abstraction update to lessen the scope.
 - #7414 
 - Note these changes will still be correct even if the above PR is not accepted.

The stubs and schema updates could be 2 separate PRs as they aren't directly connected.
