### PR TITLE
[DOCS] Temporarily revert `update_expectation_suite` call in GX Cloud quickstart

### DIFF
--- a/docs/docusaurus/docs/gx_cloud/tutorials/getting_started/getting_started_with_gx_cloud.md
+++ b/docs/docusaurus/docs/gx_cloud/tutorials/getting_started/getting_started_with_gx_cloud.md
@@ -163,7 +163,7 @@ expectation_suite.add_expectation(
 print(expectation_suite)
 
 # Save the Expectation Suite
-context.update_expectation_suite(expectation_suite=expectation_suite)
+context.save_expectation_suite(expectation_suite=expectation_suite)
 ```
 
 With the Expectation defined above, we are stating that we _expect_ the column of your choice to always be populated. That is: none of the column's values should be null.


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix that enables this method is not yet a part of our latest release
- This change will be reverted once the release is out


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation
