### PR TITLE
[DOCS] Fix issues with technical tags links in earlier versions

### DIFF
--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -225,11 +225,10 @@ def use_relative_imports_for_tag_references(
             f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
         )
         for file_path in files:
-            relative_path = file_path.relative_to(path)
             with open(file_path, "r+") as f:
                 contents = f.read()
                 contents = _use_relative_imports_for_tag_references_substitution(
-                    contents, relative_path
+                    contents, path, file_path
                 )
                 f.seek(0)
                 f.truncate()
@@ -243,7 +242,7 @@ def use_relative_imports_for_tag_references(
 
 
 def _use_relative_imports_for_tag_references_substitution(
-    contents: str, relative_path: pathlib.Path
+    contents: str, path_to_versioned_docs: pathlib.Path, path_to_document: pathlib.Path
 ) -> str:
     """Change import path to use relative instead of @site alias.
 
@@ -252,15 +251,18 @@ def _use_relative_imports_for_tag_references_substitution(
 
     Args:
         contents: String to perform substitution.
-        relative_path: Path from document where import is included to the term_tags folder.
+        path_to_versioned_docs: e.g. "docs/docusaurus/versioned_docs/version-0.14.13/"
+        path_to_document: Path to the document containing the import to substitute.
 
     Returns:
         Updated contents
     """
+    relative_path = path_to_document.relative_to(path_to_versioned_docs)
+    dotted_relative_path = "/".join(".." for _ in range(len(relative_path.parts)))
     pattern = re.compile(
         r"(?P<import>import TechnicalTag from ')(?P<at_site>@site/docs/)(?P<rest>.*)"
     )
-    contents = re.sub(pattern, rf"\g<import>{relative_path}/\g<rest>", contents)
+    contents = re.sub(pattern, rf"\g<import>{dotted_relative_path}/\g<rest>", contents)
     return contents
 
 

--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -258,7 +258,7 @@ def _use_relative_imports_for_tag_references_substitution(
         Updated contents
     """
     relative_path = path_to_document.relative_to(path_to_versioned_docs)
-    dotted_relative_path = "/".join(".." for _ in range(len(relative_path.parts)))
+    dotted_relative_path = "/".join(".." for _ in range(len(relative_path.parts) - 1))
     pattern = re.compile(
         r"(?P<import>import TechnicalTag from ')(?P<at_site>@site/docs/)(?P<rest>.*)"
     )

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -50,7 +50,7 @@ This guide will help you connect to your data stored on GCS using Pandas.
     )
 
     expected_contents = """import TabItem from '@theme/TabItem';
-import TechnicalTag from '../../../../../term_tags/_tag.mdx';
+import TechnicalTag from '../../../../term_tags/_tag.mdx';
 
 This guide will help you connect to your data stored on GCS using Pandas.
 """

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -38,9 +38,15 @@ import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
 This guide will help you connect to your data stored on GCS using Pandas.
 """
 
-    relative_path = pathlib.Path("../../../../../")
+    path_to_versioned_docs = pathlib.Path(
+        "docs/docusaurus/versioned_docs/version-0.14.13/"
+    )
+    file_path = pathlib.Path(
+        "docs/docusaurus/versioned_docs/version-0.14.13/guides/connecting_to_your_data/cloud/gcs/pandas.md"
+    )
+
     updated_contents = _use_relative_imports_for_tag_references_substitution(
-        contents, relative_path
+        contents, path_to_versioned_docs, file_path
     )
 
     expected_contents = """import TabItem from '@theme/TabItem';

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -1,7 +1,10 @@
+import pathlib
+
 import pytest
 
 from docs.prepare_prior_versions import (
     _update_tag_references_for_correct_version_substitution,
+    _use_relative_imports_for_tag_references_substitution,
 )
 
 
@@ -24,4 +27,26 @@ def test__update_tag_references_for_correct_version_substitution():
     <a href={'/docs/0.15.50/' + data[props.tag].url}>{props.text}</a>
     <span class="tooltiptext">{data[props.tag].definition}</span>
 </span>"""
+    assert updated_contents == expected_contents
+
+
+@pytest.mark.unit
+def test__use_relative_imports_for_tag_references_substitution():
+    contents = """import TabItem from '@theme/TabItem';
+import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
+
+This guide will help you connect to your data stored on GCS using Pandas.
+"""
+
+    relative_path = pathlib.Path("../../../../../")
+    updated_contents = _use_relative_imports_for_tag_references_substitution(
+        contents, relative_path
+    )
+
+    expected_contents = """import TabItem from '@theme/TabItem';
+import TechnicalTag from '../../../../../term_tags/_tag.mdx';
+
+This guide will help you connect to your data stored on GCS using Pandas.
+"""
+
     assert updated_contents == expected_contents


### PR DESCRIPTION
- Earlier versions need a relative link so that the technical tag implementation used is the one appropriate for that version.