### PR TITLE
[MAINTENANCE] Simplifying CapitalOne DataProfilerColumnDomainBuilder Using Default "profile_path" Argument

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
@@ -96,18 +96,7 @@ class DataProfilerStructuredDataAssistant(DataAssistant):
         column name in profiler report; GreatExpectations "table.columns" metric is used to validate column existence.
         """
         data_profiler_column_domain_builder: DomainBuilder = (
-            DataProfilerColumnDomainBuilder(
-                profile_path=f"{VARIABLES_KEY}profile_path",
-                include_column_names=None,
-                exclude_column_names=None,
-                include_column_name_suffixes=None,
-                exclude_column_name_suffixes=None,
-                semantic_type_filter_module_name=None,
-                semantic_type_filter_class_name=None,
-                include_semantic_types=None,
-                exclude_semantic_types=None,
-                data_context=None,
-            )
+            DataProfilerColumnDomainBuilder()
         )
 
         data_profiler_profile_report_metric_single_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.build_metric_single_batch_parameter_builder(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/domain_builder/data_profiler_column_domain_builder.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/domain_builder/data_profiler_column_domain_builder.py
@@ -13,6 +13,7 @@ from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
 )
 from great_expectations.rule_based_profiler.parameter_container import (
+    VARIABLES_KEY,  # noqa: TCH001
     ParameterContainer,  # noqa: TCH001
 )
 from great_expectations.util import is_candidate_subset_of_target
@@ -32,7 +33,7 @@ class DataProfilerColumnDomainBuilder(ColumnDomainBuilder):
 
     def __init__(
         self,
-        profile_path: str,
+        profile_path: str = f"{VARIABLES_KEY}profile_path",
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         exclude_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         include_column_name_suffixes: Optional[Union[str, Iterable, List[str]]] = None,
@@ -49,7 +50,7 @@ class DataProfilerColumnDomainBuilder(ColumnDomainBuilder):
     ) -> None:
         """
         Args:
-            profile_path: path to output (in ".pkl" format) of CapitalOne DataProfiler
+            profile_path: path to output (in ".pkl" format) of CapitalOne DataProfiler (default references "variables").
             include_column_names: Explicitly specified desired columns (if None, it is computed based on active Batch).
             exclude_column_names: If provided, these columns are pre-filtered and excluded from consideration.
             include_column_name_suffixes: Explicitly specified desired suffixes for corresponding columns to match.

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
@@ -303,7 +303,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_value(
 
 @pytest.mark.integration
 @pytest.mark.slow  # 1.21s
-def test_data_profiler_column_domain_builder_with_profile_path_as_reference(
+def test_data_profiler_column_domain_builder_with_profile_path_as_default_reference(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
 ):
     """
@@ -338,7 +338,273 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference(
     }
 
     domain_builder: DomainBuilder = DataProfilerColumnDomainBuilder(
-        profile_path=f"{VARIABLES_KEY}profile_path",
+        data_context=data_context,
+    )
+    domains: List[Domain] = domain_builder.get_domains(
+        rule_name="my_rule",
+        variables=variables,
+        batch_request=batch_request,
+    )
+
+    assert len(domains) == 18
+    assert domains == [
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "vendor_id",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "vendor_id": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "pickup_datetime",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "pickup_datetime": SemanticDomainTypes.TEXT.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "dropoff_datetime",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "dropoff_datetime": SemanticDomainTypes.TEXT.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "passenger_count",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "passenger_count": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "trip_distance",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "trip_distance": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "rate_code_id",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "rate_code_id": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "store_and_fwd_flag",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "store_and_fwd_flag": SemanticDomainTypes.TEXT.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "pickup_location_id",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "pickup_location_id": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "dropoff_location_id",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "dropoff_location_id": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "payment_type",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "payment_type": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "fare_amount",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "fare_amount": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "extra",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "extra": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "mta_tax",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "mta_tax": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "tip_amount",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "tip_amount": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "tolls_amount",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "tolls_amount": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "improvement_surcharge",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "improvement_surcharge": SemanticDomainTypes.NUMERIC.value,
+                }
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "total_amount",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "total_amount": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+        {
+            "rule_name": "my_rule",
+            "domain_type": MetricDomainTypes.COLUMN.value,
+            "domain_kwargs": {
+                "column": "congestion_surcharge",
+            },
+            "details": {
+                INFERRED_SEMANTIC_TYPE_KEY: {
+                    "congestion_surcharge": SemanticDomainTypes.NUMERIC.value,
+                },
+            },
+        },
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.slow  # 1.21s
+def test_data_profiler_column_domain_builder_with_profile_path_as_reference(
+    bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
+):
+    """
+    This test verifies that "Domain" objects corresponding to full list of columns in Profiler Report (same as in Batch)
+    are emitted when path to "profile.pkl" is specified as Rule variable (implicitly).
+    """
+    data_context: FileDataContext = (
+        bobby_columnar_table_multi_batch_deterministic_data_context
+    )
+
+    profile_path = os.path.join(  # noqa: PTH118
+        test_root_path,
+        "data_profiler_files",
+        "profile.pkl",
+    )
+
+    variables_configs: dict = {
+        "my_profile_path": profile_path,
+        "estimator": "quantiles",
+        "false_positive_rate": 1.0e-2,
+        "mostly": 1.0,
+    }
+    variables: ParameterContainer = build_parameter_container_for_variables(
+        variables_configs=variables_configs
+    )
+
+    batch_request: dict = {
+        "datasource_name": "taxi_pandas",
+        "data_connector_name": "monthly",
+        "data_asset_name": "my_reports",
+        "data_connector_query": {"index": -1},
+    }
+
+    domain_builder: DomainBuilder = DataProfilerColumnDomainBuilder(
+        profile_path=f"{VARIABLES_KEY}my_profile_path",
         data_context=data_context,
     )
     domains: List[Domain] = domain_builder.get_domains(
@@ -588,7 +854,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with
     )
 
     variables_configs: dict = {
-        "profile_path": profile_path,
+        "my_profile_path": profile_path,
         "estimator": "quantiles",
         "false_positive_rate": 1.0e-2,
         "mostly": 1.0,
@@ -605,7 +871,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with
     }
 
     domain_builder: DomainBuilder = DataProfilerColumnDomainBuilder(
-        profile_path=f"{VARIABLES_KEY}profile_path",
+        profile_path=f"{VARIABLES_KEY}my_profile_path",
         exclude_column_names=[
             "store_and_fwd_flag",
             "congestion_surcharge",
@@ -791,7 +1057,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with
     )
 
     variables_configs: dict = {
-        "profile_path": profile_path,
+        "my_profile_path": profile_path,
         "estimator": "quantiles",
         "false_positive_rate": 1.0e-2,
         "mostly": 1.0,
@@ -808,7 +1074,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with
     }
 
     domain_builder: DomainBuilder = DataProfilerColumnDomainBuilder(
-        profile_path=f"{VARIABLES_KEY}profile_path",
+        profile_path=f"{VARIABLES_KEY}my_profile_path",
         data_context=data_context,
     )
     with mock.patch(


### PR DESCRIPTION
### Scope
* Instantiation of `DataProfilerColumnDomainBuilder` is simplified with the use of the default `$variables.profile_path` reference.
* Added a new unit test and updated existing tests to better highlight the behavior.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1285/DX-392
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!