### PR TITLE
[DOCS] Corrects a typo found in the navigation section of the legacy docs

### DIFF
--- a/docs_rtd/_templates/layout.html
+++ b/docs_rtd/_templates/layout.html
@@ -49,7 +49,7 @@
         class="header-item"
         style="width:155px"
       >
-        COMMUINITY
+        COMMUNITY
         <div class="drop-modal" id="community-modal">
           <ul>
             <li>


### PR DESCRIPTION
### Changes proposed in this pull request:
- Correct a typo found in the navigation section of the legacy docs

### Definition of Done
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.
