### PR TITLE
[MAINTENANCE] list_datasources should return FDS configs as well

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1564,6 +1564,12 @@ class AbstractDataContext(ConfigPeer, ABC):
                 )
             )
             datasources.append(masked_config)
+
+        for (
+            datasource_name,
+            fluent_datasource_config,
+        ) in self.fluent_datasources.items():
+            datasources.append(fluent_datasource_config.dict())
         return datasources
 
     @public_api

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2471,6 +2471,7 @@ class DataContextConfig(BaseYamlConfig):
         if datasources is None:
             datasources = {}  # type: ignore[assignment]
         self.datasources = datasources
+        self.fluent_datasources = fluent_datasources or {}
         self.expectations_store_name = expectations_store_name
         self.validations_store_name = validations_store_name
         self.evaluation_parameter_store_name = evaluation_parameter_store_name

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1406,6 +1406,7 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
         ("datasources",),
         ("evaluation_parameter_store_name",),
         ("expectations_store_name",),
+        ("fluent_datasources",),
         ("include_rendered_content",),
         ("notebooks",),
         ("plugins_directory",),

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -1,5 +1,6 @@
 import pathlib
 from unittest import mock
+import great_expectations as gx
 
 import pytest
 
@@ -17,6 +18,7 @@ from great_expectations.data_context.types.base import (
     DataContextConfig,
     DatasourceConfig,
     GXCloudConfig,
+    InMemoryStoreBackendDefaults,
 )
 from great_expectations.datasource import Datasource
 from great_expectations.util import get_context
@@ -427,3 +429,27 @@ def test_BaseDataContext_delete_datasource_updates_cache(
 
     assert not mock_delete.called
     assert name not in context.datasources
+
+
+@pytest.mark.unit
+def test_list_datasources() -> None:
+    project_config = DataContextConfig(
+        store_backend_defaults=InMemoryStoreBackendDefaults()
+    )
+    project_config.datasources = {
+        "my_datasource_name": {
+            "class_name": "Datasource",
+            "data_connectors": {},
+            "execution_engine": {
+                "class_name": "PandasExecutionEngine",
+                "module_name": "great_expectations.execution_engine",
+            },
+            "module_name": "great_expectations.datasource",
+        }
+    }
+    context = gx.get_context(project_config=project_config)
+
+    datasource_name = "my_experimental_datasource_awaiting_migration"
+    context.sources.add_pandas(datasource_name)
+
+    assert len(context.list_datasources()) == 2

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -224,6 +224,7 @@ def test_get_config(empty_data_context):
         "plugins_directory",
         "stores",
         "expectations_store_name",
+        "fluent_datasources",
         "validations_store_name",
         "evaluation_parameter_store_name",
         "checkpoint_store_name",


### PR DESCRIPTION
Changes proposed in this pull request:
- The list_datasources api should also return fluent datasources config, this fix does that

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
