### PR TITLE
[MAINTENANCE] Fixing path formatting for DataConnector of Fluent SparkAzureBlobStorageDatasource and correction of the `SQLAlchemy` compatibility usage in `TableHead` metric 

### DIFF
--- a/great_expectations/compatibility/sqlalchemy.py
+++ b/great_expectations/compatibility/sqlalchemy.py
@@ -168,6 +168,11 @@ except (ImportError, AttributeError):
     quoted_name = SQLALCHEMY_NOT_IMPORTED
 
 try:
+    from sqlalchemy.sql.elements import _anonymous_label
+except (ImportError, AttributeError):
+    _anonymous_label = SQLALCHEMY_NOT_IMPORTED
+
+try:
     from sqlalchemy.sql.elements import ColumnElement
 except (ImportError, AttributeError):
     ColumnElement = SQLALCHEMY_NOT_IMPORTED

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -152,7 +152,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
             container=abs_container,
             name_starts_with=abs_name_starts_with,
             delimiter=abs_delimiter,
-            file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_HTTPS_URL_TEMPLATE.format,
+            file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_WASBS_URL_TEMPLATE.format,
         )
 
         # build a more specific `_test_connection_error_message`

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Iterator
 
 import pandas as pd
 
+from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.sqlalchemy_and_pandas import (
     pandas_read_sql,
@@ -75,9 +76,9 @@ class TableHead(TableMetricProvider):
             else cls.default_kwarg_values["n_rows"]
         )
         df_chunk_iterator: Iterator[pd.DataFrame]
-        if (
-            isinstance(table_name, sa.sql.elements._anonymous_label)
-            or table_name is None
+        if (table_name is None) or (
+            sqlalchemy._anonymous_label
+            and isinstance(table_name, sqlalchemy._anonymous_label)
         ):
             # if a custom query was passed
             try:
@@ -126,7 +127,6 @@ class TableHead(TableMetricProvider):
                     df = TableHead._get_head_df_from_df_iterator(
                         df_chunk_iterator=df_chunk_iterator, n_rows=n_rows
                     )
-
             except (ValueError, NotImplementedError):
                 # MetaData that is used by pd.read_sql_table
                 # cannot work on a temp table with pandas < 1.4.0.
@@ -161,6 +161,7 @@ class TableHead(TableMetricProvider):
             else:
                 if n_rows > 0:
                     stmt = stmt.limit(n_rows)
+
                 sql = stmt.compile(
                     dialect=execution_engine.engine.dialect,
                     compile_kwargs={"literal_binds": True},
@@ -175,7 +176,7 @@ class TableHead(TableMetricProvider):
                     df_chunk_iterator=df_chunk_iterator, n_rows=n_rows
                 )
             else:
-                df = pandas_read_sql(sql=sql, con=execution_engine.engine)
+                df = pandas_read_sql_query(sql=sql, con=execution_engine.engine)
 
         return df
 


### PR DESCRIPTION
### Scope
* Fix to AzureBlobStorage path formatting used in `DataConnector` for SparkAzureBlobStorageDatasource (Fluent Datasources).
* Correction of the `SQLAlchemy` compatibility usage in `TableHead` metric.

### Remarks
* Both of the above-stated problems were discovered -- and their corrections verified -- via User Acceptance Testing (a `Jupyter` notebook of Fluent Datasources against Microsoft Azure Blob Storage files and Amazon Athena database).

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!