### PR TITLE
[DOCS] corrects typo in GCS setup guide

### DIFF
--- a/docs/docusaurus/docs/guides/setup/optional_dependencies/cloud/how_to_set_up_gx_to_work_with_data_on_gcs.md
+++ b/docs/docusaurus/docs/guides/setup/optional_dependencies/cloud/how_to_set_up_gx_to_work_with_data_on_gcs.md
@@ -37,7 +37,7 @@ import LinksAfterInstallingGx from '/docs/components/setup/next_steps/_links_aft
 
 ## Introduction
 
-This guide will walk you through best practices for creating your GX Python environment and demonstrate how to locally install Great Expectations along with the necessary dependencies for working with data stored in Amazon Web Services S3 storage.
+This guide will walk you through best practices for creating your GX Python environment and demonstrate how to locally install Great Expectations along with the necessary dependencies for working with data stored on Google Cloud Storage.
 
 ## Prerequisites
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Correct typo from S3 to GCS

### Definition of Done
- [X] I have made corresponding changes to the documentation
