### PR TITLE
[BUGFIX] Typo in min versions install

### DIFF
--- a/ci/constraints-test/py37-min-install.txt
+++ b/ci/constraints-test/py37-min-install.txt
@@ -1,3 +1,3 @@
 numpy==1.18.5
 pandas==1.1.0
---constraints https://raw.githubusercontent.com/apache/airflow/constraints-2.2.0/constraints-3.7.txt
+--constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.2.0/constraints-3.7.txt


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix typo with `--constraint` flag

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.