### PR TITLE
[DOCS] Improve expect_column_values_to_be_of_type docstring

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -143,8 +143,8 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             whereas valid types for a SqlAlchemyDataset include types named by the current driver such as 'INTEGER' \
             in most SQL dialects and 'TEXT' in dialects such as postgresql. Valid types for SparkDFDataset include \
             'StringType', 'BooleanType' and other pyspark-defined type names. Note that the strings representing these \
-            types are sometimes case-sensitive. For instance, with a Pandas backend `datetime` be unrecognized and
-            fail the expectation, while `Datetime` would pass with valid data.
+            types are sometimes case-sensitive. For instance, with a Pandas backend `timestamp` be unrecognized and
+            fail the expectation, while `Timestamp` would pass with valid data.
 
     Keyword Args:
         mostly (None or a float between 0 and 1): \

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -143,7 +143,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             whereas valid types for a SqlAlchemyDataset include types named by the current driver such as 'INTEGER' \
             in most SQL dialects and 'TEXT' in dialects such as postgresql. Valid types for SparkDFDataset include \
             'StringType', 'BooleanType' and other pyspark-defined type names. Note that the strings representing these \
-            types are sometimes case-sensitive. For instance, with a Pandas backend `timestamp` be unrecognized and
+            types are sometimes case-sensitive. For instance, with a Pandas backend `timestamp` will be unrecognized and
             fail the expectation, while `Timestamp` would pass with valid data.
 
     Keyword Args:

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -142,7 +142,9 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             PandasDataset include any numpy dtype values (such as 'int64') or native python types (such as 'int'), \
             whereas valid types for a SqlAlchemyDataset include types named by the current driver such as 'INTEGER' \
             in most SQL dialects and 'TEXT' in dialects such as postgresql. Valid types for SparkDFDataset include \
-            'StringType', 'BooleanType' and other pyspark-defined type names.
+            'StringType', 'BooleanType' and other pyspark-defined type names. Note that the strings representing these \
+            types are sometimes case-sensitive. For instance, with a Pandas backend `datetime` be unrecognized and
+            fail the expectation, while `Datetime` would pass with valid data.
 
     Keyword Args:
         mostly (None or a float between 0 and 1): \


### PR DESCRIPTION

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- add context to the docstring so users know that the `type_` field is transparently passed through to execution engine, and may be case sensitive.


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
