### PR TITLE
[MAINTENANCE] Use invoke public-api in main CI pipeline

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -131,7 +131,8 @@ stages:
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
         - script: |
-            python docs/sphinx_api_docs_source/public_api_report.py
+            pip install --requirement reqs/requirements-dev-test.txt
+            invoke public-api
           name: PublicAPIReport
 
   - stage: docker_tests


### PR DESCRIPTION
Changes proposed in this pull request:
- Use `invoke public-api` in the main pipeline. Should have been changed in https://github.com/great-expectations/great_expectations/pull/7730 but was missed (sorry!).

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code