### PR TITLE
[MAINTENANCE] numpy.typing only available after v1.20

### DIFF
--- a/great_expectations/compatibility/numpy.py
+++ b/great_expectations/compatibility/numpy.py
@@ -1,8 +1,15 @@
+"""Utilities and imports for ensuring compatibility with different versions
+of numpy that are supported by great expectations."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-from numpy import typing as npt
 from packaging import version
+
+if TYPE_CHECKING:
+    # needed until numpy min version 1.20
+    from numpy import typing as npt
 
 
 def numpy_quantile(


### PR DESCRIPTION
Changes proposed in this pull request:
- numpy.typing is only available after v1.20 so we import only when type checking
- This is how it was done previously, https://github.com/great-expectations/great_expectations/pull/7637 erroneously removed the `if TYPE_CHECKING` check.
- Add a short module docstring.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas