### PR TITLE
[FEATURE] Update mySQL docker compose to specify platform

### DIFF
--- a/CONTRIBUTING_CODE.md
+++ b/CONTRIBUTING_CODE.md
@@ -229,8 +229,6 @@ To resolve these errors, configure Docker to run on another port and confirm the
 
 ### MySQL
 
-The `mysql` Docker image can't be used with Mac computers with Apple M1 chips.
-
 If another service is using port 3306, Docker might start the container but silently fail to set up the port.
 
 1. CD to `assets/docker/mysql` in your `great_expectations` repository, and then and run the following command:

--- a/assets/docker/mysql/docker-compose.yml
+++ b/assets/docker/mysql/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.2'
 services:
   mysql_db:
+    platform: linux/amd64
     image: mysql:8.0.20
     volumes:
         - ./conf.d:/etc/mysql/conf.d


### PR DESCRIPTION

This update allows the mySQL docker to build and run on M2 macs (I have not tested on M1 but my assumption is that it is similar and would work).

Before:
<img width="902" alt="Screenshot 2023-05-30 at 3 10 14 PM" src="https://github.com/great-expectations/great_expectations/assets/2117313/4cce2fd4-c49b-4d40-a657-15318f457dba">

After: 
<img width="1708" alt="Screenshot 2023-05-30 at 3 10 04 PM" src="https://github.com/great-expectations/great_expectations/assets/2117313/2425d62c-e209-4c69-bb83-bbc93dc4e873">

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
