### PR TITLE
[BUGFIX] Fix inability to extend SimpleCheckpoint -- and several additional enhancements and clean up

### DIFF
--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -602,10 +602,12 @@ class RuntimeBatchRequest(BatchRequestBase):
         batch_identifiers: Optional[dict],
         batch_spec_passthrough: Optional[dict] = None,
     ) -> None:
-        # we either have both runtime_parameters and batch_identifiers, or neither
-        if not (
-            (not runtime_parameters and not batch_identifiers)
-            or (runtime_parameters and batch_identifiers)
+        """
+        We must have both or neither of runtime_parameters and batch_identifiers (but not either one of them).
+        This is strict equivalence ("if-and-only") condition ("exclusive NOR"); otherwise, ("exclusive OR") means error.
+        """
+        if (not runtime_parameters and batch_identifiers) or (
+            runtime_parameters and not batch_identifiers
         ):
             raise ValueError(
                 "It must be that either both runtime_parameters and batch_identifiers are present, or both are missing"

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -962,7 +962,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             verify_dynamic_loading_support(module_name=module_name)
             class_name = kwargs.get("class_name", "Datasource")
             datasource_class = load_class(
-                module_name=module_name, class_name=class_name
+                class_name=class_name, module_name=module_name
             )
 
             # For any class that should be loaded, it may control its configuration construction

--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -260,6 +260,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, str] = ...,
+        create_temp_table: bool = True,
     ) -> SQLDatasource: ...
     def update_sql(
         self,
@@ -268,6 +269,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, str] = ...,
+        create_temp_table: bool = True,
     ) -> SQLDatasource: ...
     def add_or_update_sql(
         self,
@@ -276,6 +278,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, str] = ...,
+        create_temp_table: bool = True,
     ) -> SQLDatasource: ...
     def delete_sql(
         self,
@@ -288,6 +291,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def update_postgres(
         self,
@@ -296,6 +300,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def add_or_update_postgres(
         self,
@@ -304,6 +309,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def delete_postgres(
         self,
@@ -523,6 +529,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, SqliteDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> SqliteDatasource: ...
     def update_sqlite(
         self,
@@ -531,6 +538,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, SqliteDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> SqliteDatasource: ...
     def add_or_update_sqlite(
         self,
@@ -539,6 +547,7 @@ class _SourceFactories:
         datasource: Optional[Datasource] = None,
         *,
         connection_string: Union[ConfigStr, SqliteDsn, str] = ...,
+        create_temp_table: bool = True,
     ) -> SqliteDatasource: ...
     def delete_sqlite(
         self,

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -14,7 +14,7 @@ import pytest
 
 import great_expectations as gx
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.checkpoint import Checkpoint, LegacyCheckpoint
+from great_expectations.checkpoint import Checkpoint, LegacyCheckpoint, SimpleCheckpoint
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.core import ExpectationSuiteValidationResult
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
@@ -96,6 +96,66 @@ def test_checkpoint_with_config_version_has_action_list(empty_data_context):
     obs = checkpoint.action_list
     assert isinstance(obs, list)
     assert obs == [{"foo": "bar"}]
+
+
+def test_add_custom_checkpoint_extensions(
+    titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
+    common_action_list,
+):
+    context: FileDataContext = titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled
+    context.add_expectation_suite(expectation_suite_name="my_expectation_suite")
+
+    checkpoint_config: dict = {
+        "class_name": "ExtendedCheckpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_checkpoint",
+        "expectation_suite_name": "my_expectation_suite",
+        "action_list": common_action_list,
+    }
+    checkpoint = context.add_checkpoint(**checkpoint_config)
+    assert issubclass(checkpoint.__class__, Checkpoint)
+    assert checkpoint.__class__.__name__ == "ExtendedCheckpoint"
+
+    checkpoint_config: dict = {
+        "class_name": "ExtendedSimpleCheckpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_checkpoint",
+        "expectation_suite_name": "my_expectation_suite",
+        "action_list": common_action_list,
+    }
+    checkpoint = context.add_checkpoint(**checkpoint_config)
+    assert issubclass(checkpoint.__class__, SimpleCheckpoint)
+    assert checkpoint.__class__.__name__ == "ExtendedSimpleCheckpoint"
+
+    checkpoint_config: dict = {
+        "class_name": "ExtendedLegacyCheckpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_checkpoint",
+        "expectation_suite_name": "my_expectation_suite",
+        "action_list": common_action_list,
+    }
+    with pytest.raises(gx_exceptions.InvalidCheckpointConfigError) as icpce:
+        context.add_checkpoint(**checkpoint_config)
+
+    assert (
+        str(icpce.value)
+        == 'Extending "LegacyCheckpoint" is not allowed, because "LegacyCheckpoint" is deprecated.'
+    )
+
+    checkpoint_config: dict = {
+        "class_name": "ExtendedCheckpointIllegalBaseClass",
+        "module_name": "extended_checkpoint",
+        "name": "my_checkpoint",
+        "expectation_suite_name": "my_expectation_suite",
+        "action_list": common_action_list,
+    }
+    with pytest.raises(gx_exceptions.InvalidCheckpointConfigError) as icpce:
+        context.add_checkpoint(**checkpoint_config)
+
+    assert (
+        str(icpce.value)
+        == 'Custom class "ExtendedCheckpointIllegalBaseClass" must extend either "Checkpoint" or "SimpleCheckpoint" (exclusively).'
+    )
 
 
 @mock.patch(
@@ -431,7 +491,6 @@ def test_basic_checkpoint_config_validation(
         gx_exceptions.DataContextError,
         match=r'Checkpoint "my_checkpoint" must be called with a validator or contain either a batch_request or validations.',
     ):
-        # noinspection PyUnusedLocal
         context.run_checkpoint(
             checkpoint_name=checkpoint.name,
         )
@@ -1300,7 +1359,6 @@ def test_legacy_checkpoint_instantiates_and_produces_a_validation_result_when_ru
     filesystem_csv_data_context_with_validation_operators.add_expectation_suite(
         "my_suite"
     )
-    # noinspection PyUnusedLocal
     checkpoint.run()
 
     assert (

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -118,8 +118,8 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedSimpleCheckpoint",
-        "module_name": "my_custom_extended_simple_checkpoint",
-        "name": "my_checkpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_custom_extended_simple_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
     }
@@ -129,8 +129,8 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedLegacyCheckpoint",
-        "module_name": "my_custom_extended_legacy_checkpoint",
-        "name": "my_checkpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_custom_extended_legacy_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
     }
@@ -144,8 +144,8 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedCheckpointIllegalBaseClass",
-        "module_name": "my_custom_extended_checkpoint_illegal_base_class",
-        "name": "my_checkpoint",
+        "module_name": "extended_checkpoint",
+        "name": "my_custom_extended_checkpoint_illegal_base_class",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
     }

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -108,7 +108,7 @@ def test_add_custom_checkpoint_extensions(
     checkpoint_config: dict = {
         "class_name": "ExtendedCheckpoint",
         "module_name": "extended_checkpoint",
-        "name": "my_checkpoint",
+        "name": "my_custom_extended_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
     }
@@ -118,7 +118,7 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedSimpleCheckpoint",
-        "module_name": "extended_checkpoint",
+        "module_name": "my_custom_extended_simple_checkpoint",
         "name": "my_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
@@ -129,7 +129,7 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedLegacyCheckpoint",
-        "module_name": "extended_checkpoint",
+        "module_name": "my_custom_extended_legacy_checkpoint",
         "name": "my_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,
@@ -144,7 +144,7 @@ def test_add_custom_checkpoint_extensions(
 
     checkpoint_config: dict = {
         "class_name": "ExtendedCheckpointIllegalBaseClass",
-        "module_name": "extended_checkpoint",
+        "module_name": "my_custom_extended_checkpoint_illegal_base_class",
         "name": "my_checkpoint",
         "expectation_suite_name": "my_expectation_suite",
         "action_list": common_action_list,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,7 +932,7 @@ def titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_em
                 )
             ),
         ),
-        str(pathlib.Path(context_path / "plugins" / "extended_checkpoint.py")),
+        pathlib.Path(context_path / "plugins" / "extended_checkpoint.py"),
     )
     data_path: str = os.path.join(context_path, "..", "data", "titanic")  # noqa: PTH118
     os.makedirs(os.path.join(data_path), exist_ok=True)  # noqa: PTH118, PTH103
@@ -1565,7 +1565,7 @@ def titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with
                 )
             ),
         ),
-        str(pathlib.Path(context_path / "plugins" / "extended_checkpoint.py")),
+        pathlib.Path(context_path / "plugins" / "extended_checkpoint.py"),
     )
     shutil.copy(
         file_relative_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -917,6 +917,27 @@ def titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_em
     os.makedirs(  # noqa: PTH103
         os.path.join(context_path, "expectations"), exist_ok=True  # noqa: PTH118
     )
+    os.makedirs(  # noqa: PTH103
+        os.path.join(context_path, "plugins"), exist_ok=True  # noqa: PTH118
+    )
+    shutil.copy(
+        file_relative_path(
+            __file__,
+            str(
+                pathlib.Path(
+                    "data_context",
+                    "fixtures",
+                    "plugins",
+                    "extended_checkpoint.py",
+                )
+            ),
+        ),
+        str(
+            os.path.join(
+                context_path, "plugins", "extended_checkpoint.py"
+            )  # noqa: PTH118
+        ),
+    )
     data_path: str = os.path.join(context_path, "..", "data", "titanic")  # noqa: PTH118
     os.makedirs(os.path.join(data_path), exist_ok=True)  # noqa: PTH118, PTH103
     shutil.copy(
@@ -1532,6 +1553,27 @@ def titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with
             ),
         ),
         str(os.path.join(context_path, "great_expectations.yml")),  # noqa: PTH118
+    )
+    os.makedirs(  # noqa: PTH103
+        os.path.join(context_path, "plugins"), exist_ok=True  # noqa: PTH118
+    )
+    shutil.copy(
+        file_relative_path(
+            __file__,
+            str(
+                pathlib.Path(
+                    "data_context",
+                    "fixtures",
+                    "plugins",
+                    "extended_checkpoint.py",
+                )
+            ),
+        ),
+        str(
+            os.path.join(
+                context_path, "plugins", "extended_checkpoint.py"
+            )  # noqa: PTH118
+        ),
     )
     shutil.copy(
         file_relative_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,7 +932,7 @@ def titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_em
                 )
             ),
         ),
-        pathlib.Path(context_path / "plugins" / "extended_checkpoint.py"),
+        pathlib.Path(context_path) / "plugins" / "extended_checkpoint.py",
     )
     data_path: str = os.path.join(context_path, "..", "data", "titanic")  # noqa: PTH118
     os.makedirs(os.path.join(data_path), exist_ok=True)  # noqa: PTH118, PTH103
@@ -1565,7 +1565,7 @@ def titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with
                 )
             ),
         ),
-        pathlib.Path(context_path / "plugins" / "extended_checkpoint.py"),
+        pathlib.Path(context_path) / "plugins" / "extended_checkpoint.py",
     )
     shutil.copy(
         file_relative_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,11 +932,7 @@ def titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_em
                 )
             ),
         ),
-        str(
-            os.path.join(
-                context_path, "plugins", "extended_checkpoint.py"
-            )  # noqa: PTH118
-        ),
+        str(pathlib.Path(context_path / "plugins" / "extended_checkpoint.py")),
     )
     data_path: str = os.path.join(context_path, "..", "data", "titanic")  # noqa: PTH118
     os.makedirs(os.path.join(data_path), exist_ok=True)  # noqa: PTH118, PTH103
@@ -1569,11 +1565,7 @@ def titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with
                 )
             ),
         ),
-        str(
-            os.path.join(
-                context_path, "plugins", "extended_checkpoint.py"
-            )  # noqa: PTH118
-        ),
+        str(pathlib.Path(context_path / "plugins" / "extended_checkpoint.py")),
     )
     shutil.copy(
         file_relative_path(

--- a/tests/data_context/fixtures/plugins/extended_checkpoint.py
+++ b/tests/data_context/fixtures/plugins/extended_checkpoint.py
@@ -1,0 +1,74 @@
+import logging
+from typing import List, Optional
+
+from great_expectations.checkpoint import Checkpoint, LegacyCheckpoint, SimpleCheckpoint
+
+logger = logging.getLogger(__name__)
+
+
+class ExtendedCheckpoint(Checkpoint):
+    def __init__(
+        self,
+        name: str,
+        data_context,
+        expectation_suite_name: Optional[str] = None,
+        action_list: Optional[List[dict]] = None,
+    ):
+        super().__init__(
+            name=name,
+            data_context=data_context,
+            config_version=1,
+            expectation_suite_name=expectation_suite_name,
+            action_list=action_list,
+        )
+
+
+class ExtendedSimpleCheckpoint(SimpleCheckpoint):
+    def __init__(
+        self,
+        name: str,
+        data_context,
+        expectation_suite_name: Optional[str] = None,
+        action_list: Optional[List[dict]] = None,
+    ):
+        super().__init__(
+            name=name,
+            data_context=data_context,
+            config_version=1,
+            expectation_suite_name=expectation_suite_name,
+            action_list=action_list,
+        )
+
+
+class ExtendedLegacyCheckpoint(LegacyCheckpoint):
+    def __init__(
+        self,
+        name: str,
+        data_context,
+        expectation_suite_name: Optional[str] = None,
+        action_list: Optional[List[dict]] = None,
+    ):
+        super().__init__(
+            name=name,
+            data_context=data_context,
+            config_version=1,
+            expectation_suite_name=expectation_suite_name,
+            action_list=action_list,
+        )
+
+
+class ExtendedCheckpointIllegalBaseClass:
+    def __init__(
+        self,
+        name: str,
+        data_context,
+        expectation_suite_name: Optional[str] = None,
+        action_list: Optional[List[dict]] = None,
+    ):
+        super().__init__(
+            name=name,
+            data_context=data_context,
+            config_version=1,
+            expectation_suite_name=expectation_suite_name,
+            action_list=action_list,
+        )


### PR DESCRIPTION
### Scope
* Previously, extending `SimpleCheckpoint` and `Checkpoint` was not working properly, because logic was based on `class_name`; now, the logic is based on which class the extending class is extending.
* Additional tests verifying `SimpleCheckpoint` and `Checkpoint` extension capabilities and `LegacyCheckpoint` extension restrictions.  (Corresponding test fixtures have been included.)
* Code clean up: Fluent Datasources API for handling `SQL` Datasources did not include `create_temp_table` directive in the interface declarations (now they do).
* Code clean up: The logic for handling validation of `runtime_parameters` in `batch.py` was simplified (`not XNOR` became simply `XOR` -- these are equivalent, though the latter is simpler; a docstring was added to explain the logic).

### Remarks
* The relevant issue is `https://github.com/great-expectations/great_expectations/issues/7790`.
* JIRA: DX-470

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!