### PR TITLE
[DOCS] Fix snippet parsing logic when evaluating regex in docs

### DIFF
--- a/docs/docusaurus/scripts/remark-named-snippets/snippet.js
+++ b/docs/docusaurus/scripts/remark-named-snippets/snippet.js
@@ -71,6 +71,9 @@ function parseFile (file) {
   const parser = new htmlparser2.Parser({
     onopentag (tagname, attrs) {
       if (tagname !== 'snippet') {
+        // If we see a non-snippet tag, we want to make sure we still append the literal text to our parsed results.
+        // This is particularly relevant around regex in our docs
+        this.ontext(`<${tagname}>`)
         return
       }
 


### PR DESCRIPTION
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
