### PR TITLE
[DOCS] Temporarily pin ipython for python 3.8 before building api docs

### DIFF
--- a/docs/build_docs
+++ b/docs/build_docs
@@ -72,6 +72,11 @@ echo -e "${ORANGE}Installing Great Expectations library dev dependencies.${NC}"
 echo -e "${ORANGE}Installing api docs dependencies.${NC}"
 (cd ../sphinx_api_docs_source; pip install -r requirements-dev-api-docs.txt)
 
+# TODO: Remove the below temporary install after v0.16.10 is released:
+echo -e "${ORANGE}Temporarily install compatible version of Ipython (remove this after v0.16.10 is released).${NC}"
+# Due to https://github.com/ipython/ipython/issues/14053
+(pip install --upgrade 'ipython<8.13.0; python_version <= "3.8"')
+
 echo -e "${ORANGE}Building API docs for current version.${NC}"
 (cd ../../; invoke docs)
 

--- a/docs/build_docs
+++ b/docs/build_docs
@@ -75,7 +75,7 @@ echo -e "${ORANGE}Installing api docs dependencies.${NC}"
 # TODO: Remove the below temporary install after v0.16.10 is released:
 echo -e "${ORANGE}Temporarily install compatible version of Ipython (remove this after v0.16.10 is released).${NC}"
 # Due to https://github.com/ipython/ipython/issues/14053
-(pip install --upgrade 'ipython<8.13.0; python_version <= "3.8"')
+(pip install 'ipython<8.13.0; python_version <= "3.8"')
 
 echo -e "${ORANGE}Building API docs for current version.${NC}"
 (cd ../../; invoke docs)


### PR DESCRIPTION
Changes proposed in this pull request:
- API docs builds were failing due to an incompatibility with ipython. This was also affecting GX. Since the api docs use the latest `released` version of GX, they will not benefit from the fix. This temporary pin will allow API docs to be built but should be removed in the next release because the change was made in `requirements.txt`

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas