### PR TITLE
[DOCS] Add ExpectationConfiguration note on Doc

### DIFF
--- a/docs/docusaurus/docs/guides/expectations/how_to_edit_an_existing_expectationsuite.md
+++ b/docs/docusaurus/docs/guides/expectations/how_to_edit_an_existing_expectationsuite.md
@@ -1,8 +1,8 @@
 ---
-title: How to Edit an Expectation Suite 
+title: How to Edit an Expectation Suite using ExpectationConfiguration
 tag: [how-to, getting started]
-description: Create an Expectation Suite using a Validator. Then, examine and modify specific Expectations in the Suite.
-keywords: [Expectations, ExpectationsSuite]
+description: Create an Expectation Suite using a Validator. Then, examine and modify specific Expectations in the Suite using Expectation Configuration.
+keywords: [Expectations, ExpectationsSuite, Expectation Configuration, ExpectationConfiguration]
 ---
 
 import Prerequisites from '/docs/components/_prerequisites.jsx'


### PR DESCRIPTION
Add ExpectationConfiguration on doc as in our current docs, ExpectationConfiguration does not show up through internal doc search. Placing it here by clarifying expectation configuration as the way to edit an expectation suite would be clear in language as well.




- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
