### PR TITLE
[BUGFIX] Setting maximum on `typing-extension` package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,6 @@ requests>=2.20
 ruamel.yaml>=0.16,<0.17.18  # See https://github.com/great-expectations/great_expectations/issues/4152
 scipy>=1.6.0
 tqdm>=4.59.0
-typing-extensions>=3.10.0.0 # Leverage type annotations from recent Python releases
+typing-extensions>=3.10.0.0,<4.6.0 # Leverage type annotations from recent Python releases
 tzlocal>=1.2
 urllib3>=1.26

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -179,7 +179,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 77
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 80
 
     assert sorted_packages_with_pins_or_upper_bounds == [
         ("requirements-dev-api-docs-test.txt", "docstring-parser", (("==", "0.15"),)),
@@ -246,6 +246,11 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "sqlalchemy", (("<", "2.0.0"), (">=", "1.4.0"))),
         ("requirements-dev.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev.txt", "teradatasqlalchemy", (("==", "17.0.0.1"),)),
+        (
+            "requirements-dev.txt",
+            "typing-extensions",
+            (("<", "4.6.0"), (">=", "3.10.0.0")),
+        ),
         ("requirements-dev.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
         ("requirements-types.txt", "PyMySQL", (("<", "0.10"), (">=", "0.9.3"))),
         ("requirements-types.txt", "adr-tools-python", (("==", "1.0.3"),)),
@@ -265,10 +270,16 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-types.txt", "sqlalchemy", (("<", "2.0.0"), (">=", "1.4.0"))),
         ("requirements-types.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-types.txt", "teradatasqlalchemy", (("==", "17.0.0.1"),)),
+        (
+            "requirements-types.txt",
+            "typing-extensions",
+            (("<", "4.6.0"), (">=", "3.10.0.0")),
+        ),
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "makefun", (("<", "2"), (">=", "1.7.0"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements.txt", "pandas", (("<", "2.0.0"), (">=", "1.3.0"))),
         ("requirements.txt", "pydantic", (("<", "2.0"), (">=", "1.9.2"))),
         ("requirements.txt", "ruamel.yaml", (("<", "0.17.18"), (">=", "0.16"))),
+        ("requirements.txt", "typing-extensions", (("<", "4.6.0"), (">=", "3.10.0.0"))),
     ]


### PR DESCRIPTION
### Scope
Typing-Extensions changed at 15:30 Pacific Time on May 22, 2023 -- this caused `update_forward_refs()` to malfunction.  Hence, putting a maximum on package version.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!