### PR TITLE
[MAINTENANCE] FDS - Datasources can rebuild their own asset data_connectors

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4627,9 +4627,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
 
         if self._datasource_store.cloud_mode:
             for fds in config.fluent_datasources.values():
-                self._build_fds_asset_data_connectors_if_needed(
-                    self._add_fluent_datasource(**fds)
-                )
+                self._add_fluent_datasource(**fds)._rebuild_asset_data_connectors()
 
         datasources: Dict[str, DatasourceConfig] = cast(
             Dict[str, DatasourceConfig], config.datasources

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -775,8 +775,8 @@ class AbstractDataContext(ConfigPeer, ABC):
         update_datasource._data_context = self
         # config provider needed for config substitution
         update_datasource._config_provider = self.config_provider
-        # rebuild data connector
-        self._build_fds_asset_data_connectors_if_needed(update_datasource)
+
+        update_datasource._rebuild_asset_data_connectors()
 
         update_datasource.test_connection()
         update_datasource._data_context._save_project_config()
@@ -5570,19 +5570,9 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             ds_name = datasource.name
             logger.info(f"Loaded '{ds_name}' from fluent config")
 
-            self._build_fds_asset_data_connectors_if_needed(datasource)
+            datasource._rebuild_asset_data_connectors()
 
             self._add_fluent_datasource(datasource=datasource)
-
-    @staticmethod
-    def _build_fds_asset_data_connectors_if_needed(
-        fds_datasource: FluentDatasource,
-    ) -> None:
-        """If Datasource required a data_connector we need to build the data_connector for each asset"""
-        if fds_datasource.data_connector_type:
-            for data_asset in fds_datasource.assets:
-                connect_options = getattr(data_asset, "connect_options", {})
-                fds_datasource._build_data_connector(data_asset, **connect_options)
 
     def _synchronize_fluent_datasources(self) -> Dict[str, FluentDatasource]:
         """

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -563,6 +563,7 @@ class Datasource(
         """If Datasource required a data_connector we need to build the data_connector for each asset"""
         if self.data_connector_type:
             for data_asset in self.assets:
+                # check if data_connector exist before rebuilding?
                 connect_options = getattr(data_asset, "connect_options", {})
                 self._build_data_connector(data_asset, **connect_options)
 

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -559,6 +559,13 @@ class Datasource(
             except TypeError as type_err:
                 warnings.warn(str(type_err), GxSerializationWarning)
 
+    def _rebuild_asset_data_connectors(self) -> None:
+        """If Datasource required a data_connector we need to build the data_connector for each asset"""
+        if self.data_connector_type:
+            for data_asset in self.assets:
+                connect_options = getattr(data_asset, "connect_options", {})
+                self._build_data_connector(data_asset, **connect_options)
+
     @staticmethod
     def parse_order_by_sorters(
         order_by: Optional[List[Union[Sorter, str, dict]]] = None

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -117,8 +117,7 @@ def seed_cloud(
     logger.info(f"Seeded Datasources ->\n{pf(fds_config, depth=2)}")
     assert fds_config
 
-    cloud_api_fake.remove(responses.GET, dc_config_url)
-    cloud_api_fake.add(
+    cloud_api_fake.upsert(
         responses.GET,
         dc_config_url,
         json={
@@ -129,7 +128,9 @@ def seed_cloud(
             "datasources": fds_config,
         },
     )
-    return cloud_api_fake
+    yield cloud_api_fake
+
+    assert len(cloud_api_fake.calls) >= 1, f"{org_url_base} was never called"
 
 
 @pytest.fixture

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -84,7 +84,7 @@ def fluent_yaml_config_file(
 
 @pytest.fixture
 @functools.lru_cache(maxsize=1)
-def seeded_fds_file_context(
+def seeded_file_context(
     cloud_storage_get_client_doubles,
     fluent_yaml_config_file: pathlib.Path,
 ) -> FileDataContext:
@@ -142,7 +142,7 @@ def seeded_cloud_context(
     return empty_cloud_context_fluent
 
 
-@pytest.fixture(params=["seeded_fds_file_context", "seeded_cloud_context"])
+@pytest.fixture(params=["seeded_file_context", "seeded_cloud_context"])
 def seeded_contexts(
     request: FixtureRequest,
 ):
@@ -167,17 +167,17 @@ def test_load_an_existing_config(
 
 def test_serialize_fluent_config(
     cloud_storage_get_client_doubles,
-    seeded_fds_file_context: FileDataContext,
+    seeded_file_context: FileDataContext,
 ):
-    dumped_yaml: str = seeded_fds_file_context.fluent_config.yaml()
+    dumped_yaml: str = seeded_file_context.fluent_config.yaml()
     print(f"  Dumped Config\n\n{dumped_yaml}\n")
 
-    assert seeded_fds_file_context.fluent_config.datasources
+    assert seeded_file_context.fluent_config.datasources
 
     for (
         ds_name,
         datasource,
-    ) in seeded_fds_file_context.fluent_config.get_datasources_as_dict().items():
+    ) in seeded_file_context.fluent_config.get_datasources_as_dict().items():
         assert ds_name in dumped_yaml
 
         for asset_name in datasource.get_asset_names():
@@ -212,14 +212,14 @@ def test_data_connectors_are_built_on_config_load(
     assert dc_datasources
 
 
-def test_fluent_simple_validate_workflow(seeded_fds_file_context: FileDataContext):
-    datasource = seeded_fds_file_context.get_datasource("sqlite_taxi")
+def test_fluent_simple_validate_workflow(seeded_file_context: FileDataContext):
+    datasource = seeded_file_context.get_datasource("sqlite_taxi")
     assert isinstance(datasource, Datasource)
     batch_request = datasource.get_asset("my_asset").build_batch_request(
         {"year": 2019, "month": 1}
     )
 
-    validator = seeded_fds_file_context.get_validator(batch_request=batch_request)
+    validator = seeded_file_context.get_validator(batch_request=batch_request)
     result = validator.expect_column_max_to_be_between(
         column="passenger_count", min_value=1, max_value=12
     )
@@ -227,15 +227,15 @@ def test_fluent_simple_validate_workflow(seeded_fds_file_context: FileDataContex
     assert result["success"] is True
 
 
-def test_save_project_does_not_break(seeded_fds_file_context: FileDataContext):
-    print(seeded_fds_file_context.fluent_config)
-    seeded_fds_file_context._save_project_config()
+def test_save_project_does_not_break(seeded_file_context: FileDataContext):
+    print(seeded_file_context.fluent_config)
+    seeded_file_context._save_project_config()
 
 
-def test_variables_save_config_does_not_break(seeded_fds_file_context: FileDataContext):
-    print(f"\tcontext.fluent_config ->\n{seeded_fds_file_context.fluent_config}\n")
-    print(f"\tcontext.variables ->\n{seeded_fds_file_context.variables}")
-    seeded_fds_file_context.variables.save_config()
+def test_variables_save_config_does_not_break(seeded_file_context: FileDataContext):
+    print(f"\tcontext.fluent_config ->\n{seeded_file_context.fluent_config}\n")
+    print(f"\tcontext.variables ->\n{seeded_file_context.variables}")
+    seeded_file_context.variables.save_config()
 
 
 def test_save_datacontext_persists_fluent_config(


### PR DESCRIPTION
### Changes proposed in this pull request:
- Removes the `AbstractDataContext._build_fds_asset_data_connectors_if_needed()`
- Adds `Datasource._rebuild_asset_data_connectors()` method and call it where needed
- simplify tests


Followup from 
- https://github.com/great-expectations/great_expectations/pull/7813

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
