### PR TITLE
[MAINTENANCE] Enable TCH251 - banned-api for sqlalchemy

### DIFF
--- a/contrib/ruff.toml
+++ b/contrib/ruff.toml
@@ -4,9 +4,12 @@
 extend = "../pyproject.toml"
 
 extend-ignore = [
-    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    # https://beta.ruff.rs/docs/rules/#flake8-type-checking-tch
     # This is likely to be a high-touch rule that most contribs don't need to care about.
     "TCH001",
+    # https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid
+    "TID251",  # banned-api - this is a new process for great_expecations once we've firmly established this pattern we
+    # can enable it for contrib packages
 ]
 
 [isort]

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -132,9 +132,9 @@ from great_expectations.core.usage_statistics.usage_statistics import (  # isort
     usage_statistics_enabled_method,
 )
 
-try:
-    from sqlalchemy.exc import SQLAlchemyError
-except ImportError:
+from great_expectations.optional_imports import SQLAlchemyError
+
+if not SQLAlchemyError:
     # We'll redefine this error in code below to catch ProfilerError, which is caught above, so SA errors will
     # just fall through
     SQLAlchemyError = gx_exceptions.ProfilerError

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -13,13 +13,9 @@ import pyparsing as pp
 
 from great_expectations.alias_types import PathStr  # noqa: TCH001
 from great_expectations.exceptions import StoreConfigurationError
+from great_expectations.optional_imports import sqlalchemy as sa
 from great_expectations.types import safe_deep_copy
 from great_expectations.util import load_class, verify_dynamic_loading_support
-
-try:
-    import sqlalchemy as sa
-except ImportError:
-    sa = None
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/datasource/fluent/pandas_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_datasource.pyi
@@ -23,7 +23,6 @@ from typing import (
 
 import pandas as pd
 import pydantic
-import sqlalchemy
 from typing_extensions import Literal
 
 from great_expectations.datasource.fluent.interfaces import (
@@ -34,6 +33,7 @@ from great_expectations.datasource.fluent.interfaces import (
     Datasource,
     _DataAssetT,
 )
+from great_expectations.optional_imports import sqlalchemy
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent import Sorter

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -46,7 +46,7 @@ from great_expectations.execution_engine.split_and_sample.sqlalchemy_data_splitt
 from great_expectations.optional_imports import sqlalchemy
 
 if TYPE_CHECKING:
-    import sqlalchemy as sa
+    import sqlalchemy as sa  # noqa: TID251 # type-checking only
 
 
 class SQLDatasourceError(Exception):

--- a/great_expectations/datasource/simple_sqlalchemy_datasource.py
+++ b/great_expectations/datasource/simple_sqlalchemy_datasource.py
@@ -10,7 +10,9 @@ from great_expectations.datasource.data_connector.configured_asset_sql_data_conn
 from great_expectations.datasource.new_datasource import BaseDatasource
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine import Engine as SaEngine
+    from sqlalchemy.engine import (  # noqa: TID251 # type-checking only
+        Engine as SaEngine,
+    )
 
     from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 

--- a/great_expectations/optional_imports.py
+++ b/great_expectations/optional_imports.py
@@ -77,11 +77,12 @@ SQLALCHEMY_NOT_IMPORTED = NotImported(
 )
 try:
     import sqlalchemy
+    from sqlalchemy.exc import SQLAlchemyError
 
     sqlalchemy_version_check(sqlalchemy.__version__)
 except ImportError:
     sqlalchemy = SQLALCHEMY_NOT_IMPORTED
-
+    SQLAlchemyError = SQLALCHEMY_NOT_IMPORTED
 
 SPARK_NOT_IMPORTED = NotImported(
     "pyspark is not installed, please 'pip install pyspark'"

--- a/great_expectations/optional_imports.py
+++ b/great_expectations/optional_imports.py
@@ -77,12 +77,13 @@ SQLALCHEMY_NOT_IMPORTED = NotImported(
 )
 try:
     import sqlalchemy
-    from sqlalchemy.exc import SQLAlchemyError
+    from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
     sqlalchemy_version_check(sqlalchemy.__version__)
 except ImportError:
     sqlalchemy = SQLALCHEMY_NOT_IMPORTED
     SQLAlchemyError = SQLALCHEMY_NOT_IMPORTED
+    OperationalError = SQLALCHEMY_NOT_IMPORTED
 
 SPARK_NOT_IMPORTED = NotImported(
     "pyspark is not installed, please 'pip install pyspark'"

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -1,15 +1,14 @@
 import logging
 
 from great_expectations.core.profiler_types_mapping import ProfilerTypeMapping
+from great_expectations.optional_imports import OperationalError
 from great_expectations.profile.base import (
     DatasetProfiler,
     ProfilerCardinality,
     ProfilerDataType,
 )
 
-try:
-    from sqlalchemy.exc import OperationalError
-except ModuleNotFoundError:
+if not OperationalError:
     OperationalError = RuntimeError
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,51 @@ extend-exclude = [
 "great_expectations/optional_imports.py" = [
     "TID251",  # flake8-banned-api
 ]
+"great_expectations/dataset/*" = [ # dataset is deprecated
+    "TID251",  # flake8-banned-api
+]
+
+# #########################################
+# BEGIN temporary banned-api exclusion list
+# TODO: remove packages from this list as they are addressed
+"great_expectations/cli/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/data_context/store/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/datasource/batch_kwargs_generator/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/datasource/data_connector/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/execution_engine/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/expectations/core/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/expectations/metrics/*" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/self_check/util.py" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/self_check/sqlalchemy_connection_manager.py" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/util.py" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/rule_based_profiler/attributed_resolved_metrics.py" = [
+    "TID251",  # flake8-banned-api
+]
+"great_expectations/expectations/row_conditions.py" = [
+    "TID251",  # flake8-banned-api
+]
+# END temporary banned-api exclusion list
+# #########################################
 
 [tool.ruff.mccabe]
 max-complexity = 15
@@ -297,7 +342,7 @@ convention = "google"
 [tool.ruff.flake8-tidy-imports]
 [tool.ruff.flake8-tidy-imports.banned-api]
 # Uncomment this to prevent importing sqlalchemy everywhere but optional_imports.py
-# "sqlalchemy".msg = "Don't import sqlalchemy directly, please use the great_expectations.import_manager."
+"sqlalchemy".msg = "Don't import sqlalchemy directly, please use the great_expectations.optional_imports."
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -9,7 +9,7 @@ extend-ignore = [
     # Let's differ this for tests until there are auto-fixes
     "TCH001",
     # https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid
-    "TID251",  # banned-api - is used to prevent meanigless attribute errors caused by missing optional depedencies
+    "TID251",  # banned-api - is used to prevent opaque attribute errors caused by missing optional dependencies
     # not something we have to worry about in test code
 ]
 

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -4,10 +4,13 @@
 extend = "../pyproject.toml"
 
 extend-ignore = [
-    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    # https://beta.ruff.rs/docs/rules/#flake8-type-checking-tch
     # This is likely to be a high-touch rule. Doing this in `tests` doesn't help circular imports.
     # Let's differ this for tests until there are auto-fixes
     "TCH001",
+    # https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid
+    "TID251",  # banned-api - is used to prevent meanigless attribute errors caused by missing optional depedencies
+    # not something we have to worry about in test code
 ]
 
 [isort]


### PR DESCRIPTION
Changes proposed in this pull request:
- gradual adoption for `TCH251` banned-api
-
-

