### PR TITLE
[BUGFIX] Patch Expectation registry issue introduced in 0.16.9

### DIFF
--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -24,6 +24,12 @@ from .util import (
     validate,
 )
 
+# By placing this registry function in our top-level __init__,  we ensure that all
+# GX workflows have populated expectation registries before they are used.
+#
+# Both of the following import paths will trigger this file, causing the registration to occur:
+#   import great_expectations as gx
+#   from great_expectations.core import ExpectationSuite, ExpectationConfiguration
 register_core_expectations()
 
 # from great_expectations.expectations.core import *

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -52,7 +52,6 @@ from great_expectations.execution_engine.pandas_batch_data import PandasBatchDat
 from great_expectations.expectations.registry import (
     get_expectation_impl,
     list_registered_expectation_implementations,
-    register_core_expectations,
 )
 from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig
 from great_expectations.rule_based_profiler.helpers.configuration_reconciliation import (
@@ -194,9 +193,6 @@ class Validator:
         include_rendered_content: Optional[bool] = None,
         **kwargs,
     ) -> None:
-        # Ensure that Expectations are available for __dir__ and __getattr__
-        register_core_expectations()
-
         self._data_context: Optional[AbstractDataContext] = data_context
 
         self._metrics_calculator: MetricsCalculator = MetricsCalculator(


### PR DESCRIPTION
Changes proposed in this pull request:
- Our call to `register_core_expectations` in our top-level `__init__` solves the issue we were seeing
    - Note that this was introduced after the 0.16.9 release so the fix is already in
- Deleting the extra call in `Validator` as we'll already have the registery populated by this time


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
