### PR TITLE
[BUGFIX] Register core Expectations JIT in Validator workflows

### DIFF
--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -182,6 +182,9 @@ def register_core_expectations() -> None:
     will fail.
     """
     before_count = len(_registered_expectations)
+
+    # Implicitly calls MetaExpectation.__new__ as Expectations are loaded from core.__init__.py
+    # As __new__ calls upon register_expectation, this import builds our core registry
     from great_expectations.expectations import core  # noqa: F401
 
     after_count = len(_registered_expectations)

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -181,7 +181,15 @@ def register_core_expectations() -> None:
     in our import graph - if not, our registry will be empty and Validator workflows
     will fail.
     """
+    before_count = len(_registered_expectations)
     from great_expectations.expectations import core  # noqa: F401
+
+    after_count = len(_registered_expectations)
+
+    if before_count == after_count:
+        logger.debug("Already registered core expectations; no updates to registry")
+    else:
+        logger.debug(f"Registered {after_count-before_count} core expectations")
 
 
 def _add_response_key(res, key, value):

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -169,6 +169,21 @@ def register_expectation(expectation: Type[Expectation]) -> None:
     _registered_expectations[expectation_type] = expectation
 
 
+def register_core_expectations() -> None:
+    """As Expectation registration is the responsibility of MetaExpectation.__new__,
+    simply importing a given class will ensure that it is added to the Expectation
+    registry.
+
+    We use this JIT in the Validator to ensure that core Expectations are available
+    for usage when called upon.
+
+    Without this function, we need to hope that core Expectations are imported somewhere
+    in our import graph - if not, our registry will be empty and Validator workflows
+    will fail.
+    """
+    from great_expectations.expectations import core  # noqa: F401
+
+
 def _add_response_key(res, key, value):
     if key in res:
         res[key].append(value)

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -6,9 +6,6 @@ from copy import deepcopy
 from great_expectations.core.expectation_configuration import (
     ExpectationConfiguration,  # noqa: TCH001
 )
-from great_expectations.expectations.core.expect_column_kl_divergence_to_be_less_than import (  # noqa: F401
-    ExpectColumnKlDivergenceToBeLessThan,
-)
 from great_expectations.expectations.registry import get_renderer_impl
 from great_expectations.render import (
     LegacyDiagnosticRendererType,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -194,6 +194,9 @@ class Validator:
         include_rendered_content: Optional[bool] = None,
         **kwargs,
     ) -> None:
+        # Ensure that Expectations are available for __dir__ and __getattr__
+        register_core_expectations()
+
         self._data_context: Optional[AbstractDataContext] = data_context
 
         self._metrics_calculator: MetricsCalculator = MetricsCalculator(
@@ -454,12 +457,7 @@ class Validator:
 
     def __getattr__(self, name):
         name = name.lower()
-
-        is_expectation = name.startswith("expect_")
-        if is_expectation:
-            register_core_expectations()
-
-        if is_expectation and get_expectation_impl(name):
+        if name.startswith("expect_") and get_expectation_impl(name):
             return self.validate_expectation(name)
         elif (
             self._expose_dataframe_methods

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -52,6 +52,7 @@ from great_expectations.execution_engine.pandas_batch_data import PandasBatchDat
 from great_expectations.expectations.registry import (
     get_expectation_impl,
     list_registered_expectation_implementations,
+    register_core_expectations,
 )
 from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig
 from great_expectations.rule_based_profiler.helpers.configuration_reconciliation import (
@@ -453,7 +454,12 @@ class Validator:
 
     def __getattr__(self, name):
         name = name.lower()
-        if name.startswith("expect_") and get_expectation_impl(name):
+
+        is_expectation = name.startswith("expect_")
+        if is_expectation:
+            register_core_expectations()
+
+        if is_expectation and get_expectation_impl(name):
             return self.validate_expectation(name)
         elif (
             self._expose_dataframe_methods


### PR DESCRIPTION
Changes proposed in this pull request:
- Expectation registry depends upon `MetaExpectation.__new__`
- If we do not import the classes from `great_expectations.expectations.core`, this registration process does not happen.
    - As it stands, our registration depends on one stray import - we previously didn't know why we needed this but kept it around so things didn't break.
- This PR introduces an explicit `register_core_expectations` method


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
