### PR TITLE
[BUGFIX] Add minor affordances to handle cases of data assistant usage

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -88,7 +88,7 @@ class DataAssistantDispatcher:
         registered_data_assistants = cls._registered_data_assistants
 
         if name in registered_data_assistants:
-            raise ValueError(f'Existing declarations of DataAssistant "{name}" found.')
+            logger.warning(f'Existing declarations of DataAssistant "{name}" found.')
 
         logger.debug(
             f'Registering the declaration of DataAssistant "{name}" took place.'

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -3142,7 +3142,9 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
         )
         attributed_metrics: Dict[
             str, List[ParameterNode]
-        ] = attributed_metrics_by_table_domain[table_domain]
+        ] = attributed_metrics_by_table_domain.get(table_domain, dict())
+        if len(attributed_metrics) == 0:
+            return []
 
         table_based_metric_names: Set[Union[tuple[str, ...], str]] = set()
         for metrics in metric_expectation_map.keys():


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- handle case of missing table domain metrics
- allow duplicate assistants to be loaded with a warning
