### PR TITLE
[DOCS] Temporarily pin typing-extensions for API docs

### DIFF
--- a/docs/prepare_to_build_docs.sh
+++ b/docs/prepare_to_build_docs.sh
@@ -67,6 +67,9 @@ print_orange_header "Installing Great Expectations library dev dependencies."
 print_orange_header "Installing api docs dependencies."
 (cd ../sphinx_api_docs_source; pip install -r requirements-dev-api-docs.txt)
 
+print_orange_header "Temporarily pinning typing_extensions<4.6.0"
+pip install --upgrade typing-extensions">=3.10.0.0,<4.6.0"
+
 print_orange_header "Building API docs for current version. Please ignore sphinx docstring errors in red/pink, for example: ERROR: Unexpected indentation."
 (cd ../../; invoke api-docs)
 


### PR DESCRIPTION
See also https://github.com/great-expectations/great_expectations/pull/7970. Temporary pin in API docs build pipeline since the API docs build uses the latest release, not develop.
Should be reverted after the next release.