### PR TITLE
[BUGFIX] Fix incorrect RendererValueType for "kwargs"

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -453,7 +453,7 @@ class Expectation(metaclass=MetaExpectation):
                 RendererValueType.STRING,
                 renderer_configuration.expectation_type,
             ),
-            ("kwargs", RendererValueType.STRING, renderer_configuration.kwargs),
+            ("kwargs", RendererValueType.OBJECT, renderer_configuration.kwargs),
         )
         for name, param_type, value in add_param_args:
             renderer_configuration.add_param(

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -2965,7 +2965,7 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
                             "value": "expect_sky_to_be_color",
                         },
                         "kwargs": {
-                            "schema": {"type": "string"},
+                            "schema": {"type": "object"},
                             "value": {"color": "blue"},
                         },
                     },
@@ -2988,7 +2988,7 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
                             "value": "expect_sky_to_be_color",
                         },
                         "kwargs": {
-                            "schema": {"type": "string"},
+                            "schema": {"type": "object"},
                             "value": {"color": "blue"},
                         },
                     },


### PR DESCRIPTION
Changes proposed in this pull request:
- Assign "kwargs" type RendererValueType.OBJECT instead of RendererValueType.STRING


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
