### PR TITLE
[MAINTENANCE] ignore black formatting and ruff auto-fix revisions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ f5e7df1846102d9a62cc9b9110387925ffae60cc
 # Apply noqa markers for TID251 (sqlalchemy) violations
 # https://github.com/great-expectations/great_expectations/pull/7564
 e55b3484a86f654e8b819041dd6cc73730e01a8f
+# python 3.7 -> 3.8 Ruff auto-fixes
+# https://github.com/great-expectations/great_expectations/pull/7945
+85b81029c759dc2b6a8c8956a5babb19e3280494

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@ e55b3484a86f654e8b819041dd6cc73730e01a8f
 # python 3.7 -> 3.8 Ruff auto-fixes
 # https://github.com/great-expectations/great_expectations/pull/7945
 85b81029c759dc2b6a8c8956a5babb19e3280494
+# black 2.2 -> 2.3 formatting changes
+# https://github.com/great-expectations/great_expectations/pull/7946
+582fe60179b9b8bf31ba0a394bfa669f495ce8c6

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,6 +3,7 @@
 # https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt
 # A typical use of these would be if a large formatting change was applied across the whole codebase but otherwise
 # no runtime changes were made. Each entry should be preceded with a comment explaining the change.
+#
 # https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame
 # Apply noqa markers for all TCH001 violations
 f5e7df1846102d9a62cc9b9110387925ffae60cc


### PR DESCRIPTION
Adds the following PR's to `.git-blame-ignore-revs` to make our git blame easier to follow
- https://github.com/great-expectations/great_expectations/pull/7945
- https://github.com/great-expectations/great_expectations/pull/7946


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
