### PR TITLE
[DOCS] Remove temporary pin for ipython

### DIFF
--- a/docs/build_docs
+++ b/docs/build_docs
@@ -72,11 +72,6 @@ echo -e "${ORANGE}Installing Great Expectations library dev dependencies.${NC}"
 echo -e "${ORANGE}Installing api docs dependencies.${NC}"
 (cd ../sphinx_api_docs_source; pip install -r requirements-dev-api-docs.txt)
 
-# TODO: Remove the below temporary install after v0.16.10 is released:
-echo -e "${ORANGE}Temporarily install compatible version of Ipython (remove this after v0.16.10 is released).${NC}"
-# Due to https://github.com/ipython/ipython/issues/14053
-(pip install 'ipython<8.13.0; python_version <= "3.8"')
-
 echo -e "${ORANGE}Building API docs for current version.${NC}"
 (cd ../../; invoke docs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ Click>=7.1.2
 colorama>=0.4.3
 cryptography>=3.2
 importlib-metadata>=1.7.0 # (included in Python 3.8 by default.)
-Ipython>=7.16.3,<8.13.0; python_version <= "3.8" # https://github.com/ipython/ipython/issues/14053
-Ipython>=7.16.3; python_version >= "3.9"
+Ipython>=7.16.3
 ipywidgets>=7.5.1
 jinja2>=2.10
 jsonpatch>=1.22


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the temporary pin put in place in https://github.com/great-expectations/great_expectations/pull/7764