### PR TITLE
[DOCS] Use orange in docs logs

### DIFF
--- a/docs/build_docs
+++ b/docs/build_docs
@@ -3,7 +3,7 @@
 # Build API docs then build docusaurus docs.
 # Currently used in our netlify pipeline.
 
-ORANGE='\033[0;33m'
+ORANGE='\033[38;5;208m'
 NC='\033[0m' # No Color
 
 CURRENT_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
Changes proposed in this pull request:
- Change the docs logs to use orange to match our brand.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.