### PR TITLE
[MAINTENANCE] Fix sqlalchemy 2.0 incompatible warnings

### DIFF
--- a/tests/cli/test_checkpoint.py
+++ b/tests/cli/test_checkpoint.py
@@ -14,6 +14,9 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from nbformat import NotebookNode
 
 from great_expectations.cli import cli
+from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
+    add_dataframe_to_db,
+)
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.usage_statistics.anonymizers.types.base import (
     GETTING_STARTED_DATASOURCE_NAME,
@@ -55,10 +58,10 @@ def titanic_data_context_with_sql_datasource(
             __file__, os.path.join("..", "test_sets", "Titanic.csv")
         )
         df: pd.DataFrame = pd.read_csv(filepath_or_buffer=csv_path)
-        df.to_sql(name="titanic", con=conn)
+        add_dataframe_to_db(df=df, name="titanic", con=conn)
         df = df.sample(frac=0.5, replace=True, random_state=1)
-        df.to_sql(name="incomplete", con=conn)
-        test_df.to_sql(name="wrong", con=conn)
+        add_dataframe_to_db(df=df, name="incomplete", con=conn)
+        add_dataframe_to_db(df=test_df, name="wrong", con=conn)
     except ValueError as ve:
         logger.warning(f"Unable to store information into database: {str(ve)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1761,7 +1761,8 @@ def empty_sqlite_db(sa):
         from sqlalchemy import create_engine
 
         engine = create_engine("sqlite://")
-        assert engine.execute(sa.text("select 1")).fetchall()[0] == (1,)
+        with engine.connect() as connection:
+            assert connection.execute(sa.text("select 1")).fetchall()[0] == (1,)
         return engine
     except ImportError:
         raise ValueError("sqlite tests require sqlalchemy to be installed")


### PR DESCRIPTION
Changes proposed in this pull request:
- There were a few `Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0.` warnings raised in our scheduled comprehensive pipeline that are addressed in this PR.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.