### PR TITLE
[MAINTENANCE] Capitalize "If" in rendering of conditional Expectations

### DIFF
--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -458,7 +458,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                 condition, f"$row_condition__{str(idx)}"
             )
         row_condition_str = row_condition_str.lower()
-        return f"If {row_condition_str}"
+        return f"If {row_condition_str}, then "
 
     @validator("template_str")
     def _set_template_str(cls, v: str, values: dict) -> str:
@@ -466,7 +466,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
             row_condition_str: str = RendererConfiguration._get_row_condition_string(
                 row_condition_str=values["_row_condition"]
             )
-            v = f"{row_condition_str}, then {v}"
+            v = f"{row_condition_str}{v}"
 
         return v
 

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -458,7 +458,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                 condition, f"$row_condition__{str(idx)}"
             )
         row_condition_str = row_condition_str.lower()
-        return f"if {row_condition_str}"
+        return f"If {row_condition_str}"
 
     @validator("template_str")
     def _set_template_str(cls, v: str, values: dict) -> str:

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -466,7 +466,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
             row_condition_str: str = RendererConfiguration._get_row_condition_string(
                 row_condition_str=values["_row_condition"]
             )
-            v = f"{row_condition_str}{v}"
+            v = row_condition_str + v
 
         return v
 

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -1098,7 +1098,7 @@ def test_validator_include_rendered_content_diagnostic(
                     "value": "passenger_count>0",
                 },
             },
-            template="if $row_condition__0, then $column minimum value must be greater than or equal to $min_value and less than or equal to $max_value.",
+            template="If $row_condition__0, then $column minimum value must be greater than or equal to $min_value and less than or equal to $max_value.",
         ),
         value_type="StringValueType",
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- PP-26
- Since the condition is always at the beginning of the templated string it can be capitalized

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.