### PR TITLE
[MAINTENANCE] Some fluent datasource methods should be private

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -462,7 +462,7 @@ class Datasource(
                 f"'{asset_name}' not found. Available assets are {list(self.assets.keys())}"
             ) from exc
 
-    def add_asset(self, asset: _DataAssetT) -> _DataAssetT:
+    def _add_asset(self, asset: _DataAssetT) -> _DataAssetT:
         """Adds an asset to a datasource
 
         Args:

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -176,7 +176,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_excel_asset(
         self,
@@ -232,7 +232,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_json_asset(
         self,
@@ -288,7 +288,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_parquet_asset(
         self,
@@ -342,7 +342,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     # attr-defined issue
     # https://github.com/python/mypy/issues/12472

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -512,7 +512,7 @@ class PandasDatasource(_PandasDatasource):
             name=name,
             dataframe=dataframe,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_dataframe(
         self, dataframe: pd.DataFrame, asset_name: Optional[str] = None
@@ -529,7 +529,7 @@ class PandasDatasource(_PandasDatasource):
             name=name,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_clipboard(self, asset_name: Optional[str] = None, **kwargs) -> Validator:
         if not asset_name:
@@ -548,7 +548,7 @@ class PandasDatasource(_PandasDatasource):
             filepath_or_buffer=filepath_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_csv(
         self,
@@ -573,7 +573,7 @@ class PandasDatasource(_PandasDatasource):
             io=io,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_excel(
         self,
@@ -598,7 +598,7 @@ class PandasDatasource(_PandasDatasource):
             path=path,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_feather(
         self,
@@ -623,7 +623,7 @@ class PandasDatasource(_PandasDatasource):
             query=query,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_gbq(
         self,
@@ -648,7 +648,7 @@ class PandasDatasource(_PandasDatasource):
             path_or_buf=path_or_buf,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_hdf(
         self,
@@ -673,7 +673,7 @@ class PandasDatasource(_PandasDatasource):
             io=io,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_html(
         self,
@@ -701,7 +701,7 @@ class PandasDatasource(_PandasDatasource):
             path_or_buf=path_or_buf,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_json(
         self,
@@ -726,7 +726,7 @@ class PandasDatasource(_PandasDatasource):
             path=path,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_orc(
         self,
@@ -751,7 +751,7 @@ class PandasDatasource(_PandasDatasource):
             path=path,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_parquet(
         self,
@@ -779,7 +779,7 @@ class PandasDatasource(_PandasDatasource):
             filepath_or_buffer=filepath_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_pickle(
         self,
@@ -807,7 +807,7 @@ class PandasDatasource(_PandasDatasource):
             filepath_or_buffer=filepath_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_sas(
         self,
@@ -832,7 +832,7 @@ class PandasDatasource(_PandasDatasource):
             path=path,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_spss(
         self,
@@ -862,7 +862,7 @@ class PandasDatasource(_PandasDatasource):
             con=con,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_sql(
         self,
@@ -894,7 +894,7 @@ class PandasDatasource(_PandasDatasource):
             con=con,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_sql_query(
         self,
@@ -922,7 +922,7 @@ class PandasDatasource(_PandasDatasource):
             con=con,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_sql_table(
         self,
@@ -952,7 +952,7 @@ class PandasDatasource(_PandasDatasource):
             filepath_or_buffer=filepath_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_stata(
         self,
@@ -980,7 +980,7 @@ class PandasDatasource(_PandasDatasource):
             filepath_or_buffer=filepath_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_table(
         self,
@@ -1005,7 +1005,7 @@ class PandasDatasource(_PandasDatasource):
             path_or_buffer=path_or_buffer,
             **kwargs,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def read_xml(
         self,

--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
@@ -81,7 +81,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_excel_asset(
@@ -130,7 +130,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_json_asset(
@@ -179,7 +179,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_parquet_asset(
@@ -228,7 +228,7 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     # attr-defined issue
     # https://github.com/python/mypy/issues/12472

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -101,7 +101,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_excel_asset(
@@ -149,7 +149,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_json_asset(
@@ -197,7 +197,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     @public_api
     def add_parquet_asset(
@@ -245,7 +245,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     # attr-defined issue
     # https://github.com/python/mypy/issues/12472

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -73,6 +73,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             glob_directive=glob_directive,
             data_context_root_directory=self.data_context_root_directory,
         )
+
         # build a more specific `_test_connection_error_message`
         data_asset._test_connection_error_message = (
             self.data_connector_type.build_test_connection_error_message(

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -73,3 +73,12 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             glob_directive=glob_directive,
             data_context_root_directory=self.data_context_root_directory,
         )
+        # build a more specific `_test_connection_error_message`
+        data_asset._test_connection_error_message = (
+            self.data_connector_type.build_test_connection_error_message(
+                data_asset_name=data_asset.name,
+                batching_regex=data_asset.batching_regex,
+                glob_directive=glob_directive,
+                base_directory=self.base_directory,
+            )
+        )

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -183,7 +183,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_excel_asset(
         self,
@@ -236,7 +236,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_json_asset(
         self,
@@ -289,7 +289,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_parquet_asset(
         self,
@@ -342,7 +342,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     # attr-defined issue
     # https://github.com/python/mypy/issues/12472

--- a/great_expectations/datasource/fluent/pandas_s3_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_s3_datasource.py
@@ -155,7 +155,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_excel_asset(
         self,
@@ -208,7 +208,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_json_asset(
         self,
@@ -261,7 +261,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     def add_parquet_asset(
         self,
@@ -314,7 +314,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)
 
     # attr-defined issue
     # https://github.com/python/mypy/issues/12472

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -272,7 +272,7 @@ class _SourceFactories:
                 self: Datasource, name: str, **kwargs
             ) -> pydantic.BaseModel:
                 asset = asset_type(name=name, **kwargs)
-                return self.add_asset(asset)
+                return self._add_asset(asset)
 
             # attr-defined issue
             # https://github.com/python/mypy/issues/12472
@@ -290,7 +290,7 @@ class _SourceFactories:
             ) -> Validator:
                 name = asset_name or DEFAULT_PANDAS_DATA_ASSET_NAME
                 asset = asset_type(name=name, **kwargs)
-                self.add_asset(asset)
+                self._add_asset(asset)
                 batch_request = asset.build_batch_request()
                 return self._data_context.get_validator(batch_request=batch_request)  # type: ignore[attr-defined]
 

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -291,7 +291,6 @@ class _SourceFactories:
                     connect_options = {}
 
                 asset = asset_type(name=name, **kwargs)
-
                 return self._add_asset(asset, connect_options=connect_options)
 
             # attr-defined issue

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -173,4 +173,4 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -170,4 +170,4 @@ class SparkDatasource(_SparkDatasource):
             name=name,
             dataframe=dataframe,
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/spark_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/spark_dbfs_datasource.py
@@ -80,4 +80,4 @@ class SparkDBFSDatasource(SparkFilesystemDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.py
@@ -98,4 +98,4 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
                 base_directory=self.base_directory,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -180,4 +180,4 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/spark_s3_datasource.py
+++ b/great_expectations/datasource/fluent/spark_s3_datasource.py
@@ -154,4 +154,4 @@ class SparkS3Datasource(_SparkFilePathDatasource):
                 delimiter=delimiter,
             )
         )
-        return self.add_asset(asset=asset)
+        return self._add_asset(asset=asset)

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -925,7 +925,7 @@ class SQLDatasource(Datasource):
             schema_name=schema_name,
             order_by=order_by_sorters,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)
 
     @public_api
     def add_query_asset(
@@ -952,4 +952,4 @@ class SQLDatasource(Datasource):
             query=query,
             order_by=order_by_sorters,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)


### PR DESCRIPTION
## Changes proposed in this pull request:
- `Datasource.add_asset()` -> `Datasource._add_asset()`
   - This method should never need to be called by users. They should be calling specific `add_<ASSET_TYPE>_asset()` methods instead.
