### PR TITLE
[MAINTENANCE] The 'sklearn' PyPI package is deprecated, use 'scikit-learn'

### DIFF
--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
@@ -115,7 +115,7 @@ class ExpectTableLinearFeatureImportancesToBe(BatchExpectation):
     library_metadata = {
         "tags": ["ai/ml", "fair-ai", "hackathon-22"],
         "contributors": ["@austiezr"],
-        "requirements": ["sklearn"],
+        "requirements": ["scikit-learn"],
     }
 
     metric_dependencies = ("table.modeling.linear.feature_importances",)

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -195,7 +195,6 @@ class GXDependencies:
         "scikit-learn",
         "shapely",
         "simple_icd_10",
-        "sklearn",
         "sympy",
         "tensorflow",
         "timezonefinder",

--- a/reqs/requirements-dev-all-contrib-expectations.txt
+++ b/reqs/requirements-dev-all-contrib-expectations.txt
@@ -38,7 +38,6 @@ schwifty
 scikit-learn
 shapely
 simple_icd_10
-sklearn
 sympy
 tensorflow
 timezonefinder


### PR DESCRIPTION

Changes proposed in this pull request:
- Don't use deprecated PyPi package sklearn, only scikit-learn