### PR TITLE
[MAINTENANCE] Cache the latest great_expectations version

### DIFF
--- a/tests/data_context/cloud_data_context/test_version_checker.py
+++ b/tests/data_context/cloud_data_context/test_version_checker.py
@@ -10,9 +10,10 @@ _MOCK_PYPI_VERSION = "0.16.8"
 
 @pytest.fixture
 def enable_pypi_version_check():
-    vc._ENABLE_VERSION_CHECK_IN_TESTS = False
+    stashed_version = _VersionChecker._LATEST_GX_VERSION_CACHE
+    _VersionChecker._LATEST_GX_VERSION_CACHE = None
     yield
-    vc._ENABLE_VERSION_CHECK_IN_TESTS = True
+    _VersionChecker._LATEST_GX_VERSION_CACHE = stashed_version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes proposed in this pull request:
- get rid of `pytest` in `sys.modules` checking to see if being run under tests
- Replace with a `_LATEST_GX_VERSION_CACHE` class attribute which is pre-loaded at the start of testing
- Also fixes the failing unit-test on `develop`


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

