### PR TITLE
[BUGFIX] Erroneous Code Duplication and Lack of Type Hints in Expectation Parent Class

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2900,7 +2900,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
             f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_INDEX_QUERY.value}"
         )
 
-        unexpected_rows = None
+        unexpected_rows: pd.DataFrame | None = None
         if include_unexpected_rows:
             unexpected_rows = metrics.get(
                 f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}"
@@ -3488,7 +3488,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
     unexpected_index_query: Optional[str] = None,
     # Actually Optional[List[str]], but this is necessary to keep the typechecker happy
     unexpected_index_column_names: Optional[Union[int, str, List[str]]] = None,
-    unexpected_rows=None,
+    unexpected_rows: pd.DataFrame | None = None,
 ) -> Dict:
     """Helper function to construct expectation result objects for map_expectations (such as column_map_expectation
     and file_lines_map_expectation).

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2865,13 +2865,13 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format: dict[
-            str, int | str | bool | List[str] | None
+            str, int | str | bool | list[str] | None
         ] | str = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration
         )
 
         include_unexpected_rows: bool
-        unexpected_index_column_names: Union[int, str, List[str]] | None
+        unexpected_index_column_names: int | str | bool | list[str] | None
         if isinstance(result_format, dict):
             include_unexpected_rows = result_format.get(
                 "include_unexpected_rows", False

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2864,14 +2864,12 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        result_format: dict[
-            str, int | str | bool | list[str] | None
-        ] | str = self.get_result_format(
+        result_format: str | dict[str, Any] = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration
         )
 
         include_unexpected_rows: bool
-        unexpected_index_column_names: int | str | bool | list[str] | None
+        unexpected_index_column_names: int | str | list[str] | None
         if isinstance(result_format, dict):
             include_unexpected_rows = result_format.get(
                 "include_unexpected_rows", False

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2864,9 +2864,9 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        result_format: Union[
-            Dict[str, Union[int, str, bool, List[str], None]], str
-        ] = self.get_result_format(
+        result_format: dict[
+            str, int | str | bool | List[str] | None
+        ] | str = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration
         )
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2825,21 +2825,6 @@ class ColumnMapExpectation(BatchExpectation, ABC):
                 ),
             )
 
-        if include_unexpected_rows:
-            metric_kwargs = get_metric_kwargs(
-                metric_name=f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
-                configuration=configuration,
-                runtime_configuration=runtime_configuration,
-            )
-            validation_dependencies.set_metric_configuration(
-                metric_name=f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
-                metric_configuration=MetricConfiguration(
-                    metric_name=f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
-                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
-                ),
-            )
-
         if result_format_str in ["BASIC"]:
             return validation_dependencies
 
@@ -2885,9 +2870,8 @@ class ColumnMapExpectation(BatchExpectation, ABC):
             configuration=configuration, runtime_configuration=runtime_configuration
         )
 
-        unexpected_index_column_names = None
-        include_unexpected_rows = None
-
+        include_unexpected_rows: bool
+        unexpected_index_column_names: Union[int, str, List[str]] | None
         if isinstance(result_format, dict):
             include_unexpected_rows = result_format.get(
                 "include_unexpected_rows", False
@@ -2895,6 +2879,9 @@ class ColumnMapExpectation(BatchExpectation, ABC):
             unexpected_index_column_names = result_format.get(
                 "unexpected_index_column_names", None
             )
+        else:
+            include_unexpected_rows = False
+            unexpected_index_column_names = None
 
         total_count: Optional[int] = metrics.get("table.row_count")
         null_count: Optional[int] = metrics.get(
@@ -2912,6 +2899,7 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         unexpected_index_query: Optional[str] = metrics.get(
             f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_INDEX_QUERY.value}"
         )
+
         unexpected_rows = None
         if include_unexpected_rows:
             unexpected_rows = metrics.get(
@@ -3118,6 +3106,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
                     metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
                 ),
             )
+
         if result_format_str in ["BASIC"]:
             return validation_dependencies
 


### PR DESCRIPTION
### Scope
* There was a potential copy/paste and/or bad merge error in the way of a code section duplicated.
* Also, added type hints for better code interpretability.
* Please see `https://github.com/great-expectations/great_expectations/issues/6813` for full context.

### Remarks
* JIRA: OGI-18
* 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!