### PR TITLE
[MAINTENANCE] breakup mypy ci steps

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -154,6 +154,8 @@ stages:
       - script: |
           python -m pip install --upgrade pip
           pip install --requirement requirements-types.txt
+        name: InstallDependencies
+      - script: |
           invoke type-check --ci --pretty --python-version $(python.version)
         name: StaticTypeCheck
       - script: |

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -91,11 +91,16 @@ stages:
           versionSpec: 3.7
         displayName: 'Use Python 3.7'
       - script: |
+          python -m pip install --upgrade pip
           pip install --requirement requirements-types.txt
-          invoke type-check --ci --pretty
-          # initial run doesn't check `.pyi` source files
-          invoke type-check --ci --pretty --check-stub-sources
+        name: InstallDependencies
+      - script: |
+          invoke type-check --ci --pretty --python-version $(python.version)
         name: StaticTypeCheck
+      - script: |
+          # initial run doesn't check `.pyi` source files
+          invoke type-check --ci --pretty --check-stub-sources --python-version $(python.version)
+        name: TypeCheckStubSourceFiles
 
     - job: docstring_linter
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Breakup the type-checking steps by adding an `InstallDependencies` step
- Add the source files checking step to the async CI 

This should make it easier to view any error results and monitor the speed of the type-checking step.

![image](https://user-images.githubusercontent.com/13108583/235186049-14fc988e-27d0-47ae-ba27-a575e39fb604.png)

