### PR TITLE
[MAINTENANCE] Disable UserConfigurableProfiler tests relying on deprecated V2 functionality

### DIFF
--- a/great_expectations/expectations/metrics/metric_provider.py
+++ b/great_expectations/expectations/metrics/metric_provider.py
@@ -189,7 +189,7 @@ class MetricProvider(metaclass=MetaMetricProvider):
                 To instruct "ExecutionEngine" accordingly, original metric is registered with its "declared" name, but
                 with "metric_provider" function omitted (set to "None"), and additional "AGGREGATE_FN" metric, with its
                 "metric_provider" set to (decorated) implementation function, defined in metric class, is registered.
-                Then "AGGREGATE_FN" metric can specified with key "metric_partial_fn" as evaluation metric dependency.
+                Then "AGGREGATE_FN" metric is specified with key "metric_partial_fn" as evaluation metric dependency.
                 By convention, aggregate partial metric implementation functions return three-valued tuple, containing
                 deferred execution metric implementation function of corresponding "ExecutionEngine" backend (called
                 "metric_aggregate") as well as "compute_domain_kwargs" and "accessor_domain_kwargs", which are relevant

--- a/tests/profile/test_basic_suite_builder_profiler.py
+++ b/tests/profile/test_basic_suite_builder_profiler.py
@@ -78,6 +78,9 @@ def datetime_dataset(test_backend):
     is_library_loadable(library_name="trino"),
     reason="datetime doesnt exist in Trino",
 )
+@pytest.mark.xfail(
+    reason='Utility methods "get_dataset()" is part of deprecated GX-V2 functionality (it must no longer be used).'
+)
 def test__find_next_datetime_column(datetime_dataset, numeric_high_card_dataset):
     columns = datetime_dataset.get_table_columns()
     column_cache = {}
@@ -112,6 +115,9 @@ def test__find_next_datetime_column(datetime_dataset, numeric_high_card_dataset)
 @pytest.mark.skipif(
     is_library_loadable(library_name="trino"),
     reason="datetime doesnt exist in Trino",
+)
+@pytest.mark.xfail(
+    reason='Utility methods "get_dataset()" is part of deprecated GX-V2 functionality (it must no longer be used).'
 )
 def test__create_expectations_for_datetime_column(datetime_dataset):
     column = "datetime"


### PR DESCRIPTION
### Scope
A test fixture in UserConfigurableProfiler test module was using a deprecated GX-V2 `get_dataset()` method.  The tests using this fixture are being omitted (using `@pytest.mark.xfail()`).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: DX-430
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!