### PR TITLE
[MAINTENANCE] Have list_datasources return all datasources configs including fluent datasources

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2462,6 +2462,9 @@ class DataContextConfig(BaseYamlConfig):
         if datasources is None:
             datasources = {}  # type: ignore[assignment]
         self.datasources = datasources
+        if fluent_datasources is None:
+            fluent_datasources = {}  # type: ignore[assignment]
+        self.fluent_datasources = fluent_datasources
         self.expectations_store_name = expectations_store_name
         self.validations_store_name = validations_store_name
         self.evaluation_parameter_store_name = evaluation_parameter_store_name


### PR DESCRIPTION
Changes proposed in this pull request:
- The list_datasources api should also return fluent datasources config, this fix does that
-
-

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
