### PR TITLE
[MAINTENANCE] Add `docs/*.py` to `GXChanged` for linting 

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -79,6 +79,7 @@ stages:
                 setup.py
                 MANIFEST.in
                 tests/**
+                docs/*.py
                 /*.txt
                 /*.yml
                 requirements*

--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -79,7 +79,7 @@ stages:
                 setup.py
                 MANIFEST.in
                 tests/**
-                docs/*.py
+                docs/**/*.py
                 /*.txt
                 /*.yml
                 requirements*


### PR DESCRIPTION
* Adds `docs/*.py` files to `GXChanged` so they can be linted. 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated
