### PR TITLE
[DOCS] Fixes typo in code snippet for "How to organize Batches in a file-based Data Asset" guide

### DIFF
--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
@@ -165,7 +165,7 @@ my_asset.add_sorters(["+year"])
 To verify that our Data Asset will return the desired files as Batches, we will define a quick Batch Request that will include all the Batches available in the Data asset.  Then we will use that Batch Request to get a list of the returned Batches.
 
 ```python title="Python code"
-my_batch_request = my_asset.my_asset.build_batch_request()
+my_batch_request = my_asset.build_batch_request()
 batches = datasource.get_batch_list_from_batch_request(my_batch_request)
 ```
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes typo in code snippet for "How to organize Batches in a file-based Data Asset" guide

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.

