### PR TITLE
[DOCS] doc-409 Corrects links in databricks guide

### DIFF
--- a/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
+++ b/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
@@ -344,7 +344,7 @@ Now let's keep going to create an Expectation Suite and validate our data.
 
 ### 5. Create Expectations
 
-Here we will use a <TechnicalTag tag="validation" text="Validator" /> to interact with our batch of data and generate an <TechnicalTag tag="expectation_suite" text="Expectation Suite" />.
+Here we will use a <TechnicalTag tag="validator" text="Validator" /> to interact with our batch of data and generate an <TechnicalTag tag="expectation_suite" text="Expectation Suite" />.
 
 Each time we evaluate an Expectation (e.g. via `validator.expect_*`), it will immediately be Validated against your data. This instant feedback helps you zero in on unexpected data very quickly, taking a lot of the guesswork out of data exploration. Also, the Expectation configuration will be stored in the Validator. When you have run all of the Expectations you want for this dataset, you can call `validator.save_expectation_suite()` to save all of your Expectation configurations into an Expectation Suite for later use in a checkpoint.
 

--- a/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
+++ b/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
@@ -344,7 +344,7 @@ Now let's keep going to create an Expectation Suite and validate our data.
 
 ### 5. Create Expectations
 
-Here we will use a Validator to interact with our batch of data and generate an Expectation Suite.
+Here we will use a <TechnicalTag tag="validation" text="Validator" /> to interact with our batch of data and generate an <TechnicalTag tag="expectation_suite" text="Expectation Suite" />.
 
 Each time we evaluate an Expectation (e.g. via `validator.expect_*`), it will immediately be Validated against your data. This instant feedback helps you zero in on unexpected data very quickly, taking a lot of the guesswork out of data exploration. Also, the Expectation configuration will be stored in the Validator. When you have run all of the Expectations you want for this dataset, you can call `validator.save_expectation_suite()` to save all of your Expectation configurations into an Expectation Suite for later use in a checkpoint.
 

--- a/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
+++ b/docs/docusaurus/docs/deployment_patterns/how_to_use_great_expectations_in_databricks.md
@@ -344,11 +344,11 @@ Now let's keep going to create an Expectation Suite and validate our data.
 
 ### 5. Create Expectations
 
-Here we will use a <TechincalTag tag="validator" text="Validator"/> to interact with our batch of data and generate an <TechincalTag tag="expectation_suite" text="Expectation Suite"/>.
+Here we will use a Validator to interact with our batch of data and generate an Expectation Suite.
 
 Each time we evaluate an Expectation (e.g. via `validator.expect_*`), it will immediately be Validated against your data. This instant feedback helps you zero in on unexpected data very quickly, taking a lot of the guesswork out of data exploration. Also, the Expectation configuration will be stored in the Validator. When you have run all of the Expectations you want for this dataset, you can call `validator.save_expectation_suite()` to save all of your Expectation configurations into an Expectation Suite for later use in a checkpoint.
 
-This is the same method of interactive Expectation Suite editing used in the CLI interactive mode notebook accessed via `great_expectations suite new --interactive`. For more information, see our documentation on [How to create and edit Expectations with instant feedback from a sample Batch of data](../../docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md). You can also create Expectation Suites using a [profiler](../guides/expectations/how_to_create_and_edit_expectations_with_a_profiler.md) to automatically create expectations based on your data or [manually using domain knowledge and without inspecting data directly](../guides/expectations/how_to_create_and_edit_expectations_based_on_domain_knowledge_without_inspecting_data_directly.md). 
+This is the same method of interactive Expectation Suite editing used in the CLI interactive mode notebook accessed via `great_expectations suite new --interactive`. For more information, see our documentation on [How to create and edit Expectations with instant feedback from a sample Batch of data](../../docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md). You can also create Expectation Suites using a [Data Assistant](../guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant.md) to automatically create expectations based on your data or [manually using domain knowledge and without inspecting data directly](../guides/expectations/how_to_create_and_edit_expectations_based_on_domain_knowledge_without_inspecting_data_directly.md). 
 
 <Tabs
   groupId="file-or-dataframe-pandas-or-yaml"


### PR DESCRIPTION
Changes proposed in this pull request:
- corrects broken technical term tags
- updates Profiler link to point to Data Assistants

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run `yarn build` locally to verify all links are valid