### PR TITLE
[MAINTENANCE] Change param order of add checkpoint

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1762,6 +1762,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     )
     def add_checkpoint(
         self,
+        checkpoint: Checkpoint | None = None,
         name: str | None = None,
         config_version: int | float | None = None,
         template_name: str | None = None,
@@ -1788,7 +1789,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         default_validation_id: str | None = None,
         id: str | None = None,
         expectation_suite_id: str | None = None,
-        checkpoint: Checkpoint | None = None,
     ) -> Checkpoint:
         """Add a Checkpoint to the DataContext.
 
@@ -1796,6 +1796,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             - https://docs.greatexpectations.io/docs/terms/checkpoint/
 
         Args:
+            checkpoint: An existing checkpoint you wish to persist.
             name: The name to give the checkpoint.
             config_version: The config version of this checkpoint.
             template_name: The template to use in generating this checkpoint.
@@ -1820,7 +1821,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             default_validation_id: The default validation ID to use in generating this checkpoint.
             id: The ID to use in generating this checkpoint (preferred over `ge_cloud_id`).
             expectation_suite_id: The expectation suite ID to use in generating this checkpoint (preferred over `expectation_suite_ge_cloud_id`).
-            checkpoint: An existing checkpoint you wish to persist.
 
         Returns:
             The Checkpoint object created.

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1673,6 +1673,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     @overload
     def add_checkpoint(
         self,
+        checkpoint: None = ...,
         name: str = ...,
         config_version: int | float | None = ...,
         template_name: str | None = ...,
@@ -1699,7 +1700,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         default_validation_id: str | None = ...,
         id: str | None = ...,
         expectation_suite_id: str | None = ...,
-        checkpoint: None = ...,
     ) -> Checkpoint:
         """
         Individual constructor arguments are provided.
@@ -1710,6 +1710,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     @overload
     def add_checkpoint(
         self,
+        checkpoint: Checkpoint = ...,
         name: None = ...,
         config_version: None = ...,
         template_name: None = ...,
@@ -1734,7 +1735,6 @@ class AbstractDataContext(ConfigPeer, ABC):
         default_validation_id: None = ...,
         id: None = ...,
         expectation_suite_id: None = ...,
-        checkpoint: Checkpoint = ...,
     ) -> Checkpoint:
         """
         A `checkpoint` is provided.

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -645,6 +645,7 @@ class CloudDataContext(SerializableDataContext):
 
     def add_checkpoint(
         self,
+        checkpoint: Checkpoint | None = None,
         name: str | None = None,
         config_version: int | float | None = None,
         template_name: str | None = None,
@@ -671,7 +672,6 @@ class CloudDataContext(SerializableDataContext):
         default_validation_id: str | None = None,
         id: str | None = None,
         expectation_suite_id: str | None = None,
-        checkpoint: Checkpoint | None = None,
     ) -> Checkpoint:
         """
         See `AbstractDataContext.add_checkpoint` for more information.

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -1029,6 +1029,23 @@ def test_add_checkpoint_with_existing_checkpoint(
 
 
 @pytest.mark.unit
+def test_add_checkpoint_with_existing_checkpoint_without_keyword_arg(
+    in_memory_data_context: EphemeralDataContextSpy,
+):
+    """What does this test and why?
+    context.add_checkpoint(checkpoint) should work without requiring the use of the keyword argument e.g.
+    context.add_checkpoint(checkpoint=checkpoint)"""
+    context = in_memory_data_context
+    checkpoint_name = "my_checkpoint"
+    checkpoint = Checkpoint(name=checkpoint_name, data_context=context)
+
+    persisted_checkpoint = context.add_checkpoint(checkpoint)
+
+    assert checkpoint == persisted_checkpoint
+    assert context.checkpoint_store.save_count == 1
+
+
+@pytest.mark.unit
 def test_add_checkpoint_namespace_collision_raises_deprecation(
     in_memory_data_context: EphemeralDataContextSpy,
 ):

--- a/tests/integration/docusaurus/validation/checkpoints/how_to_create_a_new_checkpoint.py
+++ b/tests/integration/docusaurus/validation/checkpoints/how_to_create_a_new_checkpoint.py
@@ -64,7 +64,7 @@ context.build_data_docs()
 # </snippet>
 
 # <snippet name="tests/integration/docusaurus/validation/checkpoints/how_to_create_a_new_checkpoint.py add checkpoint">
-context.add_checkpoint(checkpoint=checkpoint)
+context.add_checkpoint(checkpoint)
 # </snippet>
 
 assert context.list_checkpoints() == ["my_checkpoint"]


### PR DESCRIPTION
Changes proposed in this pull request:
- Change the parameter order of `add_checkpoint` to allow an instantiated checkpoint to be added without keyword argument e.g. `context.add_checkpoint(checkpoint)` now works.
- Add test.
- Update usage example in How to create a new Checkpoint doc.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.