### PR TITLE
[DOCS] Add guidance for "DataFrameAsset.build_batch_request()" in "https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas".

### DIFF
--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
@@ -58,7 +58,7 @@ We will use the `build_batch_request(...)` method of our Data Asset to generate 
 
 For `dataframe` Data Assets, the `dataframe` is always specified as the argument of exactly one API method:
 
-```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe"
+```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe"
 ```
 
 ### 5. Verify that the correct Batches were returned

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
@@ -56,6 +56,11 @@ We will use the `build_batch_request(...)` method of our Data Asset to generate 
 ```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request"
 ```
 
+For `dataframe` Data Assets, the `dataframe` is always specified as the argument of exactly one API method:
+
+```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe"
+```
+
 ### 5. Verify that the correct Batches were returned
 
 The `get_batch_list_from_batch_request(...)` method will return a list of the Batches a given Batch Request refers to.

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.md
@@ -62,6 +62,11 @@ Now that we have the `name` and `dataframe` for our Data Asset, we can create th
 ```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py data_asset"
 ```
 
+For `dataframe` Data Assets, the `dataframe` is always specified as the argument of exactly one API method:
+
+```python name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe"
+```
+
 ## Next steps
 
 Now that you have connected to your data, you may want to look into:

--- a/docs/docusaurus/docs/terms/evaluation_parameter.md
+++ b/docs/docusaurus/docs/terms/evaluation_parameter.md
@@ -20,7 +20,7 @@ When creating Expectations based on introspection of Data, it can be useful to r
 
 ```python title="Python code"
 eval_param_urn = 'urn:great_expectations:validations:my_expectation_suite_1:expect_table_row_count_to_be_between.result.observed_value'
-downstream_batch.expect_table_row_count_to_equal(
+validator.expect_table_row_count_to_equal(
     value={
         '$PARAMETER': eval_param_urn, # this is the actual parameter we're going to use in the validation
     }

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
@@ -47,8 +47,8 @@ assert my_asset.batch_request_options == ("year", "month", "path")
 import pandas as pd
 
 dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
-my_datasource = context.sources.add_pandas(name="my_pandas_datasource")
-my_asset = my_datasource.add_dataframe_asset(name="my_asset")
+my_ephemeral_datasource = context.sources.add_pandas(name="my_pandas_datasource")
+my_asset = my_ephemeral_datasource.add_dataframe_asset(name="my_ephemeral_asset")
 
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
@@ -32,6 +32,17 @@ my_asset = my_datasource.add_csv_asset(
     order_by=["year", "month"],
 )
 
+import pandas as pd
+
+dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
+my_ephemeral_datasource = context.sources.add_pandas(name="my_pandas_datasource")
+my_asset = my_ephemeral_datasource.add_dataframe_asset(name="my_ephemeral_asset")
+
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">
+my_batch_request = my_asset.build_batch_request(dataframe=dataframe)
+# </snippet>
+
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_asset">
 my_asset = context.get_datasource("my_datasource").get_asset("my_asset")
@@ -43,17 +54,6 @@ print(my_asset.batch_request_options)
 # </snippet>
 
 assert my_asset.batch_request_options == ("year", "month", "path")
-
-import pandas as pd
-
-dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
-my_ephemeral_datasource = context.sources.add_pandas(name="my_pandas_datasource")
-my_asset = my_ephemeral_datasource.add_dataframe_asset(name="my_ephemeral_asset")
-
-# Python
-# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">
-my_batch_request = my_asset.build_batch_request(dataframe=dataframe)
-# </snippet>
 
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request">

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
@@ -44,6 +44,15 @@ print(my_asset.batch_request_options)
 
 assert my_asset.batch_request_options == ("year", "month", "path")
 
+import pandas as pd
+
+dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
+
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">
+my_batch_request = my_asset.build_batch_request(dataframe=dataframe)
+# </snippet>
+
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request">
 my_batch_request = my_asset.build_batch_request()

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
@@ -47,6 +47,8 @@ assert my_asset.batch_request_options == ("year", "month", "path")
 import pandas as pd
 
 dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
+my_datasource = context.sources.add_pandas(name="my_pandas_datasource")
+my_asset = my_datasource.add_dataframe_asset(name="my_asset")
 
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py
@@ -35,7 +35,11 @@ name = "taxi_dataframe"
 data_asset = datasource.add_dataframe_asset(name=name)
 # </snippet>
 
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe">
 my_batch_request = data_asset.build_batch_request(dataframe=dataframe)
+# </snippet>
+
 assert my_batch_request.datasource_name == "my_pandas_datasource"
 assert my_batch_request.data_asset_name == "taxi_dataframe"
 assert my_batch_request.options == {}


### PR DESCRIPTION
### Scope
* The document "https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas" was missing guidance for how to pass `dataframe` to `PandasDatasource.DataFrameAsset`.

### Remarks
* JIRA: DX-469/DX-441
* Discovered while investigating the issue #7971 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!