### PR TITLE
[DOCS] Update pypyi page urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ long_description = "Always know what to expect from your data. (See https://gith
 config = {
     "description": "Always know what to expect from your data.",
     "author": "The Great Expectations Team",
-    "url": "https://github.com/great-expectations/great_expectations",
+    "url": "https://greatexpectations.io",
+    "download_url": "https://github.com/great-expectations/great_expectations",
     "author_email": "team@greatexpectations.io",
     "version": versioneer.get_version(),
     "cmdclass": versioneer.get_cmdclass(),


### PR DESCRIPTION
Update the `url` and `download_url` entries

https://setuptools.pypa.io/en/latest/deprecated/distutils/setupscript.html#additional-meta-data