### PR TITLE
[MAINTENANCE] Refactor documentation integration tests into their proper categories according to their respective backend.

### DIFF
--- a/tests/integration/test_definitions/abs/integration_tests.py
+++ b/tests/integration/test_definitions/abs/integration_tests.py
@@ -67,6 +67,16 @@ split_data = []
 
 sample_data = []
 
+fluent_datasources = [
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_azure_blob_storage_using_pandas",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.AZURE],
+    ),
+]
+
 abs_integration_tests += connecting_to_your_data
 abs_integration_tests += split_data
 abs_integration_tests += sample_data
+abs_integration_tests += fluent_datasources

--- a/tests/integration/test_definitions/gcs/integration_tests.py
+++ b/tests/integration/test_definitions/gcs/integration_tests.py
@@ -110,8 +110,18 @@ deployment_patterns = [
     ),
 ]
 
+fluent_datasources = [
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_gcs_using_pandas",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_pandas.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.GCS],
+    ),
+]
+
 gcs_integration_tests += connecting_to_your_data
 gcs_integration_tests += how_to_configure_metadata_store
 gcs_integration_tests += split_data
 gcs_integration_tests += sample_data
 gcs_integration_tests += deployment_patterns
+gcs_integration_tests += fluent_datasources

--- a/tests/integration/test_definitions/multiple_backend/integration_tests.py
+++ b/tests/integration/test_definitions/multiple_backend/integration_tests.py
@@ -3,6 +3,30 @@ from tests.integration.integration_test_fixture import IntegrationTestFixture
 
 multiple_backend = []
 
+connecting_to_your_data = [
+    IntegrationTestFixture(
+        name="s3_spark_inferred_and_runtime_yaml_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
+    ),
+    IntegrationTestFixture(
+        name="s3_spark_inferred_and_runtime_python_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
+    ),
+]
+
+deployment_patterns = [
+    IntegrationTestFixture(
+        name="deployment_pattern_spark_s3",
+        user_flow_script="tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py",
+        data_context_dir=None,
+        backend_dependencies=[BackendDependencies.AWS, BackendDependencies.SPARK],
+    ),
+]
+
 cross_table_comparisons = [
     # Uncomment after mysql warnings are resolved and mysql stage of docs-integration is uncommented
     # IntegrationTestFixture(
@@ -37,5 +61,29 @@ creating_custom_expectations = [
     ),
 ]
 
+fluent_datasources = [
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_s3_using_spark",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_spark.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.AWS, BackendDependencies.SPARK],
+    ),
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_gcs_using_spark",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_spark.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.GCS, BackendDependencies.SPARK],
+    ),
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_azure_blob_storage_using_spark",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_spark.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.AZURE, BackendDependencies.SPARK],
+    ),
+]
+
+multiple_backend += connecting_to_your_data
+multiple_backend += deployment_patterns
 multiple_backend += cross_table_comparisons
 multiple_backend += creating_custom_expectations
+multiple_backend += fluent_datasources

--- a/tests/integration/test_definitions/s3/integration_tests.py
+++ b/tests/integration/test_definitions/s3/integration_tests.py
@@ -30,18 +30,6 @@ connecting_to_your_data = [
         data_dir="tests/test_sets/dataconnector_docs",
         backend_dependencies=[BackendDependencies.AWS],
     ),
-    IntegrationTestFixture(
-        name="s3_spark_inferred_and_runtime_yaml_example",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
-    ),
-    IntegrationTestFixture(
-        name="s3_spark_inferred_and_runtime_python_example",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.SPARK, BackendDependencies.AWS],
-    ),
 ]
 
 deployment_patterns = [
@@ -51,19 +39,23 @@ deployment_patterns = [
         data_context_dir=None,
         backend_dependencies=[BackendDependencies.AWS],
     ),
-    IntegrationTestFixture(
-        name="deployment_pattern_spark_s3",
-        user_flow_script="tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py",
-        data_context_dir=None,
-        backend_dependencies=[BackendDependencies.AWS, BackendDependencies.SPARK],
-    ),
 ]
 
 split_data = []
 
 sample_data = []
 
+fluent_datasources = [
+    IntegrationTestFixture(
+        name="how_to_connect_to_data_on_s3_using_pandas",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_pandas.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        backend_dependencies=[BackendDependencies.AWS],
+    ),
+]
+
 s3_integration_tests += connecting_to_your_data
 s3_integration_tests += deployment_patterns
 s3_integration_tests += split_data
 s3_integration_tests += sample_data
+s3_integration_tests += fluent_datasources

--- a/tests/integration/test_definitions/spark/integration_tests.py
+++ b/tests/integration/test_definitions/spark/integration_tests.py
@@ -105,6 +105,17 @@ creating_custom_expectations = [
     ),
 ]
 
+fluent_datasources = [
+    IntegrationTestFixture(
+        name="how_to_connect_to_one_or_more_files_using_spark",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_spark.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+        backend_dependencies=[BackendDependencies.SPARK],
+    ),
+]
+
 spark_integration_tests += connecting_to_your_data
 spark_integration_tests += databricks_deployment_patterns
+spark_integration_tests += fluent_datasources
 spark_integration_tests += migration_guide

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -348,13 +348,6 @@ fluent_datasources = [
         data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
     ),
     IntegrationTestFixture(
-        name="how_to_connect_to_one_or_more_files_using_spark",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_spark.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-        backend_dependencies=[BackendDependencies.SPARK],
-    ),
-    IntegrationTestFixture(
         name="how_to_quickly_connect_to_a_single_file_with_pandas",
         user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_quickly_connect_to_a_single_file_with_pandas.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
@@ -363,42 +356,6 @@ fluent_datasources = [
         name="how_to_connect_to_sqlite_data",
         user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sqlite_data.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_s3_using_pandas",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_pandas.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.AWS],
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_s3_using_spark",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_spark.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.AWS, BackendDependencies.SPARK],
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_gcs_using_pandas",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_pandas.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.GCS],
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_gcs_using_spark",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_spark.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.GCS, BackendDependencies.SPARK],
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_azure_blob_storage_using_pandas",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.AZURE],
-    ),
-    IntegrationTestFixture(
-        name="how_to_connect_to_data_on_azure_blob_storage_using_spark",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_spark.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        backend_dependencies=[BackendDependencies.AZURE, BackendDependencies.SPARK],
     ),
 ]
 


### PR DESCRIPTION
### Scope
* DocuSaurus documentation tests should be organized according to the backend (Spark, GCS, Azure Blob Storage, S3).  Multiple backend tests (e.g., Spark with S3, Spark with GCS, etc.) go into a separate combined category.

### Remarks
* JIRA: DX-469/DX-441

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!