### PR TITLE
[MAINTENANCE] Use same version of mypy in contrib tool

### DIFF
--- a/contrib/cli/requirements.txt
+++ b/contrib/cli/requirements.txt
@@ -1,7 +1,7 @@
 black[jupyter]==22.3.0 # Linting / code style
 Click>=7.1.2         # CLI tooling
 cookiecutter==2.1.1  # Project templating
-mypy==1.1.1          # Type checker
+mypy==1.2.0          # Type checker
 pydantic>=1.0,<2.0    # Needed for mypy plugin
 pytest>=5.3.5        # Test framework
 ruff==0.0.262        # Linting / code style


### PR DESCRIPTION
Let gx and the contrib tool be installed together again.

```
ERROR: Cannot install great-expectations-contrib==0.1.0 and great-expectations[dev]==0.16.8+76.g8e7dd99db.dirty because these package versions have conflicting dependencies.

The conflict is caused by:
    great-expectations-contrib 0.1.0 depends on mypy==1.1.1
    great-expectations[dev] 0.16.8+76.g8e7dd99db.dirty depends on mypy==1.2.0; extra == "dev"
```

Changes proposed in this pull request:
- Use same version of mypy in contrib tool
