### PR TITLE
[MAINTENANCE] Test DirectoryCSVAsset with both str and pathlib.Path

### DIFF
--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -7,6 +7,7 @@ import re
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
 
+from great_expectations.alias_types import PathStr
 from great_expectations.core import IDDict
 from great_expectations.core.batch import BatchDefinition
 from great_expectations.core.batch_spec import BatchSpec, PathBatchSpec
@@ -69,7 +70,7 @@ def file_get_unfiltered_batch_definition_list_fn(
 
 
 def make_directory_get_unfiltered_batch_definition_list_fn(
-    data_directory: str | pathlib.Path,
+    data_directory: PathStr,
 ) -> Callable[[FilePathDataConnector, BatchRequest], list[BatchDefinition]]:
     def directory_get_unfiltered_batch_definition_list_fn(
         data_connector: FilePathDataConnector,

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import copy
 import logging
-import pathlib
 import re
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from great_expectations.alias_types import PathStr
 from great_expectations.core import IDDict
 from great_expectations.core.batch import BatchDefinition
 from great_expectations.core.batch_spec import BatchSpec, PathBatchSpec
@@ -32,8 +30,8 @@ from great_expectations.datasource.fluent.data_asset.data_connector.regex_parser
 # TODO: <Alex>ALEX</Alex>
 
 if TYPE_CHECKING:
+    from great_expectations.alias_types import PathStr
     from great_expectations.datasource.fluent import BatchRequest
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -203,7 +203,7 @@ def test_csv_asset_with_non_string_batching_regex_named_parameters(
     ],
 )
 def test_get_batch_list_from_directory_one_batch(
-    path: str | pathlib.Path,
+    path: PathStr,
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     """What does this test and why?
@@ -229,7 +229,7 @@ def test_get_batch_list_from_directory_one_batch(
     ],
 )
 def test_get_batch_list_from_directory_merges_files(
-    path: str | pathlib.Path,
+    path: PathStr,
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     """What does this test and why?

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -195,7 +195,15 @@ def test_csv_asset_with_non_string_batching_regex_named_parameters(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("samples_2020", id="str"),
+        pytest.param(pathlib.Path("samples_2020"), id="pathlib.Path"),
+    ],
+)
 def test_get_batch_list_from_directory_one_batch(
+    path: str | pathlib.Path,
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     """What does this test and why?
@@ -203,7 +211,7 @@ def test_get_batch_list_from_directory_one_batch(
     A "directory" asset should only have a single batch."""
     asset = spark_filesystem_datasource.add_directory_csv_asset(
         name="csv_asset",
-        data_directory="samples_2020",
+        data_directory=path,
         header=True,
         infer_schema=True,
     )
@@ -213,7 +221,15 @@ def test_get_batch_list_from_directory_one_batch(
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("samples_2020", id="str"),
+        pytest.param(pathlib.Path("samples_2020"), id="pathlib.Path"),
+    ],
+)
 def test_get_batch_list_from_directory_merges_files(
+    path: str | pathlib.Path,
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     """What does this test and why?
@@ -224,7 +240,7 @@ def test_get_batch_list_from_directory_merges_files(
     """
     asset = spark_filesystem_datasource.add_directory_csv_asset(
         name="csv_asset",
-        data_directory="samples_2020",
+        data_directory=path,
         header=True,
         infer_schema=True,
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Parametrize DirectoryCSVAsset tests with both a str and pathlib.Path passed to `datasource.add_directory_csv_asset()`
- Companion to https://github.com/great-expectations/great_expectations/pull/7777

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.