### PR TITLE
[DOCS]  Corrects typo in code block within in-memory Pandas guide

### DIFF
--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.md
@@ -68,7 +68,7 @@ name = "taxi_dataframe"
 Now that we have the `name` and `dataframe` for our Data Asset, we can create the Data Asset with the code:
 
 ```python title="Python code"
-data_asset = datasource.add_dataframe(name=name, dataframe=dataframe)
+data_asset = datasource.add_dataframe_asset(name=name, dataframe=dataframe)
 ```
 
 ## Next steps


### PR DESCRIPTION
### Changes proposed in this pull request:
- Correct typo in code block within in-memory Pandas guide (add_dataframe -> add_dataframe_asset)

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.
