### PR TITLE
[MAINTENANCE] Update expectation logic and add docstring to build_gallery

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -4,10 +4,8 @@ import json
 import logging
 import os
 import re
-import shutil
 import sys
 import traceback
-from datetime import datetime
 from glob import glob
 from io import StringIO
 from subprocess import CalledProcessError, CompletedProcess, check_output, run
@@ -331,8 +329,7 @@ def combine_backend_results(
                 logger.error(f"No backend_test_result_counts for {expectation_name}")
                 bad_key_names.append(expectation_name)
                 continue
-            maturity_checklist_object = Expectation._get_maturity_checklist(
-                expectation_instance=expectation_instance,
+            maturity_checklist_object = expectation_instance._get_maturity_checklist(
                 library_metadata=diagnostic_object.library_metadata,
                 description=diagnostic_object.description,
                 examples=diagnostic_object.examples,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1398,8 +1398,7 @@ class Expectation(metaclass=MetaExpectation):
         )
 
         maturity_checklist: ExpectationDiagnosticMaturityMessages = (
-            Expectation._get_maturity_checklist(
-                expectation_instance=self,
+            self._get_maturity_checklist(
                 library_metadata=library_metadata,
                 description=description_diagnostics,
                 examples=examples,
@@ -2172,9 +2171,8 @@ class Expectation(metaclass=MetaExpectation):
         augmented_library_metadata["problems"] = problems
         return AugmentedLibraryMetadata.from_legacy_dict(augmented_library_metadata)
 
-    @staticmethod
     def _get_maturity_checklist(
-        expectation_instance,
+        self,
         library_metadata: Union[
             AugmentedLibraryMetadata, ExpectationDescriptionDiagnostics
         ],
@@ -2203,11 +2201,11 @@ class Expectation(metaclass=MetaExpectation):
         )
         beta_checks.append(
             ExpectationDiagnostics._check_input_validation(
-                expectation_instance, examples
+                self, examples
             )
         )
         beta_checks.append(
-            ExpectationDiagnostics._check_renderer_methods(expectation_instance)
+            ExpectationDiagnostics._check_renderer_methods(self)
         )
         beta_checks.append(
             ExpectationDiagnostics._check_core_logic_for_all_applicable_execution_engines(


### PR DESCRIPTION
Changes proposed in this pull request:
- Update expectation logic to use the instance methods instead of static methods
- Add docstring to build_gallery

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.