### PR TITLE
[BUGFIX] Use relative imports for capitalone_dataprofiler_expectations package

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_exclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_exclusive_threshold_range.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_between_bounds,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_between_bounds,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffBetweenThresholdRange(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_inclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_inclusive_threshold_range.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_between_bounds,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_between_bounds,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffBetweenInclusiveThresholdRange(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_greater_than_or_equal_to_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_greater_than_or_equal_to_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffGreaterThanOrEqualToThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_threshold.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_greater_than_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_greater_than_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffGreaterThanThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_less_than_or_equal_to_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_less_than_or_equal_to_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffLessThanOrEqualToThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_threshold.py
@@ -4,21 +4,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_less_than_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_less_than_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsDiffLessThanThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_between_bounds,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_between_bounds,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffBetweenThresholdRange(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_between_bounds,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_between_bounds,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffBetweenInclusiveThresholdRange(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_greater_than_or_equal_to_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_greater_than_or_equal_to_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffGreaterThanOrEqualToThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_threshold.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_greater_than_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_greater_than_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffGreaterThanThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_less_than_or_equal_to_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_less_than_or_equal_to_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffLessThanOrEqualToThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_threshold.py
@@ -6,21 +6,22 @@ from typing import Any, Dict, Optional
 
 import dataprofiler as dp
 import pandas as pd
-from capitalone_dataprofiler_expectations.expectations.profile_numeric_columns_diff_expectation import (
-    ProfileNumericColumnsDiffExpectation,
-)
-from capitalone_dataprofiler_expectations.expectations.util import (
-    is_value_less_than_threshold,
-    replace_generic_operator_in_report_keys,
-)
-from capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from ..metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
+from .profile_numeric_columns_diff_expectation import (
+    ProfileNumericColumnsDiffExpectation,
+)
+from .util import (
+    is_value_less_than_threshold,
+    replace_generic_operator_in_report_keys,
+)
 
 
 class DataProfilerProfileNumericColumnsPercentDiffLessThanThreshold(

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/__init__.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/__init__.py
@@ -1,25 +1,25 @@
 # Make sure to include any Metrics your want exported below!
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_column_profiler_report import (
+from .data_profiler_metrics.data_profiler_column_profiler_report import (
     DataProfilerColumnProfileReport,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_diff import (
+from .data_profiler_metrics.data_profiler_profile_diff import (
     DataProfilerProfileDiff,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+from .data_profiler_metrics.data_profiler_profile_metric_provider import (
     DataProfilerProfileMetricProvider,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_numeric_columns import (
+from .data_profiler_metrics.data_profiler_profile_numeric_columns import (
     DataProfilerProfileNumericColumns,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_percent_diff import (
+from .data_profiler_metrics.data_profiler_profile_percent_diff import (
     DataProfilerProfilePercentDiff,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_report import (
+from .data_profiler_metrics.data_profiler_profile_report import (
     DataProfilerProfileReport,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_table_column_infos import (
+from .data_profiler_metrics.data_profiler_table_column_infos import (
     DataProfilerTableColumnInfos,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_table_column_list import (
+from .data_profiler_metrics.data_profiler_table_column_list import (
     DataProfilerTableColumnList,
 )

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/__init__.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/__init__.py
@@ -1,24 +1,24 @@
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_column_profiler_report import (
+from .data_profiler_column_profiler_report import (
     DataProfilerColumnProfileReport,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_diff import (
+from .data_profiler_profile_diff import (
     DataProfilerProfileDiff,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
+from .data_profiler_profile_metric_provider import (
     DataProfilerProfileMetricProvider,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_numeric_columns import (
+from .data_profiler_profile_numeric_columns import (
     DataProfilerProfileNumericColumns,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_percent_diff import (
+from .data_profiler_profile_percent_diff import (
     DataProfilerProfilePercentDiff,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_report import (
+from .data_profiler_profile_report import (
     DataProfilerProfileReport,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_table_column_infos import (
+from .data_profiler_table_column_infos import (
     DataProfilerTableColumnInfos,
 )
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_table_column_list import (
+from .data_profiler_table_column_list import (
     DataProfilerTableColumnList,
 )

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_column_profiler_report.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_column_profiler_report.py
@@ -1,8 +1,5 @@
 from typing import Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
@@ -11,6 +8,10 @@ from great_expectations.expectations.metrics.util import (
     get_dbms_compatible_column_names,
 )
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerColumnProfileReport(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_diff.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_diff.py
@@ -1,11 +1,12 @@
 import dataprofiler as dp
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.execution_engine import PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerProfileDiff(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_numeric_columns.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_numeric_columns.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerProfileNumericColumns(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_percent_diff.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_percent_diff.py
@@ -1,13 +1,14 @@
 import copy
 from typing import Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerProfilePercentDiff(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_report.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_profile_report.py
@@ -1,11 +1,12 @@
 import dataprofiler as dp
 
 import great_expectations.exceptions as gx_exceptions
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.execution_engine import PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerProfileReport(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_table_column_infos.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_table_column_infos.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerTableColumnInfos(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_table_column_list.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/metrics/data_profiler_metrics/data_profiler_table_column_list.py
@@ -1,8 +1,5 @@
 from typing import List, Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics.data_profiler_metrics.data_profiler_profile_metric_provider import (
-    DataProfilerProfileMetricProvider,
-)
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.metrics.metric_provider import metric_value
@@ -10,6 +7,10 @@ from great_expectations.expectations.metrics.util import (
     get_dbms_compatible_column_names,
 )
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+from .data_profiler_profile_metric_provider import (
+    DataProfilerProfileMetricProvider,
+)
 
 
 class DataProfilerTableColumnList(DataProfilerProfileMetricProvider):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
@@ -1,11 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.rule_based_profiler.data_assistant_result import (
-    DataProfilerStructuredDataAssistantResult,
-)
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.rule_based_profiler.domain_builder.data_profiler_column_domain_builder import (
-    DataProfilerColumnDomainBuilder,
-)
 from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
 from great_expectations.rule_based_profiler.data_assistant_result import (
@@ -28,6 +22,13 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 from great_expectations.rule_based_profiler.rule import Rule
 from great_expectations.validator.validator import Validator
+
+from ..data_assistant_result import (
+    DataProfilerStructuredDataAssistantResult,
+)
+from ..domain_builder.data_profiler_column_domain_builder import (
+    DataProfilerColumnDomainBuilder,
+)
 
 
 class DataProfilerStructuredDataAssistant(DataAssistant):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/expectations/metrics/test_core.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/expectations/metrics/test_core.py
@@ -7,13 +7,14 @@ from unittest import mock
 import dataprofiler as dp
 import pandas as pd
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics import *  # noqa: F401,F403
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.self_check.util import build_pandas_engine
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
+
+from ....metrics import *  # noqa: F401,F403
 
 if TYPE_CHECKING:
-    from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.tests.conftest import (
+    from ...conftest import (
         BaseProfiler,
     )
 

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
@@ -7,13 +7,6 @@ from unittest import mock
 
 import pytest
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics import *  # noqa: F401,F403
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.rule_based_profiler.data_assistant.data_profiler_structured_data_assistant import (  # noqa: F401,F403  # registers this DataAssistant and prevents removal of "unused" import
-    DataProfilerStructuredDataAssistant,
-)
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.rule_based_profiler.data_assistant_result import (
-    DataProfilerStructuredDataAssistantResult,
-)
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.domain import Domain
 from great_expectations.core.metric_domain_types import MetricDomainTypes
@@ -24,6 +17,14 @@ from great_expectations.rule_based_profiler.data_assistant_result import (
 from great_expectations.rule_based_profiler.parameter_container import (
     FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY,
     ParameterNode,
+)
+
+from ....metrics import *  # noqa: F401,F403
+from ....rule_based_profiler.data_assistant.data_profiler_structured_data_assistant import (  # noqa: F401,F403  # registers this DataAssistant and prevents removal of "unused" import
+    DataProfilerStructuredDataAssistant,
+)
+from ....rule_based_profiler.data_assistant_result import (
+    DataProfilerStructuredDataAssistantResult,
 )
 
 if TYPE_CHECKING:

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
@@ -6,10 +6,6 @@ from unittest import mock
 
 import pytest
 
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.metrics import *  # noqa: F401,F403
-from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.rule_based_profiler.domain_builder.data_profiler_column_domain_builder import (
-    DataProfilerColumnDomainBuilder,
-)
 from great_expectations.core.domain import (
     INFERRED_SEMANTIC_TYPE_KEY,
     Domain,
@@ -24,8 +20,13 @@ from great_expectations.rule_based_profiler.parameter_container import (
     build_parameter_container_for_variables,
 )
 
+from ....metrics import *  # noqa: F401,F403
+from ....rule_based_profiler.domain_builder.data_profiler_column_domain_builder import (
+    DataProfilerColumnDomainBuilder,
+)
+
 if TYPE_CHECKING:
-    from contrib.capitalone_dataprofiler_expectations.capitalone_dataprofiler_expectations.tests.conftest import (
+    from ...conftest import (
         BaseProfiler,
     )
 

--- a/docs/expectation_gallery/azure-pipelines-expectation-gallery.yml
+++ b/docs/expectation_gallery/azure-pipelines-expectation-gallery.yml
@@ -88,11 +88,11 @@ stages:
           python.version: '3.8'
           GE_pytest_opts: ''
 
-#       services:
-#         postgres: postgres
-#         mysql: mysql
-#         mssql: mssql
-#         trino: trino
+        services:
+          postgres: postgres
+          mysql: mysql
+          mssql: mssql
+          trino: trino
 
         steps:
           - task: UsePythonVersion@0
@@ -105,178 +105,176 @@ stages:
 
           - script: |
               pip install \
-                dataprofiler scikit-learn tensorflow \
+                "google-cloud-bigquery-storage" \
                 "cryptography==38.0.4" \
-                --editable ".[spark]" \
+                --requirement reqs/requirements-dev-all-contrib-expectations.txt \
+                --editable "contrib/cli" \
+                --editable ".[dev]" \
                 --constraint constraints-dev.txt
             displayName: 'Install dependencies'
 
-#         - script: |
-#             printf 'Waiting for MySQL database to accept connections'
-#             until mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --execute "SHOW DATABASES"; do
-#               printf '.'
-#               sleep 1;
-#             done;
-#           displayName: 'Wait for MySQL database to initialise'
-#
-#         - script: |
-#             echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" > mysql_setup_script.sql
-#             mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < mysql_setup_script.sql
-#           displayName: 'Configure mysql'
-#
-#         - script: |
-#             sqlcmd -U sa -P "ReallyStrongPwd1234%^&*" -Q "CREATE DATABASE test_ci;" -o create_db_output.txt
-#           displayName: 'Configure mssql'
-#
-#         - script: |
-#             printf 'Waiting for Trino database to accept connections'
-#             sleep 30
+          - script: |
+              printf 'Waiting for MySQL database to accept connections'
+              until mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --execute "SHOW DATABASES"; do
+                printf '.'
+                sleep 1;
+              done;
+            displayName: 'Wait for MySQL database to initialise'
+
+          - script: |
+              echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" > mysql_setup_script.sql
+              mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < mysql_setup_script.sql
+            displayName: 'Configure mysql'
+
+          - script: |
+              sqlcmd -U sa -P "ReallyStrongPwd1234%^&*" -Q "CREATE DATABASE test_ci;" -o create_db_output.txt
+            displayName: 'Configure mssql'
+
+          - script: |
+              printf 'Waiting for Trino database to accept connections'
+              sleep 30
 #             until trino --execute "SHOW CATALOGS"; do
 #               printf '.'
 #               sleep 1;
 #             done;
-#           displayName: 'Wait for Trino database to initialise'
-#
-#         - task: DownloadSecureFile@1
-#           name: gcp_authkey
-#           displayName: 'Download Google Service Account'
-#           inputs:
-#             secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
-#             retryCount: '2'
+            displayName: 'Wait for Trino database to initialise'
 
-          - bash: python ./build_gallery.py --backends "pandas" expect_column_values_confidence_for_data_label_to_be_greater_than_or_equal_to_threshold expect_column_values_confidence_for_data_label_to_be_less_than_or_equal_to_threshold expect_column_values_to_be_equal_to_or_greater_than_profile_min expect_column_values_to_be_equal_to_or_less_than_profile_max expect_column_values_to_be_probabilistically_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_between_exclusive_threshold_range expect_profile_numeric_columns_diff_between_inclusive_threshold_range expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_greater_than_threshold expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_diff_less_than_threshold expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_greater_than_threshold expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_less_than_threshold ; touch gallery-tracebacks.txt ; cat gallery-tracebacks.txt ; echo -e "\n\n\n\n\n" ; cat checklists.txt
+          - task: DownloadSecureFile@1
+            name: gcp_authkey
+            displayName: 'Download Google Service Account'
+            inputs:
+              secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
+              retryCount: '2'
+
+          - bash: python ./build_gallery.py --backends "pandas" --outfile-name "quick_check.json" ; exp_count=$(grep "^ *\"expect_" quick_check.json | wc -l); package_summary=$(grep "\"package\":" quick_check.json | sort | uniq -c | sort -nr) ; touch gallery-tracebacks.txt; cat gallery-tracebacks.txt ; echo -e "\n\n$exp_count Expectations in quick_check.json\n";  echo -e "$package_summary"; [[ $exp_count -lt 297 ]] && echo "Fewer than 297 Expectations" && exit 1 ; [[ $(echo -e "$package_summary" | wc -l) -lt 6 ]] && echo "Fewer than 6 packages" && exit 1 ; echo "ok"
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Temp capone stuff only'
+            displayName: 'Build Gallery Quick Check'
 
-#         - bash: python ./build_gallery.py --backends "pandas" --outfile-name "quick_check.json" ; exp_count=$(grep "^ *\"expect_" quick_check.json | wc -l); package_summary=$(grep "\"package\":" quick_check.json | sort | uniq -c | sort -nr) ; touch gallery-tracebacks.txt; cat gallery-tracebacks.txt ; echo -e "\n\n$exp_count Expectations in quick_check.json\n";  echo -e "$package_summary"; [[ $exp_count -lt 297 ]] && echo "Fewer than 297 Expectations" && exit 1 ; [[ $(echo -e "$package_summary" | wc -l) -lt 6 ]] && echo "Fewer than 6 packages" && exit 1 ; echo "ok"
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Build Gallery Quick Check'
-#
-#         - bash: python ./build_gallery.py --outfile-name "expectation_library_v2--staging.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Build Gallery'
-#           env:
-#             # snowflake credentials
-#             SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
-#             SNOWFLAKE_USER: $(SNOWFLAKE_USER)
-#             SNOWFLAKE_PW: $(SNOWFLAKE_PW)
-#             SNOWFLAKE_DATABASE: $(SNOWFLAKE_DATABASE)
-#             SNOWFLAKE_SCHEMA: $(SNOWFLAKE_SCHEMA)
-#             SNOWFLAKE_WAREHOUSE: $(SNOWFLAKE_WAREHOUSE)
-#             SNOWFLAKE_ROLE: $(SNOWFLAKE_ROLE)
-#             # redshift credentials
-#             REDSHIFT_USERNAME: $(REDSHIFT_USERNAME)
-#             REDSHIFT_PASSWORD: $(REDSHIFT_PASSWORD)
-#             REDSHIFT_HOST: $(REDSHIFT_HOST)
-#             REDSHIFT_PORT: $(REDSHIFT_PORT)
-#             REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
-#             REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
-#             # AWS credentials
-#             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-#             AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-#             AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
-#             ATHENA_DB_NAME: $(ATHENA_DB_NAME)
-#             ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
-#             ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)
-#             ATHENA_TEN_TRIPS_DB_NAME: $(ATHENA_TEN_TRIPS_DB_NAME)
-#             # GCP credentials
-#             GOOGLE_APPLICATION_CREDENTIALS: $(gcp_authkey.secureFilePath)
-#             GE_TEST_GCP_PROJECT: $(GE_TEST_GCP_PROJECT)
-#             GE_TEST_BIGQUERY_DATASET: $(GE_TEST_BIGQUERY_DATASET)
-#             # Azure credentials
-#             AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
-#             AZURE_ACCESS_KEY: $(AZURE_ACCESS_KEY)
-#
-#         - bash: grep -o "coverage_score:.*" output--build_gallery.txt | sort -k2,2nr
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show coverage scores'
-#
-#         - bash: cut -d " " -f 3,4 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,4,6 gallery-exp-types.txt | sort
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show Expectation types and counts'
-#
-#         - bash: grep -o "Implemented engines.*" output--build_gallery.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show implemented engines'
-#
-#         - bash: cat checklists.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show full checklist summary'
-#
-#         - bash: grep -E "(^expect|Completeness checklist|^ *[A-z]|^ *-|-----)" checklists.txt | grep -vE '(No validate_configuration|Using default validate_configuration|Has a full suite|Has passed a manual)'
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show checklist issues'
-#
-#         - bash: cat testing-error-messages.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show testing errors'
-#
-#         - bash: grep --color -n -i warning -B 2 output--build_gallery.txt || echo "No warnings found"
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show testing warnings'
-#
-#         - bash: cat gallery-tracebacks.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show gallery tracebacks'
-#
-#         - bash: grep "to df.to_sql" testing-times.txt || echo "No df.to_sql calls were made"
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show DataFrame to SQL times'
-#
-#         - bash: grep "to run" testing-times.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show testing times grouped by backend and Expectation'
-#
-#         - bash: grep "to evaluate_json" testing-times.txt
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Show testing times for individual tests'
-#
-#         - bash: python ./build_package_gallery.py
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Build Package Gallery'
-#
-#         - task: S3Upload@1
-#           inputs:
-#             regionName: 'us-east-2'
-#             awsCredentials: 'aws-ci-great-expectations'
-#             bucketName: 'superconductive-public'
-#             sourceFolder: '$(Build.SourcesDirectory)/assets/scripts'
-#             globExpressions: '*.json'
-#             targetFolder: 'static/gallery/'
-#             filesAcl: 'public-read'
-#
-#         - task: NodeTool@0
-#           inputs:
-#             versionSpec: '16.16'
-#
-#         - bash: bash ./trigger_algolia.sh
-#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-#           displayName: 'Update Algolia indexes from S3'
-#           env:
-#             # algolia credentials
-#             ALGOLIA_ACCOUNT: $(ALGOLIA_ACCOUNT)
-#             ALGOLIA_EXPECTATION_INDEX: $(ALGOLIA_EXPECTATION_INDEX)
-#             ALGOLIA_PACKAGE_EXPEC_INDEX: $(ALGOLIA_PACKAGE_EXPEC_INDEX)
-#             ALGOLIA_PACKAGE_INDEX: $(ALGOLIA_PACKAGE_INDEX)
-#             ALGOLIA_WRITE_KEY: $(ALGOLIA_WRITE_KEY)
-#             # Build Gallery Paths
-#             ALGOLIA_S3_PACKAGES_URL: $(ALGOLIA_S3_PACKAGES_URL)
-#             ALGOLIA_S3_EXPECTATIONS_URL: $(ALGOLIA_S3_EXPECTATIONS_URL)
-#             # replica indices from expectations for sorting
-#             ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX)
-#             ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX)
-#             # replica indices from package expectations for sorting
-#             ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX)
-#             ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX)
-#             ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
-#             ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
-#
+          - bash: python ./build_gallery.py --outfile-name "expectation_library_v2--staging.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Build Gallery'
+            env:
+              # snowflake credentials
+              SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
+              SNOWFLAKE_USER: $(SNOWFLAKE_USER)
+              SNOWFLAKE_PW: $(SNOWFLAKE_PW)
+              SNOWFLAKE_DATABASE: $(SNOWFLAKE_DATABASE)
+              SNOWFLAKE_SCHEMA: $(SNOWFLAKE_SCHEMA)
+              SNOWFLAKE_WAREHOUSE: $(SNOWFLAKE_WAREHOUSE)
+              SNOWFLAKE_ROLE: $(SNOWFLAKE_ROLE)
+              # redshift credentials
+              REDSHIFT_USERNAME: $(REDSHIFT_USERNAME)
+              REDSHIFT_PASSWORD: $(REDSHIFT_PASSWORD)
+              REDSHIFT_HOST: $(REDSHIFT_HOST)
+              REDSHIFT_PORT: $(REDSHIFT_PORT)
+              REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
+              REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
+              # AWS credentials
+              AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+              AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+              AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
+              ATHENA_DB_NAME: $(ATHENA_DB_NAME)
+              ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
+              ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)
+              ATHENA_TEN_TRIPS_DB_NAME: $(ATHENA_TEN_TRIPS_DB_NAME)
+              # GCP credentials
+              GOOGLE_APPLICATION_CREDENTIALS: $(gcp_authkey.secureFilePath)
+              GE_TEST_GCP_PROJECT: $(GE_TEST_GCP_PROJECT)
+              GE_TEST_BIGQUERY_DATASET: $(GE_TEST_BIGQUERY_DATASET)
+              # Azure credentials
+              AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
+              AZURE_ACCESS_KEY: $(AZURE_ACCESS_KEY)
+
+          - bash: grep -o "coverage_score:.*" output--build_gallery.txt | sort -k2,2nr
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show coverage scores'
+
+          - bash: cut -d " " -f 3,4 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,4,6 gallery-exp-types.txt | sort
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show Expectation types and counts'
+
+          - bash: grep -o "Implemented engines.*" output--build_gallery.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show implemented engines'
+
+          - bash: cat checklists.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show full checklist summary'
+
+          - bash: grep -E "(^expect|Completeness checklist|^ *[A-z]|^ *-|-----)" checklists.txt | grep -vE '(No validate_configuration|Using default validate_configuration|Has a full suite|Has passed a manual)'
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show checklist issues'
+
+          - bash: cat testing-error-messages.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show testing errors'
+
+          - bash: grep --color -n -i warning -B 2 output--build_gallery.txt || echo "No warnings found"
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show testing warnings'
+
+          - bash: cat gallery-tracebacks.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show gallery tracebacks'
+
+          - bash: grep "to df.to_sql" testing-times.txt || echo "No df.to_sql calls were made"
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show DataFrame to SQL times'
+
+          - bash: grep "to run" testing-times.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show testing times grouped by backend and Expectation'
+
+          - bash: grep "to evaluate_json" testing-times.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show testing times for individual tests'
+
+          - bash: python ./build_package_gallery.py
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Build Package Gallery'
+
+          - task: S3Upload@1
+            inputs:
+              regionName: 'us-east-2'
+              awsCredentials: 'aws-ci-great-expectations'
+              bucketName: 'superconductive-public'
+              sourceFolder: '$(Build.SourcesDirectory)/assets/scripts'
+              globExpressions: '*.json'
+              targetFolder: 'static/gallery/'
+              filesAcl: 'public-read'
+
+          - task: NodeTool@0
+            inputs:
+              versionSpec: '16.16'
+
+          - bash: bash ./trigger_algolia.sh
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Update Algolia indexes from S3'
+            env:
+              # algolia credentials
+              ALGOLIA_ACCOUNT: $(ALGOLIA_ACCOUNT)
+              ALGOLIA_EXPECTATION_INDEX: $(ALGOLIA_EXPECTATION_INDEX)
+              ALGOLIA_PACKAGE_EXPEC_INDEX: $(ALGOLIA_PACKAGE_EXPEC_INDEX)
+              ALGOLIA_PACKAGE_INDEX: $(ALGOLIA_PACKAGE_INDEX)
+              ALGOLIA_WRITE_KEY: $(ALGOLIA_WRITE_KEY)
+              # Build Gallery Paths
+              ALGOLIA_S3_PACKAGES_URL: $(ALGOLIA_S3_PACKAGES_URL)
+              ALGOLIA_S3_EXPECTATIONS_URL: $(ALGOLIA_S3_EXPECTATIONS_URL)
+              # replica indices from expectations for sorting
+              ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX)
+              ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX)
+              # replica indices from package expectations for sorting
+              ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX)
+              ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX)
+              ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
+              ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
+
 #         - bash: |
 #             echo "About to trigger webhook: $GALLERY_BUILD_HOOK"
 #             curl -X POST -d {} $GALLERY_BUILD_HOOK

--- a/docs/expectation_gallery/azure-pipelines-expectation-gallery.yml
+++ b/docs/expectation_gallery/azure-pipelines-expectation-gallery.yml
@@ -88,11 +88,11 @@ stages:
           python.version: '3.8'
           GE_pytest_opts: ''
 
-        services:
-          postgres: postgres
-          mysql: mysql
-          mssql: mssql
-          trino: trino
+#       services:
+#         postgres: postgres
+#         mysql: mysql
+#         mssql: mssql
+#         trino: trino
 
         steps:
           - task: UsePythonVersion@0
@@ -105,176 +105,178 @@ stages:
 
           - script: |
               pip install \
-                "google-cloud-bigquery-storage" \
+                dataprofiler scikit-learn tensorflow \
                 "cryptography==38.0.4" \
-                --requirement reqs/requirements-dev-all-contrib-expectations.txt \
-                --editable "contrib/cli" \
-                --editable ".[dev]" \
+                --editable ".[spark]" \
                 --constraint constraints-dev.txt
             displayName: 'Install dependencies'
 
-          - script: |
-              printf 'Waiting for MySQL database to accept connections'
-              until mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --execute "SHOW DATABASES"; do
-                printf '.'
-                sleep 1;
-              done;
-            displayName: 'Wait for MySQL database to initialise'
-
-          - script: |
-              echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" > mysql_setup_script.sql
-              mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < mysql_setup_script.sql
-            displayName: 'Configure mysql'
-
-          - script: |
-              sqlcmd -U sa -P "ReallyStrongPwd1234%^&*" -Q "CREATE DATABASE test_ci;" -o create_db_output.txt
-            displayName: 'Configure mssql'
-
-          - script: |
-              printf 'Waiting for Trino database to accept connections'
-              sleep 30
+#         - script: |
+#             printf 'Waiting for MySQL database to accept connections'
+#             until mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --execute "SHOW DATABASES"; do
+#               printf '.'
+#               sleep 1;
+#             done;
+#           displayName: 'Wait for MySQL database to initialise'
+#
+#         - script: |
+#             echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" > mysql_setup_script.sql
+#             mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < mysql_setup_script.sql
+#           displayName: 'Configure mysql'
+#
+#         - script: |
+#             sqlcmd -U sa -P "ReallyStrongPwd1234%^&*" -Q "CREATE DATABASE test_ci;" -o create_db_output.txt
+#           displayName: 'Configure mssql'
+#
+#         - script: |
+#             printf 'Waiting for Trino database to accept connections'
+#             sleep 30
 #             until trino --execute "SHOW CATALOGS"; do
 #               printf '.'
 #               sleep 1;
 #             done;
-            displayName: 'Wait for Trino database to initialise'
+#           displayName: 'Wait for Trino database to initialise'
+#
+#         - task: DownloadSecureFile@1
+#           name: gcp_authkey
+#           displayName: 'Download Google Service Account'
+#           inputs:
+#             secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
+#             retryCount: '2'
 
-          - task: DownloadSecureFile@1
-            name: gcp_authkey
-            displayName: 'Download Google Service Account'
-            inputs:
-              secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
-              retryCount: '2'
-
-          - bash: python ./build_gallery.py --backends "pandas" --outfile-name "quick_check.json" ; exp_count=$(grep "^ *\"expect_" quick_check.json | wc -l); package_summary=$(grep "\"package\":" quick_check.json | sort | uniq -c | sort -nr) ; touch gallery-tracebacks.txt; cat gallery-tracebacks.txt ; echo -e "\n\n$exp_count Expectations in quick_check.json\n";  echo -e "$package_summary"; [[ $exp_count -lt 297 ]] && echo "Fewer than 297 Expectations" && exit 1 ; [[ $(echo -e "$package_summary" | wc -l) -lt 6 ]] && echo "Fewer than 6 packages" && exit 1 ; echo "ok"
+          - bash: python ./build_gallery.py --backends "pandas" expect_column_values_confidence_for_data_label_to_be_greater_than_or_equal_to_threshold expect_column_values_confidence_for_data_label_to_be_less_than_or_equal_to_threshold expect_column_values_to_be_equal_to_or_greater_than_profile_min expect_column_values_to_be_equal_to_or_less_than_profile_max expect_column_values_to_be_probabilistically_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_between_exclusive_threshold_range expect_profile_numeric_columns_diff_between_inclusive_threshold_range expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_greater_than_threshold expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_diff_less_than_threshold expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_greater_than_threshold expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_less_than_threshold ; touch gallery-tracebacks.txt ; cat gallery-tracebacks.txt ; echo -e "\n\n\n\n\n" ; cat checklists.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Build Gallery Quick Check'
+            displayName: 'Temp capone stuff only'
 
-          - bash: python ./build_gallery.py --outfile-name "expectation_library_v2--staging.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Build Gallery'
-            env:
-              # snowflake credentials
-              SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
-              SNOWFLAKE_USER: $(SNOWFLAKE_USER)
-              SNOWFLAKE_PW: $(SNOWFLAKE_PW)
-              SNOWFLAKE_DATABASE: $(SNOWFLAKE_DATABASE)
-              SNOWFLAKE_SCHEMA: $(SNOWFLAKE_SCHEMA)
-              SNOWFLAKE_WAREHOUSE: $(SNOWFLAKE_WAREHOUSE)
-              SNOWFLAKE_ROLE: $(SNOWFLAKE_ROLE)
-              # redshift credentials
-              REDSHIFT_USERNAME: $(REDSHIFT_USERNAME)
-              REDSHIFT_PASSWORD: $(REDSHIFT_PASSWORD)
-              REDSHIFT_HOST: $(REDSHIFT_HOST)
-              REDSHIFT_PORT: $(REDSHIFT_PORT)
-              REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
-              REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
-              # AWS credentials
-              AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-              AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-              AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
-              ATHENA_DB_NAME: $(ATHENA_DB_NAME)
-              ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
-              ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)
-              ATHENA_TEN_TRIPS_DB_NAME: $(ATHENA_TEN_TRIPS_DB_NAME)
-              # GCP credentials
-              GOOGLE_APPLICATION_CREDENTIALS: $(gcp_authkey.secureFilePath)
-              GE_TEST_GCP_PROJECT: $(GE_TEST_GCP_PROJECT)
-              GE_TEST_BIGQUERY_DATASET: $(GE_TEST_BIGQUERY_DATASET)
-              # Azure credentials
-              AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
-              AZURE_ACCESS_KEY: $(AZURE_ACCESS_KEY)
-
-          - bash: grep -o "coverage_score:.*" output--build_gallery.txt | sort -k2,2nr
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show coverage scores'
-
-          - bash: cut -d " " -f 3,4 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,4,6 gallery-exp-types.txt | sort
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show Expectation types and counts'
-
-          - bash: grep -o "Implemented engines.*" output--build_gallery.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show implemented engines'
-
-          - bash: cat checklists.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show full checklist summary'
-
-          - bash: grep -E "(^expect|Completeness checklist|^ *[A-z]|^ *-|-----)" checklists.txt | grep -vE '(No validate_configuration|Using default validate_configuration|Has a full suite|Has passed a manual)'
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show checklist issues'
-
-          - bash: cat testing-error-messages.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show testing errors'
-
-          - bash: grep --color -n -i warning -B 2 output--build_gallery.txt || echo "No warnings found"
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show testing warnings'
-
-          - bash: cat gallery-tracebacks.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show gallery tracebacks'
-
-          - bash: grep "to df.to_sql" testing-times.txt || echo "No df.to_sql calls were made"
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show DataFrame to SQL times'
-
-          - bash: grep "to run" testing-times.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show testing times grouped by backend and Expectation'
-
-          - bash: grep "to evaluate_json" testing-times.txt
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show testing times for individual tests'
-
-          - bash: python ./build_package_gallery.py
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Build Package Gallery'
-
-          - task: S3Upload@1
-            inputs:
-              regionName: 'us-east-2'
-              awsCredentials: 'aws-ci-great-expectations'
-              bucketName: 'superconductive-public'
-              sourceFolder: '$(Build.SourcesDirectory)/assets/scripts'
-              globExpressions: '*.json'
-              targetFolder: 'static/gallery/'
-              filesAcl: 'public-read'
-
-          - task: NodeTool@0
-            inputs:
-              versionSpec: '16.16'
-
-          - bash: bash ./trigger_algolia.sh
-            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Update Algolia indexes from S3'
-            env:
-              # algolia credentials
-              ALGOLIA_ACCOUNT: $(ALGOLIA_ACCOUNT)
-              ALGOLIA_EXPECTATION_INDEX: $(ALGOLIA_EXPECTATION_INDEX)
-              ALGOLIA_PACKAGE_EXPEC_INDEX: $(ALGOLIA_PACKAGE_EXPEC_INDEX)
-              ALGOLIA_PACKAGE_INDEX: $(ALGOLIA_PACKAGE_INDEX)
-              ALGOLIA_WRITE_KEY: $(ALGOLIA_WRITE_KEY)
-              # Build Gallery Paths
-              ALGOLIA_S3_PACKAGES_URL: $(ALGOLIA_S3_PACKAGES_URL)
-              ALGOLIA_S3_EXPECTATIONS_URL: $(ALGOLIA_S3_EXPECTATIONS_URL)
-              # replica indices from expectations for sorting
-              ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX)
-              ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX)
-              # replica indices from package expectations for sorting
-              ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX)
-              ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX)
-              ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
-              ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
-
+#         - bash: python ./build_gallery.py --backends "pandas" --outfile-name "quick_check.json" ; exp_count=$(grep "^ *\"expect_" quick_check.json | wc -l); package_summary=$(grep "\"package\":" quick_check.json | sort | uniq -c | sort -nr) ; touch gallery-tracebacks.txt; cat gallery-tracebacks.txt ; echo -e "\n\n$exp_count Expectations in quick_check.json\n";  echo -e "$package_summary"; [[ $exp_count -lt 297 ]] && echo "Fewer than 297 Expectations" && exit 1 ; [[ $(echo -e "$package_summary" | wc -l) -lt 6 ]] && echo "Fewer than 6 packages" && exit 1 ; echo "ok"
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Build Gallery Quick Check'
+#
+#         - bash: python ./build_gallery.py --outfile-name "expectation_library_v2--staging.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Build Gallery'
+#           env:
+#             # snowflake credentials
+#             SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)
+#             SNOWFLAKE_USER: $(SNOWFLAKE_USER)
+#             SNOWFLAKE_PW: $(SNOWFLAKE_PW)
+#             SNOWFLAKE_DATABASE: $(SNOWFLAKE_DATABASE)
+#             SNOWFLAKE_SCHEMA: $(SNOWFLAKE_SCHEMA)
+#             SNOWFLAKE_WAREHOUSE: $(SNOWFLAKE_WAREHOUSE)
+#             SNOWFLAKE_ROLE: $(SNOWFLAKE_ROLE)
+#             # redshift credentials
+#             REDSHIFT_USERNAME: $(REDSHIFT_USERNAME)
+#             REDSHIFT_PASSWORD: $(REDSHIFT_PASSWORD)
+#             REDSHIFT_HOST: $(REDSHIFT_HOST)
+#             REDSHIFT_PORT: $(REDSHIFT_PORT)
+#             REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
+#             REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
+#             # AWS credentials
+#             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+#             AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+#             AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
+#             ATHENA_DB_NAME: $(ATHENA_DB_NAME)
+#             ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
+#             ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)
+#             ATHENA_TEN_TRIPS_DB_NAME: $(ATHENA_TEN_TRIPS_DB_NAME)
+#             # GCP credentials
+#             GOOGLE_APPLICATION_CREDENTIALS: $(gcp_authkey.secureFilePath)
+#             GE_TEST_GCP_PROJECT: $(GE_TEST_GCP_PROJECT)
+#             GE_TEST_BIGQUERY_DATASET: $(GE_TEST_BIGQUERY_DATASET)
+#             # Azure credentials
+#             AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
+#             AZURE_ACCESS_KEY: $(AZURE_ACCESS_KEY)
+#
+#         - bash: grep -o "coverage_score:.*" output--build_gallery.txt | sort -k2,2nr
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show coverage scores'
+#
+#         - bash: cut -d " " -f 3,4 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,4,6 gallery-exp-types.txt | sort
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show Expectation types and counts'
+#
+#         - bash: grep -o "Implemented engines.*" output--build_gallery.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show implemented engines'
+#
+#         - bash: cat checklists.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show full checklist summary'
+#
+#         - bash: grep -E "(^expect|Completeness checklist|^ *[A-z]|^ *-|-----)" checklists.txt | grep -vE '(No validate_configuration|Using default validate_configuration|Has a full suite|Has passed a manual)'
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show checklist issues'
+#
+#         - bash: cat testing-error-messages.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show testing errors'
+#
+#         - bash: grep --color -n -i warning -B 2 output--build_gallery.txt || echo "No warnings found"
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show testing warnings'
+#
+#         - bash: cat gallery-tracebacks.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show gallery tracebacks'
+#
+#         - bash: grep "to df.to_sql" testing-times.txt || echo "No df.to_sql calls were made"
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show DataFrame to SQL times'
+#
+#         - bash: grep "to run" testing-times.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show testing times grouped by backend and Expectation'
+#
+#         - bash: grep "to evaluate_json" testing-times.txt
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Show testing times for individual tests'
+#
+#         - bash: python ./build_package_gallery.py
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Build Package Gallery'
+#
+#         - task: S3Upload@1
+#           inputs:
+#             regionName: 'us-east-2'
+#             awsCredentials: 'aws-ci-great-expectations'
+#             bucketName: 'superconductive-public'
+#             sourceFolder: '$(Build.SourcesDirectory)/assets/scripts'
+#             globExpressions: '*.json'
+#             targetFolder: 'static/gallery/'
+#             filesAcl: 'public-read'
+#
+#         - task: NodeTool@0
+#           inputs:
+#             versionSpec: '16.16'
+#
+#         - bash: bash ./trigger_algolia.sh
+#           workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+#           displayName: 'Update Algolia indexes from S3'
+#           env:
+#             # algolia credentials
+#             ALGOLIA_ACCOUNT: $(ALGOLIA_ACCOUNT)
+#             ALGOLIA_EXPECTATION_INDEX: $(ALGOLIA_EXPECTATION_INDEX)
+#             ALGOLIA_PACKAGE_EXPEC_INDEX: $(ALGOLIA_PACKAGE_EXPEC_INDEX)
+#             ALGOLIA_PACKAGE_INDEX: $(ALGOLIA_PACKAGE_INDEX)
+#             ALGOLIA_WRITE_KEY: $(ALGOLIA_WRITE_KEY)
+#             # Build Gallery Paths
+#             ALGOLIA_S3_PACKAGES_URL: $(ALGOLIA_S3_PACKAGES_URL)
+#             ALGOLIA_S3_EXPECTATIONS_URL: $(ALGOLIA_S3_EXPECTATIONS_URL)
+#             # replica indices from expectations for sorting
+#             ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_ASC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_ALPHA_DSC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_ASC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_CREATED_DSC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_ASC_INDEX)
+#             ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX: $(ALGOLIA_EXPEC_REPLICA_UPDATED_DSC_INDEX)
+#             # replica indices from package expectations for sorting
+#             ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_ASC_INDEX)
+#             ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_ALPHA_DSC_INDEX)
+#             ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_ASC_INDEX)
+#             ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX: $(ALGOLIA_PACK_EXPEC_REPLICA_COVERAGE_DSC_INDEX)
+#
 #         - bash: |
 #             echo "About to trigger webhook: $GALLERY_BUILD_HOOK"
 #             curl -X POST -d {} $GALLERY_BUILD_HOOK

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -125,7 +125,7 @@ if TYPE_CHECKING:
     import sqlalchemy  # noqa: TID251
 
 
-def get_table_columns_metric(engine: ExecutionEngine) -> [MetricConfiguration, dict]:  # type: ignore[valid-type]
+def get_table_columns_metric(engine: ExecutionEngine) -> tuple[MetricConfiguration, dict]:
     resolved_metrics: dict = {}
 
     results: dict

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -125,7 +125,7 @@ if TYPE_CHECKING:
     import sqlalchemy  # noqa: TID251
 
 
-def get_table_columns_metric(engine: ExecutionEngine) -> [MetricConfiguration, dict]:
+def get_table_columns_metric(engine: ExecutionEngine) -> [MetricConfiguration, dict]:  # type: ignore[valid-type]
     resolved_metrics: dict = {}
 
     results: dict

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -125,7 +125,9 @@ if TYPE_CHECKING:
     import sqlalchemy  # noqa: TID251
 
 
-def get_table_columns_metric(engine: ExecutionEngine) -> tuple[MetricConfiguration, dict]:
+def get_table_columns_metric(
+    engine: ExecutionEngine,
+) -> tuple[MetricConfiguration, dict]:
     resolved_metrics: dict = {}
 
     results: dict

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -147,7 +147,7 @@ def get_table_columns_metric(
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
-    table_columns_metric.metric_dependencies = {
+    table_columns_metric.metric_dependencies = {  # type: ignore[assignment]
         "table.column_types": table_column_types_metric,
     }
     results = engine.resolve_metrics(

--- a/tests/datasource/fluent/integration/integration_test_utils.py
+++ b/tests/datasource/fluent/integration/integration_test_utils.py
@@ -17,6 +17,7 @@ from great_expectations.datasource.fluent.interfaces import (
     HeadData,
 )
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.render import (
     AtomicDiagnosticRendererType,
     AtomicPrescriptiveRendererType,
@@ -27,7 +28,6 @@ from great_expectations.rule_based_profiler.data_assistant_result import (
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
 from great_expectations.validator.metrics_calculator import MetricsCalculator
-from tests.expectations.test_util import get_table_columns_metric
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch

--- a/tests/execution_engine/test_execution_engine.py
+++ b/tests/execution_engine/test_execution_engine.py
@@ -10,6 +10,7 @@ from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.expectations.row_conditions import (
     RowCondition,
     RowConditionParserType,
@@ -18,7 +19,6 @@ from great_expectations.expectations.row_conditions import (
 # Testing ordinary process of adding column row condition
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 
 
 @pytest.fixture

--- a/tests/execution_engine/test_pandas_execution_engine.py
+++ b/tests/execution_engine/test_pandas_execution_engine.py
@@ -7,6 +7,7 @@ import pytest
 
 # noinspection PyBroadException
 from great_expectations.core.metric_domain_types import MetricDomainTypes
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.optional_imports import google_cloud_storage
 import great_expectations.exceptions as gx_exceptions
@@ -16,7 +17,6 @@ from great_expectations.execution_engine.pandas_execution_engine import (
 )
 from great_expectations.util import is_library_loadable
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 
 
 def test_constructor_with_boto3_options():

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -11,6 +11,7 @@ from great_expectations.core.batch_spec import PathBatchSpec, RuntimeDataBatchSp
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
 from great_expectations.execution_engine import SparkDFExecutionEngine
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.expectations.row_conditions import (
     RowCondition,
     RowConditionParserType,
@@ -18,7 +19,6 @@ from great_expectations.expectations.row_conditions import (
 from great_expectations.self_check.util import build_spark_engine
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 from tests.test_utils import create_files_in_directory
 from great_expectations.optional_imports import F, sparktypes, pyspark_sql_Row
 

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -24,6 +24,7 @@ from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
 from great_expectations.execution_engine.sqlalchemy_execution_engine import (
     SqlAlchemyExecutionEngine,
 )
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 
 # Function to test for spark dataframe equality
 from great_expectations.expectations.row_conditions import (
@@ -39,7 +40,6 @@ from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
 from great_expectations.validator.validator import Validator
-from tests.expectations.test_util import get_table_columns_metric
 from tests.test_utils import get_sqlite_table_names, get_sqlite_temp_table_names
 
 try:

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -13,6 +13,7 @@ from great_expectations.execution_engine import (
     SqlAlchemyExecutionEngine,
     SparkDFExecutionEngine,
 )
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.self_check.util import (
     build_pandas_engine,
     build_sa_engine,
@@ -20,7 +21,6 @@ from great_expectations.self_check.util import (
 )
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 
 
 @pytest.fixture

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -22,6 +22,7 @@ from great_expectations.execution_engine.sqlalchemy_execution_engine import (
     SqlAlchemyBatchData,
     SqlAlchemyExecutionEngine,
 )
+from great_expectations.expectations.metrics.util import get_table_columns_metric
 from great_expectations.optional_imports import pyspark_sql_Column, quoted_name
 from great_expectations.expectations.metrics.util import (
     get_dbms_compatible_column_names,
@@ -35,7 +36,6 @@ from great_expectations.self_check.util import (
 from great_expectations.util import isclose
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from tests.expectations.test_util import get_table_columns_metric
 
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,

--- a/tests/expectations/test_util.py
+++ b/tests/expectations/test_util.py
@@ -19,7 +19,6 @@ from great_expectations.core.expectation_diagnostics.supporting_types import (
 )
 from great_expectations.exceptions import GreatExpectationsError
 from great_expectations.execution_engine import (
-    ExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
 from great_expectations.expectations.expectation import (
@@ -56,37 +55,6 @@ except ImportError:
     Select = None
     SQLAlchemyError = None
     logger.debug("Unable to load SqlAlchemy or one of its subclasses.")
-
-
-def get_table_columns_metric(engine: ExecutionEngine) -> [MetricConfiguration, dict]:
-    resolved_metrics: dict = {}
-
-    results: dict
-
-    table_column_types_metric: MetricConfiguration = MetricConfiguration(
-        metric_name="table.column_types",
-        metric_domain_kwargs={},
-        metric_value_kwargs={
-            "include_nested": True,
-        },
-    )
-    results = engine.resolve_metrics(metrics_to_resolve=(table_column_types_metric,))
-    resolved_metrics.update(results)
-
-    table_columns_metric: MetricConfiguration = MetricConfiguration(
-        metric_name="table.columns",
-        metric_domain_kwargs={},
-        metric_value_kwargs=None,
-    )
-    table_columns_metric.metric_dependencies = {
-        "table.column_types": table_column_types_metric,
-    }
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(table_columns_metric,), metrics=resolved_metrics
-    )
-    resolved_metrics.update(results)
-
-    return table_columns_metric, resolved_metrics
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Fixes all the capitalone_dataprofiler_expectations that fail on import with `ModuleNotFoundError: No module named 'contrib'`

Changes proposed in this pull request:
- Move get_table_columns_metric func to great_expectations.expectations.metrics.util
- Use relative imports in capitalone_dataprofiler_expectations

Tested with

```
pytest -vv contrib/capitalone_dataprofiler_expectations

build-gallery --backends "pandas" expect_column_values_confidence_for_data_label_to_be_greater_than_or_equal_to_threshold expect_column_values_confidence_for_data_label_to_be_less_than_or_equal_to_threshold expect_column_values_to_be_equal_to_or_greater_than_profile_min expect_column_values_to_be_equal_to_or_less_than_profile_max expect_column_values_to_be_probabilistically_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_between_exclusive_threshold_range expect_profile_numeric_columns_diff_between_inclusive_threshold_range expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_diff_greater_than_threshold expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_diff_less_than_threshold expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_greater_than_threshold expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold expect_profile_numeric_columns_percent_diff_less_than_threshold
```

