### PR TITLE
[MAINTENANCE] Updating CLI messages to point to new docs

### DIFF
--- a/great_expectations/cli/cli_messages.py
+++ b/great_expectations/cli/cli_messages.py
@@ -99,20 +99,20 @@ You can read more about this here: https://greatexpectations.io/blog/the-fluent-
 If you would like to proceed anyway, press Y."""
 
 SUITE_EDIT_FLUENT_DATASOURCE_ERROR = """Fluent style Datasources detected. The CLI does not work with fluent style Datasources.
-If you would like to edit an Expectation Suite with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/reference/api/data_context/AbstractDataContext_class#great_expectations.data_context.AbstractDataContext.add_expectation_suite
+If you would like to edit an Expectation Suite with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data
 """
 
 SUITE_EDIT_FLUENT_DATASOURCE_WARNING = """Fluent style Datasources detected. The CLI does not work with fluent style Datasources.
-If you would like to edit an Expectation Suite with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/reference/api/data_context/AbstractDataContext_class#great_expectations.data_context.AbstractDataContext.add_expectation_suite
+If you would like to edit an Expectation Suite with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data
 If you would like to use a block config style Datasource, you can select it here to proceed.
 """
 
 SUITE_NEW_FLUENT_DATASOURCE_ERROR = """Fluent style Datasources detected. The CLI does not work with fluent style Datasources.
-If you would like to create a new Expectation Suite interactively with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/reference/api/data_context/AbstractDataContext_class#great_expectations.data_context.AbstractDataContext.add_expectation_suite
+If you would like to create a new Expectation Suite interactively with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data
 """
 
 SUITE_NEW_FLUENT_DATASOURCE_WARNING = """Fluent style Datasources detected. The CLI does not work with fluent style Datasources.
-If you would like to create a new Expectation Suite interactively with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/reference/api/data_context/AbstractDataContext_class#great_expectations.data_context.AbstractDataContext.add_expectation_suite
+If you would like to create a new Expectation Suite interactively with your fluent style Datasource, please see the instructions here: https://docs.greatexpectations.io/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data
 If you would like to create a new Expectation Suite with your fluent style Datasource using the Onboarding Assistant, please see the instructions here: https://docs.greatexpectations.io/docs/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant/#2-prepare-a-new-expectation-suite
 If you would like to use a block config style Datasource, you can select it here to proceed.
 """


### PR DESCRIPTION
CLI messages were pointing to API docs where we now have up-to-date guides that are more help. The CLI messages have been updated to point to those guides

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted
- [ ] Appropriate tests and docs have been updated
