### PR TITLE
[DOCS] Update Links in How to use auto-initializing Expectations

### DIFF
--- a/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
+++ b/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
@@ -5,7 +5,7 @@ title: How to use auto-initializing Expectations
 import Prerequisites from '../../guides/connecting_to_your_data/components/prerequisites.jsx'
 import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
 
-This guide will walk you through the process of using a auto-initializing <TechnicalTag tag="expectation" text="Expectations" /> to automate parameter estimation when you are creating Expectations interactively by using a <TechnicalTag tag="batch" text="Batch" /> or Batches that have been loaded into a <TechnicalTag tag="validator" text="Validator" />.
+This guide will walk you through the process of using auto-initializing <TechnicalTag tag="expectation" text="Expectations" /> to automate parameter estimation when you are creating Expectations interactively by using a <TechnicalTag tag="batch" text="Batch" /> or Batches that have been loaded into a <TechnicalTag tag="validator" text="Validator" />.
 
 This guide assumes that you are creating and editing expectations in a Jupyter Notebook.  This process is covered in the guide: [How to create and edit expectations with instant feedback from a sample batch of data](./how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md).  
 
@@ -84,9 +84,8 @@ Now that the Expectation's upper and lower bounds have come from the Batches, yo
 ```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/auto_initializing_expect_column_mean_to_be_between.py save suite"
 ```
 
-
 ## Additional information
 
-To view the full scripts that were used in this page, see them on GitHub:
-- [is_expectation_auto_initializing.py](https://github.com/great-expectations/tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py)
-- [auto_initializing_expect_column_mean_to_be_between.py](https://github.com/great-expectations/tests/integration/docusaurus/expectations/auto_initializing_expectations/auto_initializing_expect_column_mean_to_be_between.py)
+The following scripts are used in this topic and are available in GitHub:
+- [is_expectation_auto_initializing.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py)
+- [auto_initializing_expect_column_mean_to_be_between.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/expectations/auto_initializing_expectations/auto_initializing_expect_column_mean_to_be_between.py)

--- a/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
+++ b/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
@@ -5,11 +5,11 @@ title: How to use auto-initializing Expectations
 import Prerequisites from '../../guides/connecting_to_your_data/components/prerequisites.jsx'
 import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
 
-This guide will walk you through the process of using auto-initializing <TechnicalTag tag="expectation" text="Expectations" /> to automate parameter estimation when you are creating Expectations interactively by using a <TechnicalTag tag="batch" text="Batch" /> or Batches that have been loaded into a <TechnicalTag tag="validator" text="Validator" />.
+Use the information provided here to learn how you can use auto-initializing <TechnicalTag tag="expectation" text="Expectations" /> to automate parameter estimation when you create Expectations interactively using a <TechnicalTag tag="batch" text="Batch" /> or Batches that have been loaded into a <TechnicalTag tag="validator" text="Validator" />.
 
-This guide assumes that you are creating and editing expectations in a Jupyter Notebook.  This process is covered in the guide: [How to create and edit expectations with instant feedback from a sample batch of data](./how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md).  
+This guide assumes that you are creating and editing expectations in a Jupyter Notebook.  For more information about this process, see [How to create and edit expectations with instant feedback from a sample batch of data](./how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md).  
 
-Additionally, this guide assumes that you are using a multi-batch <TechnicalTag tag="batch_request" text="Batch Request" /> to provide your sample data.  (Auto-initializing Expectations will work when run on a single Batch, but they really shine when run on multiple Batches that would have otherwise needed to be individually processed if a manual aproach were taken.)
+Additionally, this guide assumes that you are using a multi-batch <TechnicalTag tag="batch_request" text="Batch Request" /> to provide your sample data. Auto-initializing Expectations will work when run on a single Batch, but they really shine when run on multiple Batches that would have otherwise needed to be individually processed if a manual approach were taken.
 
 ## Prerequisites
 
@@ -17,12 +17,12 @@ Additionally, this guide assumes that you are using a multi-batch <TechnicalTag 
 - [A configured Data Context](/docs/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_quickly_instantiate_a_data_context)
 - [A configured Datasource](/docs/guides/connecting_to_your_data/connect_to_data_overview)
 - [An understanding of how to configure a BatchRequest](/docs/0.15.50/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource)
-- [An understanding of how to create and edit expectations with instant feedback from a sample batch of data](./how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md)
+- [An understanding of how to create and edit Expectations with instant feedback from a sample batch of data](./how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md)
 
 
 ## 1. Determine if your Expectation is auto-initializing
 
-Not all Expectations are auto-initializng.  In order to be a auto-initializing Expectation, an Expectation must have parameters that can be estimated.  As an example: `ExpectColumnToExist` only takes in a `Domain` (which is the column name) and checks whether the column name is in the list of names in the table's metadata.  This would be an example of an Expectation that would not work under the auto-initializing framework.
+Not all Expectations are auto-initializing.  In order to be an auto-initializing Expectation, an Expectation must have parameters that can be estimated.  As an example: `ExpectColumnToExist` only takes in a `Domain` (which is the column name) and checks whether the column name is in the list of names in the table's metadata.  This would be an example of an Expectation that would not work under the auto-initializing framework.
 
 An example of Expectations that would work under the auto-initializing framework would be the ones that have numeric ranges, like `ExpectColumnMeanToBeBetween`, `ExpectColumnMaxToBeBetween`, and `ExpectColumnSumToBeBetween`.
 
@@ -66,7 +66,7 @@ The Expectation `expect_column_mean_to_be_between()` has the following parameter
 - strict_min (boolean): If True, the column mean must be strictly larger than min_value, default=False
 - strict_max (boolean): If True, the column mean must be strictly smaller than max_value, default=False
 
-Without the auto-initialization framework you would have to get the values for `min_value` and `max_value` for your series of 12 Batches by calculating the mean value for each Batch and using calculated `mean` values to determine the `min_value` and `max_value` parameters to pass your Expectation.  This, although not _difficult_, would be a monotonous and time consuming task.
+Without the auto-initialization framework you would have to get the values for `min_value` and `max_value` for your series of 12 Batches by calculating the mean value for each Batch and using calculated `mean` values to determine the `min_value` and `max_value` parameters to pass your Expectation.  This, although not _difficult_, would be a monotonous and time-consuming task.
 
 ### Using `auto=True`
 
@@ -75,7 +75,7 @@ Auto-initializing Expectations automate this sort of calculation across batches.
 ```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/auto_initializing_expect_column_mean_to_be_between.py run expectation"
 ```
 
-Now the Expectation will calculate the `min_value` (2.83) and `max_value` (3.06) using all of the Batches that are loaded into the Validator.  In our case, that means all 12 Batches associated with the 2018 taxi data.
+Now the Expectation will calculate the `min_value` (2.83) and `max_value` (3.06) using all the Batches that are loaded into the Validator.  In our case, that means all 12 Batches associated with the 2018 taxi data.
 
 ## 3. Save your Expectation with the calculated values
 


### PR DESCRIPTION
## Description
@tjholsman identified two broken links in the **Additional information** section of [How to use auto-initializing Expectations](https://docs.greatexpectations.io/docs/guides/expectations/how_to_use_auto_initializing_expectations/). The Slack conversation is located [here](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1685569026130339). This PR updates the links.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated