### PR TITLE
[MAINTENANCE] Enable S3/Spark Connecting To Your Data tests

### DIFF
--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py
@@ -48,7 +48,7 @@ datasource_config = {
 # In normal usage you'd set your path directly in the yaml above.
 datasource_config["data_connectors"]["default_inferred_data_connector_name"][
     "bucket"
-] = "superconductive-public"
+] = "superconductive-docs-test"
 datasource_config["data_connectors"]["default_inferred_data_connector_name"][
     "prefix"
 ] = "data/taxi_yellow_tripdata_samples/"
@@ -74,7 +74,7 @@ batch_request = RuntimeBatchRequest(
 # In normal usage you'd set your path directly in the BatchRequest above.
 batch_request.runtime_parameters[
     "path"
-] = "s3a://superconductive-public/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
+] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
 context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
@@ -49,7 +49,7 @@ data_connectors:
 # Please note this override is only to provide good UX for docs and tests.
 # In normal usage you'd set your path directly in the yaml above.
 datasource_yaml = datasource_yaml.replace(
-    "<YOUR_S3_BUCKET_HERE>", "superconductive-public"
+    "<YOUR_S3_BUCKET_HERE>", "superconductive-docs-test"
 )
 datasource_yaml = datasource_yaml.replace(
     "<BUCKET_PATH_TO_DATA>", "data/taxi_yellow_tripdata_samples/"
@@ -78,7 +78,7 @@ batch_request = RuntimeBatchRequest(
 # In normal usage you'd set your path directly in the BatchRequest above.
 batch_request.runtime_parameters[
     "path"
-] = "s3a://superconductive-public/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
+] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py get validator 1">
 context.add_or_update_expectation_suite(expectation_suite_name="test_suite")

--- a/tests/integration/test_definitions/s3/integration_tests.py
+++ b/tests/integration/test_definitions/s3/integration_tests.py
@@ -34,13 +34,13 @@ connecting_to_your_data = [
         name="s3_spark_inferred_and_runtime_yaml_example",
         user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[[BackendDependencies.SPARK, BackendDependencies.AWS]],
+        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
     ),
     IntegrationTestFixture(
         name="s3_spark_inferred_and_runtime_python_example",
         user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[[BackendDependencies.SPARK, BackendDependencies.AWS]],
+        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
     ),
 ]
 

--- a/tests/integration/test_definitions/s3/integration_tests.py
+++ b/tests/integration/test_definitions/s3/integration_tests.py
@@ -30,50 +30,18 @@ connecting_to_your_data = [
         data_dir="tests/test_sets/dataconnector_docs",
         backend_dependencies=[BackendDependencies.AWS],
     ),
-    # TODO: <Alex>ALEX -- uncomment all S3 tests once S3 testing in Azure Pipelines is re-enabled and items for specific tests below are addressed.</Alex>
-    # TODO: <Alex>ALEX -- Implement S3 Configured YAML Example</Alex>
-    # TODO: <Alex>ALEX -- uncomment next test once S3 Configured YAML Example is implemented.</Alex>
-    # IntegrationTestFixture(
-    #     name = "s3_pandas_configured_yaml_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/pandas/configured_yaml_example.py",
-    #     data_context_dir= "tests/integration/fixtures/no_datasources/great_expectations",
-    #     backend_dependencies=[ BackendDependencies.AWS],
-    # ),
-    # TODO: <Alex>ALEX -- Implement S3 Configured Python Example</Alex>
-    # TODO: <Alex>ALEX -- uncomment next test once S3 Configured Python Example is implemented.</Alex>
-    # IntegrationTestFixture(
-    #     name = "s3_pandas_configured_python_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/pandas/configured_python_example.py",
-    #     data_context_dir= "tests/integration/fixtures/no_datasources/great_expectations",
-    #     backend_dependencies=[ BackendDependencies.AWS],
-    # ),
-    # TODO: <Alex>ALEX -- Implement S3 Configured YAML Example</Alex>
-    # TODO: <Alex>ALEX -- uncomment next test once Spark in Azure Pipelines is enabled and S3 Configured YAML Example is implemented.</Alex>
-    # IntegrationTestFixture(
-    #     name = "s3_spark_configured_yaml_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/configured_yaml_example.py",
-    #     backend_dependencies=[ [BackendDependencies.SPARK, BackendDependencies.AWS]],
-    # ),
-    # TODO: <Alex>ALEX -- Implement S3 Configured Python Example</Alex>
-    # TODO: <Alex>ALEX -- uncomment next test once Spark in Azure Pipelines is enabled and S3 Configured Python Example is implemented.</Alex>
-    # IntegrationTestFixture(
-    #     name = "s3_spark_configured_python_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/configured_python_example.py",
-    #     backend_dependencies=[ [BackendDependencies.SPARK, BackendDependencies.AWS]],
-    # ),
-    # TODO: <Alex>ALEX -- uncomment next two (2) tests once Spark in Azure Pipelines is enabled.</Alex>
-    # IntegrationTestFixture(
-    #     name = "s3_spark_inferred_and_runtime_yaml_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py",
-    #     data_context_dir= "tests/integration/fixtures/no_datasources/great_expectations",
-    #     backend_dependencies=[ [BackendDependencies.SPARK, BackendDependencies.AWS]],
-    # ),
-    # IntegrationTestFixture(
-    #     name = "s3_spark_inferred_and_runtime_python_example",
-    #     user_flow_script= "tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py",
-    #     data_context_dir= "tests/integration/fixtures/no_datasources/great_expectations",
-    #     backend_dependencies=[ [BackendDependencies.SPARK, BackendDependencies.AWS]],
-    # ),
+    IntegrationTestFixture(
+        name="s3_spark_inferred_and_runtime_yaml_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[[BackendDependencies.SPARK, BackendDependencies.AWS]],
+    ),
+    IntegrationTestFixture(
+        name="s3_spark_inferred_and_runtime_python_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[[BackendDependencies.SPARK, BackendDependencies.AWS]],
+    ),
 ]
 
 deployment_patterns = [


### PR DESCRIPTION
Changes proposed in this pull request:
- Follow up to #7819 
- Enables S3/Spark Integration tests that had been commented out until now
- Removes references to `configured` tests that no longer exist. 

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.