### PR TITLE
[MAINTENANCE]: replace ColumnMetricProvider with ColumnAggregateMetricProvider

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
@@ -20,7 +20,7 @@ from great_expectations.expectations.expectation import (
     render_evaluation_parameter_string,
 )
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
     column_aggregate_value,
 )
 from great_expectations.expectations.metrics.metric_provider import metric_value
@@ -34,7 +34,7 @@ from great_expectations.render.util import (
 from great_expectations.validator.validation_graph import MetricConfiguration
 
 
-class ColumnDiscreteEntropy(ColumnMetricProvider):
+class ColumnDiscreteEntropy(ColumnAggregateMetricProvider):
     """MetricProvider Class for Discrete Entropy MetricProvider"""
 
     metric_name = "column.discrete.entropy"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_distribution_to_match_benfords_law.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_distribution_to_match_benfords_law.py
@@ -8,7 +8,7 @@ from great_expectations.execution_engine.sqlalchemy_execution_engine import (
 )
 from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
     column_aggregate_value,
 )
 from great_expectations.validator.validation_graph import MetricConfiguration
@@ -36,7 +36,7 @@ def matchFirstDigit(value, digit):
         return 0.0
 
 
-class ColumnDistributionMatchesBenfordsLaw(ColumnMetricProvider):
+class ColumnDistributionMatchesBenfordsLaw(ColumnAggregateMetricProvider):
     """
     MetricProvider tests whether data matches Benford's Law Fraud Detection
     Algorithm.

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
@@ -11,13 +11,13 @@ from great_expectations.execution_engine import (
 from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics import column_aggregate_partial
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
     column_aggregate_value,
 )
 from great_expectations.expectations.metrics.import_manager import F
 
 
-class ColumnKurtosis(ColumnMetricProvider):
+class ColumnKurtosis(ColumnAggregateMetricProvider):
     """MetricProvider Class for Aggregate Mean MetricProvider"""
 
     metric_name = "column.custom.kurtosis"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_skew_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_skew_to_be_between.py
@@ -17,7 +17,7 @@ from great_expectations.execution_engine.sqlalchemy_execution_engine import (
 )
 from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
 )
 from great_expectations.expectations.metrics.column_aggregate_metric_provider import (
     column_aggregate_partial,
@@ -53,7 +53,7 @@ except ImportError:
         Row = None
 
 
-class ColumnSkew(ColumnMetricProvider):
+class ColumnSkew(ColumnAggregateMetricProvider):
     """MetricProvider Class for Aggregate Mean MetricProvider"""
 
     metric_name = "column.custom.skew"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_normally_distributed.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_normally_distributed.py
@@ -6,12 +6,12 @@ from great_expectations.core import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
     column_aggregate_value,
 )
 
 
-class ColumnNormallyDistributed(ColumnMetricProvider):
+class ColumnNormallyDistributed(ColumnAggregateMetricProvider):
     """MetricProvider Class for Aggregate Mean MetricProvider"""
 
     metric_name = "column.custom.normally_distributed"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_wasserstein_distance_to_be_less_than.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_wasserstein_distance_to_be_less_than.py
@@ -6,12 +6,12 @@ from great_expectations.core import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics.column_aggregate_metric import (
-    ColumnMetricProvider,
+    ColumnAggregateMetricProvider,
     column_aggregate_value,
 )
 
 
-class ColumnWassersteinDistance(ColumnMetricProvider):
+class ColumnWassersteinDistance(ColumnAggregateMetricProvider):
     """MetricProvider Class for Wasserstein Distance MetricProvider"""
 
     metric_name = "column.custom.wasserstein"


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the last references to a deprecated class
