### PR TITLE
[DOCS] Updating the Rule-Based Profiler doc to Fluent

### DIFF
--- a/docs/docusaurus/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
+++ b/docs/docusaurus/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
@@ -44,6 +44,7 @@ While the contents of this document accurately reflect the state of the feature,
 - Follow the steps in the [How to connect to data on a filesystem using Pandas](../../../guides/connecting_to_your_data/filesystem/pandas.md). For the purpose of this tutorial, we will work from a `yaml` to set up your <TechnicalTag tag="datasource" text="Datasource" /> config. When you open up your notebook to create and test and save your Datasource config, replace the config docstring with the following docstring:
 
 ```python
+
 example_yaml = f"""
 name: taxi_pandas
 class_name: Datasource

--- a/docs/docusaurus/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
+++ b/docs/docusaurus/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
@@ -4,10 +4,6 @@ title: How to create a new Expectation Suite using Rule Based Profilers
 import Prerequisites from '../../../guides/connecting_to_your_data/components/prerequisites.jsx';
 import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
 
-import InProgress from '/docs/components/warnings/_in_progress.md'
-
-<InProgress />
-
 In this tutorial, you will develop hands-on experience with configuring a Rule-Based <TechnicalTag tag="profiler" text="Profiler" /> to create an <TechnicalTag tag="expectation_suite" text="Expectation Suite" />. You will <TechnicalTag tag="profiling" text="Profile" /> several <TechnicalTag tag="batch" text="Batches" /> of NYC yellow taxi trip data to come up with reasonable estimates for the ranges of <TechnicalTag tag="expectation" text="Expectations" /> for several numeric columns.
 
 :::warning
@@ -32,43 +28,18 @@ While the contents of this document accurately reflect the state of the feature,
 
 - Create a new directory, called `taxi_profiling_tutorial`
 - Within this directory, create another directory called `data`
-- Navigate to the top level of `taxi_profiling_tutorial` in a terminal and run `great_expectations init`
 
 ### 2. Download the data
 
 - Download [this directory](https://github.com/great-expectations/great_expectations/tree/develop/tests/test_sets/taxi_yellow_tripdata_samples) of yellow taxi trip `csv` files from the Great Expectations GitHub repo. You can use a tool like [DownGit](https://downgit.github.io/) to do so
 - Move the unzipped directory of `csv` files into the `data` directory that you created in Step 1
 
-### 3. Set up your Datasource
+### 3. Create a context and add your Datasource
 
-- Follow the steps in the [How to connect to data on a filesystem using Pandas](../../../guides/connecting_to_your_data/filesystem/pandas.md). For the purpose of this tutorial, we will work from a `yaml` to set up your <TechnicalTag tag="datasource" text="Datasource" /> config. When you open up your notebook to create and test and save your Datasource config, replace the config docstring with the following docstring:
+- Follow the steps in the [How to connect to data on a filesystem using Pandas](../../../guides/connecting_to_your_data/filesystem/pandas.md). The following code snippet adds a Pandas Filesystem asset for our taxi data.
 
-```python
-
-example_yaml = f"""
-name: taxi_pandas
-class_name: Datasource
-execution_engine:
-  class_name: PandasExecutionEngine
-data_connectors:
-  monthly:
-    base_directory: ../<YOUR BASE DIR>/
-    glob_directive: '*.csv'
-    class_name: ConfiguredAssetFilesystemDataConnector
-    assets:
-      my_reports:
-        base_directory: ./
-        group_names:
-          - name
-          - year
-          - month
-        class_name: Asset
-        pattern: (.+)_(\d.*)-(\d.*)\.csv
-"""
+```python name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py init"
 ```
-
-- Test your YAML config to make sure it works - you should see some of the taxi `csv` filenames listed
-- Save your Datasource config
 
 ### 4. Configure the Profiler
 
@@ -122,24 +93,19 @@ You can see here that we use a special `$` syntax to reference `variables` and `
 
 ### 5. Run the Profiler
 
-Now let's use our config to Profile our data and create a simple Expectation Suite!
+Now let's use our config to Profile our data and create an Expectation Suite!
 
-First we'll do some basic set-up - set up a <TechnicalTag tag="data_context" text="Data Context" /> and parse our YAML
-
-```python name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py set up"
-```
-
-Next, we'll instantiate our Profiler, passing in our config and our Data Context
+First, we load the profiler config and instantiate our Profiler, passing in our config and our Data Context
 
 ```python name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py instantiate"
 ```
 
-Finally, we'll run the profiler and save the result to a variable. 
+Then we run the profiler and save the result to a variable. 
 
 ```python name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py run"
 ```
 
-Then, we can print our Expectation Suite so we can see how it looks!
+Now we can print our Expectation Suite so we can see how it looks!
 
 ```python name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py row_count_rule_suite"
 ```

--- a/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
+++ b/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
@@ -142,7 +142,7 @@ print(expectation_configurations)
 # <snippet name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py row_count_rule_suite">
 row_count_rule_suite = """
     {
-        "meta": {"great_expectations_version": "0.13.19+58.gf8a650720.dirty"},
+        "meta": {"great_expectations_version": "0.16.7"},
         "data_asset_type": None,
         "expectations": [
             {

--- a/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
+++ b/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
@@ -134,7 +134,7 @@ rule_based_profiler: RuleBasedProfiler = RuleBasedProfiler(
 batch_request: dict = {
     "datasource_name": "taxi_multi_batch_datasource",
     "data_asset_name": "all_years",
-    "options": {}
+    "options": {},
 }
 
 result: RuleBasedProfilerResult = rule_based_profiler.run(batch_request=batch_request)

--- a/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
+++ b/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import great_expectations as gx
 from great_expectations import DataContext
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -101,32 +102,39 @@ rules:
 """
 
 
-# <snippet name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py set up">
-data_context = DataContext()
+# <snippet name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py init">
+context = gx.get_context()
+
+context.sources.add_pandas_filesystem(
+    "taxi_multi_batch_datasource",
+    base_directory="./data",
+).add_csv_asset(
+    "all_years",
+    batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+)
 
 full_profiler_config_dict: dict = yaml.load(profiler_config)
 # </snippet>
 
 # Instantiate RuleBasedProfiler
 # <snippet name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py instantiate">
+full_profiler_config_dict: dict = yaml.load(profiler_config)
+
 rule_based_profiler: RuleBasedProfiler = RuleBasedProfiler(
     name=full_profiler_config_dict["name"],
     config_version=full_profiler_config_dict["config_version"],
     rules=full_profiler_config_dict["rules"],
     variables=full_profiler_config_dict["variables"],
-    data_context=data_context,
+    data_context=context,
 )
 # </snippet>
 
 
 # <snippet name="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py run">
 batch_request: dict = {
-    "datasource_name": "taxi_pandas",
-    "data_connector_name": "monthly",
-    "data_asset_name": "my_reports",
-    "data_connector_query": {
-        "index": "-6:-1",
-    },
+    "datasource_name": "taxi_multi_batch_datasource",
+    "data_asset_name": "all_years",
+    "options": {}
 }
 
 result: RuleBasedProfilerResult = rule_based_profiler.run(batch_request=batch_request)

--- a/tests/integration/docusaurus/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant.py
+++ b/tests/integration/docusaurus/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant.py
@@ -52,6 +52,7 @@ expectation_suite = context.add_or_update_expectation_suite(
 all_years_asset: DataAsset = context.datasources[
     "taxi_multi_batch_datasource"
 ].get_asset("all_years")
+
 multi_batch_all_years_batch_request: BatchRequest = (
     all_years_asset.build_batch_request()
 )

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -153,12 +153,6 @@ local_tests = [
         data_dir="tests/test_sets/dataconnector_docs",
     ),
     IntegrationTestFixture(
-        name="RUNME rule_base_profiler_multi_batch_example",
-        data_context_dir="tests/integration/fixtures/yellow_tripdata_pandas_fixture/great_expectations",
-        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-        user_flow_script="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
-    ),
-    IntegrationTestFixture(
         name="checkpoints_and_actions_core_concepts",
         user_flow_script="tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
@@ -269,6 +263,12 @@ fluent_datasources = [
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
         data_dir="tests/test_sets/taxi_yellow_tripdata_samples",
         user_flow_script="tests/integration/docusaurus/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py",
+    ),
+    IntegrationTestFixture(
+        name="RUNME rule_base_profiler_multi_batch_example",
+        data_context_dir="tests/integration/fixtures/yellow_tripdata_pandas_fixture/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+        user_flow_script="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
     ),
 ]
 

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -153,7 +153,7 @@ local_tests = [
         data_dir="tests/test_sets/dataconnector_docs",
     ),
     IntegrationTestFixture(
-        name="rule_base_profiler_multi_batch_example",
+        name="RUNME rule_base_profiler_multi_batch_example",
         data_context_dir="tests/integration/fixtures/yellow_tripdata_pandas_fixture/great_expectations",
         data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
         user_flow_script="tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",


### PR DESCRIPTION
Updating the Rule-Based Profiler doc to Fluent:

* Removed references to the CLI and updated the data source to Fluent
* Updated the batch request to reference the new datasource
* Reviewed the doc for consistency

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
