### PR TITLE
[BUGFIX] Correct GX configuration structure that incorporates both V3 and Fluent Datasources

### DIFF
--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -142,25 +142,28 @@ COMBINED_FLUENT_AND_OLD_STYLE_CFG_DICT: Final[dict] = {
             "connection_string": "sqlite://",
         },
     ],
-    "name": "getting_started_datasource",
-    "class_name": "Datasource",
-    "execution_engine": {
-        "class_name": "PandasExecutionEngine",
-    },
-    "data_connectors": {
-        "default_inferred_data_connector_name": {
-            "class_name": "InferredAssetFilesystemDataConnector",
-            "base_directory": "../data/",
-            "default_regex": {
-                "group_names": ["data_asset_name"],
-                "pattern": "(.*)",
+    "datasources": {
+        "getting_started_datasource": {
+            "class_name": "Datasource",
+            "execution_engine": {
+                "class_name": "PandasExecutionEngine",
             },
-        },
-        "default_runtime_data_connector_name": {
-            "class_name": "RuntimeDataConnector",
-            "assets": {
-                "my_runtime_asset_name": {
-                    "batch_identifiers": ["runtime_batch_identifier_name"],
+            "data_connectors": {
+                "default_inferred_data_connector_name": {
+                    "class_name": "InferredAssetFilesystemDataConnector",
+                    "base_directory": "../data/",
+                    "default_regex": {
+                        "group_names": ["data_asset_name"],
+                        "pattern": "(.*)",
+                    },
+                },
+                "default_runtime_data_connector_name": {
+                    "class_name": "RuntimeDataConnector",
+                    "assets": {
+                        "my_runtime_asset_name": {
+                            "batch_identifiers": ["runtime_batch_identifier_name"],
+                        },
+                    },
                 },
             },
         },


### PR DESCRIPTION
### Scope
* It appears that the current example of the way both V3 ("Block") and Fluent Datasources can coexist does not use the correct V3 structure.  This change corrects the error -- and it appears that all tests still pass.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: DX-469/DX-470
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!