### PR TITLE
[DOCS] Doc-472 Corrects numbering of steps in guide

### DIFF
--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.md
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.md
@@ -21,7 +21,7 @@ import ConfirmThatExpectationsCanBeAccessedFromAmazonSByRunningGreatExpectations
 ### 2. Verify your AWS credentials are properly configured
 <VerifyAwsCredentials />
 
-### 2. Identify your Data Context Expectations Store
+### 3. Identify your Data Context Expectations Store
 <IdentifyYourDataContextExpectationsStore />
 
 ### 3. Update your configuration file to include a new Store for Expectations on S3


### PR DESCRIPTION
Changes proposed in this pull request:
-  Corrects numbering of steps in "How to configure an Expectation Store in Amazon S3"

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.
