### PR TITLE
[BUGFIX] Upper bound `pyathena` due to breaking API in V3

### DIFF
--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -435,7 +435,7 @@ try:
 except ImportError:
     pyathena = None  # type: ignore[assignment]
     athenatypes = None
-    athenaDialect = None
+    athenaDialect = None  # type: ignore[assignment,misc]
     ATHENA_TYPES = {}
 
 # # Others from great_expectations/dataset/sqlalchemy_dataset.py

--- a/reqs/requirements-dev-athena.txt
+++ b/reqs/requirements-dev-athena.txt
@@ -1,1 +1,1 @@
-pyathena[SQLAlchemy]>=2.0.0
+pyathena[SQLAlchemy]>=2.0.0,<3 # v3 breaks on `from pyathena import sqlalchemy_athena`


### PR DESCRIPTION
Changes proposed in this pull request:
- `from pyathena import sqlalchemy_athena` no longer works in V3
    - Let's set an upper bound so our current code work
    - Should circle back to see what imports we can use to support both

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
