### PR TITLE
[DOCS] Updated Datasource terms page

### DIFF
--- a/docs/docusaurus/docs/terms/datasource.md
+++ b/docs/docusaurus/docs/terms/datasource.md
@@ -22,7 +22,7 @@ A Datasource provides a standard API for accessing and interacting with data fro
 
 ### Features and promises
 
-Datasources provide a unified API across multiple backends: the Datasource API remains the same for PostgreSQL, CSV Filesystems, and all other supported data backends.  
+Datasources provides a standard API across multiple backends: the Datasource API remains the same for PostgreSQL, CSV Filesystems, and all other supported data backends.
 :::note Important: 
 
 Datasources do not modify your data.
@@ -37,7 +37,7 @@ Datasources function by bringing together a way of interacting with Data (an <Te
 
 <ConnectHeader/>
 
-When connecting to data the Datasource is your primary tool.  At this stage, you will create Datasources to define how Great Expectations can find and access your <TechnicalTag relative="../" tag="data_asset" text="Data Assets" />.  Under the hood, each Datasource must have an Execution Engine and one or more Data Connectors configured.  Once a Datasource is configured you will be able to operate with the Datasource's API rather than needing a different API for each possible data backend you may be working with.
+When connecting to data the Datasource is your primary tool. At this stage, you will create Datasources to define how Great Expectations can find and access your <TechnicalTag relative="../" tag="data_asset" text="Data Assets" />.  Under the hood, each Datasource uses an Execution Engine (ex: SQLAlchemy, Pandas, and Spark) to connect to and query data. Once a Datasource is configured you will be able to operate with the Datasource's API rather than needing a different API for each possible data backend you may be working with.
 
 <CreateHeader/>
 
@@ -49,36 +49,27 @@ Datasources are also used to obtain Batches for <TechnicalTag relative="../" tag
 
 ## Features
 
-### Unified API
+### Standard API
 
-Datasources support connecting to a variety of different data backends.  No matter which source data system you employ, the Datasource's API will remain the same.
+Datasources support connecting to a variety of different data backends. No matter which source data system you employ, the Datasource's API will remain the same.
 
 ### No Unexpected Modifications
 
-Datasources do not modify your data during profiling or validation, but they may create temporary artifacts to optimize computing Metrics and Validation.  This behaviour can be configured at the Data Connector level.
+Datasources do not modify your data during profiling or validation, but they may create temporary artifacts to optimize computing Metrics and Validation (this behavior can be configured).
 
 ### API Basics
 
-### How to access
+### How to create and access
 
-You will typically only access your Datasource directly through Python code, which can be executed from a script, a Python console, or a Jupyter Notebook.  To access a Datasource all you need is a <TechnicalTag relative="../" tag="data_context" text="Data Context" /> and the name of the Datasource you want to access, as shown below:
+Datasources can be created and accessed using Python code, which can be executed from a script, a Python console, or a Jupyter Notebook. To access a Datasource all you need is a <TechnicalTag relative="../" tag="data_context" text="Data Context" /> and the name of the Datasource. The below snippet shows how to create a Pandas Datasource for local files:
 
-```python title="Python console:"
-import great_expectations as gx
-
-context = gx.get_context()
-datasource = context.get_datasource("my_datasource_name")
+```python name="tests/integration/docusaurus/connecting_to_your_data/connect_to_your_data_overview add_datasource"
 ```
 
-### How to create and configure
+This next snippet shows how to retrieve the Datasource from the Data Context.
 
-Creating a Datasource is quick and easy, and can be done from the <TechnicalTag relative="../" tag="cli" text="CLI" /> or through Python code.  Configuring the Datasource may differ between backends, according to the given backend's requirements, but the process of creating one will remain the same.
-
-To create a new  Datasource through the CLI, run `great_expectations datasource new`.
-
-To create a new Datasource through Python code, obtain a data context and call its `add_datasource` method.
-
-Advanced users may also create a Datasource directly through a YAML config file.
+```python name="tests/integration/docusaurus/connecting_to_your_data/connect_to_your_data_overview config"
+```
 
 For detailed instructions on how to create Datasources that are configured for various backends, see [our documentation on Connecting to Data](../guides/connecting_to_your_data/index.md).
 

--- a/docs/docusaurus/docs/terms/datasource.md
+++ b/docs/docusaurus/docs/terms/datasource.md
@@ -22,7 +22,7 @@ A Datasource provides a standard API for accessing and interacting with data fro
 
 ### Features and promises
 
-Datasources provides a standard API across multiple backends: the Datasource API remains the same for PostgreSQL, CSV Filesystems, and all other supported data backends.
+Datasources provide a standard API across multiple backends: the Datasource API remains the same for PostgreSQL, CSV Filesystems, and all other supported data backends.
 :::note Important: 
 
 Datasources do not modify your data.


### PR DESCRIPTION
Updated the Datasource terms page to reflect the fluent-style datasources

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.