### PR TITLE
[MAINTENANCE] Remove the -rs flag from the ci pytest invocations.

### DIFF
--- a/ci/azure-pipelines-cloud-integration.yml
+++ b/ci/azure-pipelines-cloud-integration.yml
@@ -41,7 +41,7 @@ stages:
           - script: |
               pip freeze > pip-freeze.txt
               mkdir -p junit
-              pytest -rs -v $(test_script) \
+              pytest -v $(test_script) \
                 $(extra_args) \
                 --bigquery \
                 --junitxml=junit/test-results.xml \
@@ -103,7 +103,7 @@ stages:
           - script: |
               pip freeze > pip-freeze.txt
               mkdir -p junit
-              pytest -rs -v $(test_script) \
+              pytest -v $(test_script) \
                 $(extra_args) \
                 --bigquery \
                 --junitxml=junit/test-results.xml \
@@ -137,7 +137,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs -v --snowflake tests/test_definitions/test_expectations_v3_api.py
+              pytest -v --snowflake tests/test_definitions/test_expectations_v3_api.py
             displayName: 'pytest'
             env:
               SNOWFLAKE_ACCOUNT: $(SNOWFLAKE_ACCOUNT)

--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -267,7 +267,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs $(pytest_args) \
+              pytest $(pytest_args) \
                 --no-sqlalchemy \
                 --ignore 'tests/cli' \
                 --ignore 'tests/integration/usage_statistics' \
@@ -330,7 +330,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs $(pytest_args) \
+              pytest $(pytest_args) \
                 --postgresql \
                 --spark \
                 --ignore 'tests/cli' \
@@ -385,7 +385,7 @@ stages:
 
           # Due to the relatively small number of usage_stats tests, we deem it appropriate to test them in their entirely through pytest
           - script: |
-              pytest -rs --no-sqlalchemy --aws-integration -v tests/integration/usage_statistics
+              pytest --no-sqlalchemy --aws-integration -v tests/integration/usage_statistics
 
             displayName: 'pytest'
             env:
@@ -435,7 +435,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs tests/test_definitions tests/expectations \
+              pytest tests/test_definitions tests/expectations \
                 --mysql \
                 --napoleon-docstrings \
                 --junitxml=junit/test-results.xml \
@@ -475,7 +475,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs tests/test_definitions tests/expectations \
+              pytest tests/test_definitions tests/expectations \
                 --mssql \
                 --napoleon-docstrings \
                 --junitxml=junit/test-results.xml \
@@ -521,7 +521,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs tests/test_definitions tests/expectations \
+              pytest tests/test_definitions tests/expectations \
                 --trino \
                 --napoleon-docstrings \
                 --junitxml=junit/test-results.xml \
@@ -564,7 +564,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest -rs --postgresql --spark --aws-integration tests/cli
+              pytest --postgresql --spark --aws-integration tests/cli
 
             displayName: 'pytest'
             env:

--- a/ci/azure-pipelines-docs-integration.yml
+++ b/ci/azure-pipelines-docs-integration.yml
@@ -90,7 +90,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_spark
@@ -115,7 +115,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --spark tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --spark tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_mysql
@@ -159,7 +159,7 @@ stages:
           displayName: 'Configure mysql'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --mysql tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --mysql tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_postgresql
@@ -186,7 +186,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --postgresql tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --postgresql tests/integration/test_script_runner.py
           displayName: 'pytest'
 
 
@@ -228,7 +228,7 @@ stages:
           displayName: 'Install and setup Google Cloud SDK'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --bigquery tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --bigquery tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # GCP credentials
@@ -259,7 +259,7 @@ stages:
           displayName: 'Create MSSQL database test_ci'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --mssql tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --mssql tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_snowflake
@@ -279,7 +279,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --snowflake tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --snowflake tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # snowflake credentials
@@ -308,7 +308,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --redshift tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --redshift tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # redshift credentials
@@ -340,7 +340,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --aws tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --aws tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
@@ -378,7 +378,7 @@ stages:
             pip install --constraint constraints-dev.txt ".[dev]" pytest-azurepipelines git+https://github.com/awslabs/aws-glue-libs.git
           displayName: 'Install dependencies'
         - script: |
-            pytest -rs -v --docs-tests -m integration --aws --spark tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --aws --spark tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
@@ -402,7 +402,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --azure tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --azure tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
@@ -427,7 +427,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --trino tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --trino tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_athena
@@ -447,7 +447,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --athena tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --athena tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             ATHENA_DB_NAME: $(ATHENA_DB_NAME)
@@ -488,5 +488,5 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -rs -v --docs-tests -m integration --mysql --postgresql tests/integration/test_script_runner.py
+            pytest -v --docs-tests -m integration --mysql --postgresql tests/integration/test_script_runner.py
           displayName: 'pytest'

--- a/ci/azure-pipelines-os-integration.yml
+++ b/ci/azure-pipelines-os-integration.yml
@@ -97,7 +97,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs $(GE_pytest_opts)
+              pytest $(GE_pytest_opts)
             displayName: 'pytest'
 
       - job: macOS
@@ -118,7 +118,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs $(GE_pytest_opts)
+              pytest $(GE_pytest_opts)
             displayName: 'pytest'
 
   - stage: db_integration_latest_sqlalchemy
@@ -164,7 +164,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs --mysql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+              pytest --mysql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'
 
       - job: mssql
@@ -195,7 +195,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs --mssql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+              pytest --mssql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'
 
       - job: postgres
@@ -223,7 +223,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs --postgresql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+              pytest --postgresql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'
 
       - job: trino
@@ -260,5 +260,5 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs --trino --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+              pytest --trino --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'

--- a/ci/azure-pipelines-sqlalchemy-compatibility.yml
+++ b/ci/azure-pipelines-sqlalchemy-compatibility.yml
@@ -129,7 +129,7 @@ stages:
 
           - script: |
               cp constraints-dev.txt constraints-dev-temp.txt
-              echo "SQLAlchemy~=$(sqlalchemy_base_version)" >> constraints-dev-temp.txt 
+              echo "SQLAlchemy~=$(sqlalchemy_base_version)" >> constraints-dev-temp.txt
               pip install --constraint constraints-dev-temp.txt ".[dev]" pytest-azurepipelines
             displayName: 'Install dependencies using SQLAlchemy base version $(sqlalchemy_base_version)'
 
@@ -137,8 +137,8 @@ stages:
           # TODO: best way to test for sqlalchemy version compatibility and implement that here.
           - script: |
               # Run pytest
-              pytest -rs --postgresql -m sqlalchemy_version_compatibility
-              pytest -rs --postgresql -m unit
+              pytest --postgresql -m sqlalchemy_version_compatibility
+              pytest --postgresql -m unit
 
             displayName: 'pytest'
             env:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -240,7 +240,7 @@ stages:
               PYTEST+="--network=host --mount type=bind,source=${PWD}/coverage,target=/coverage "
               # We don't run e2e because we don't want to test connections to external dependencies here.
               PYTEST+="greatexpectations/test:${DOCKER_TAG} /bin/bash -c \"pytest -m 'not e2e' "
-              PYTEST+="--random-order --postgresql --cloud -rs "
+              PYTEST+="--random-order --postgresql --cloud "
               # We should be able to specify --cov-report=xml:path but this doesn't work so we write to the default
               # path and then mv it.
               PYTEST+="--junitxml=/coverage/junit/test-results.xml --cov=. --cov-report=xml --cov-report=html:/coverage/htmlcov "
@@ -290,7 +290,7 @@ stages:
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
               PYTEST="docker run greatexpectations/test:${DOCKER_TAG} "
               # These tests currently do no succeed in random order.
-              PYTEST+="pytest -rs tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py"
+              PYTEST+="pytest tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest Onboarding Data Assistant'
@@ -318,7 +318,7 @@ stages:
               # We do NOT randomize the spark tests.
               # Spark only allows 1 context per JVM process, so we share it between tests.
               # Currently these tests order dependent.
-              PYTEST+="pytest -rs --spark --ignore=tests/cli --ignore=tests/integration/usage_statistics"
+              PYTEST+="pytest --spark --ignore=tests/cli --ignore=tests/integration/usage_statistics"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest Spark'
@@ -360,7 +360,7 @@ stages:
               PYTEST+="greatexpectations/test:${DOCKER_TAG} /bin/bash -c \""
               PYTEST+="mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < /script/mysql_setup.sql && "
               # The last \" closes the quote from bash -c \".
-              PYTEST+="pytest -rs --mysql --random-order tests/test_definitions tests/expectations\""
+              PYTEST+="pytest --mysql --random-order tests/test_definitions tests/expectations\""
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest MySQL'
@@ -397,7 +397,7 @@ stages:
               PYTEST="docker run -e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) "
               PYTEST+="-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) -e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) "
               PYTEST+="--network=host greatexpectations/test:${DOCKER_TAG} "
-              PYTEST+="pytest -rs --trino --random-order tests/test_definitions tests/expectations"
+              PYTEST+="pytest --trino --random-order tests/test_definitions tests/expectations"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest Trino'
@@ -427,7 +427,7 @@ stages:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
               PYTEST="docker run --network=host greatexpectations/test:${DOCKER_TAG} "
-              PYTEST+="pytest -rs --postgresql --spark --aws-integration tests/cli"
+              PYTEST+="pytest --postgresql --spark --aws-integration tests/cli"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest cli'
@@ -463,7 +463,7 @@ stages:
               PYTEST+="pip install --no-cache-dir --requirement requirements-dev.txt "
               PYTEST+="--requirement reqs/requirements-dev-test.txt --constraint constraints-dev.txt "
               PYTEST+="--constraint $(constraints) && "
-              PYTEST+="pytest -rs --no-sqlalchemy --random-order --ignore=tests/cli --ignore=tests/integration/usage_statistic "
+              PYTEST+="pytest --no-sqlalchemy --random-order --ignore=tests/cli --ignore=tests/integration/usage_statistic "
               PYTEST+="--ignore=tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py\""
               echo ${PYTEST}
               eval ${PYTEST}
@@ -492,7 +492,7 @@ stages:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
               PYTEST="docker run --network=host greatexpectations/test:${DOCKER_TAG} "
-              PYTEST+="pytest -rs --no-sqlalchemy --aws-integration --random-order tests/integration/usage_statistics"
+              PYTEST+="pytest --no-sqlalchemy --aws-integration --random-order tests/integration/usage_statistics"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest Usage Stats'
@@ -522,7 +522,7 @@ stages:
               PYTEST+="-e GE_CLOUD_ORGANIZATION_ID=${GX_CLOUD_ORGANIZATION_ID} "
               PYTEST+="-e GE_CLOUD_ACCESS_TOKEN=${GX_CLOUD_ACCESS_TOKEN} -e GE_CLOUD_BASE_URL=${GX_CLOUD_BASE_URL} "
               PYTEST+="greatexpectations/test:${DOCKER_TAG} "
-              PYTEST+="pytest -rs --random-order --cloud -m \"cloud and e2e\""
+              PYTEST+="pytest --random-order --cloud -m \"cloud and e2e\""
               echo ${PYTEST}
               eval ${PYTEST}
             env:
@@ -600,7 +600,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pytest -rs tests/test_definitions tests/expectations \
+              pytest tests/test_definitions tests/expectations \
                 --mssql \
                 --napoleon-docstrings \
                 --junitxml=junit/test-results.xml \

--- a/ci/dev-install-matrix.yml
+++ b/ci/dev-install-matrix.yml
@@ -32,7 +32,7 @@ jobs:
 
         - script: |
             pip install pytest pytest-cov pytest-azurepipelines
-            pytest -rs --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
           displayName: 'pytest'
 
         - task: PublishTestResults@2
@@ -79,7 +79,7 @@ jobs:
         - script: |
             pip install -I pytest
             pip install pytest-cov pytest-azurepipelines
-            pytest -rs --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "not external_sqldialect"
+            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "not external_sqldialect"
           displayName: 'pytest'
 
         - task: PublishTestResults@2


### PR DESCRIPTION
I've removed the flag `-rs` from our pytest invocations which displays skipped tests in the summary. This reverts it to the default, listing failures and errors.

I ran this from the `ci` directory than visually inspected the diff.
```
for x in *.yml; do echo $x; perl -lane 's/ \-rs / /g; print' $x > ${x}.t; mv ${x}.t $x; done
```

I also verified I no longer see this flag using `grep '\-rs' *.yml`.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
