### PR TITLE
[MAINTENANCE] Update default action list in `Checkpoint` based on user environment

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2154,8 +2154,7 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         return checkpoint
 
-    @staticmethod
-    def _determine_default_action_list() -> Sequence[ActionDict]:
+    def _determine_default_action_list(self) -> Sequence[ActionDict]:
         from great_expectations.checkpoint.checkpoint import Checkpoint
 
         return Checkpoint.DEFAULT_ACTION_LIST

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2118,6 +2118,8 @@ class AbstractDataContext(ConfigPeer, ABC):
                 "Must either pass in an existing checkpoint or individual constructor arguments (but not both)"
             )
 
+        action_list = action_list or self._determine_default_action_list()
+
         if not checkpoint:
             assert (
                 name
@@ -2151,6 +2153,12 @@ class AbstractDataContext(ConfigPeer, ABC):
             )
 
         return checkpoint
+
+    @staticmethod
+    def _determine_default_action_list() -> Sequence[ActionDict]:
+        from great_expectations.checkpoint.checkpoint import Checkpoint
+
+        return Checkpoint.DEFAULT_ACTION_LIST
 
     @public_api
     @new_argument(

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -775,17 +775,15 @@ class CloudDataContext(SerializableDataContext):
             )
             return self.checkpoint_store.add_or_update_checkpoint(checkpoint)
 
-    @staticmethod
-    def _determine_default_action_list() -> Sequence[ActionDict]:
+    def _determine_default_action_list(self) -> Sequence[ActionDict]:
         default_actions = super()._determine_default_action_list()
 
-        cloud_actions: Sequence[ActionDict] = []
-        for action in default_actions:
-            # Data docs are not relevant to Cloud and should be excluded
-            if action["action"]["class_name"] != "UpdateDataDocsAction":
-                cloud_actions.append(action)
-
-        return cloud_actions
+        # Data docs are not relevant to Cloud and should be excluded
+        return [
+            action
+            for action in default_actions
+            if action["action"]["class_name"] != "UpdateDataDocsAction"
+        ]
 
     def list_checkpoints(self) -> Union[List[str], List[ConfigurationIdentifier]]:
         return self.checkpoint_store.list_checkpoints(ge_cloud_mode=True)

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -775,6 +775,18 @@ class CloudDataContext(SerializableDataContext):
             )
             return self.checkpoint_store.add_or_update_checkpoint(checkpoint)
 
+    @staticmethod
+    def _determine_default_action_list() -> Sequence[ActionDict]:
+        default_actions = super()._determine_default_action_list()
+
+        cloud_actions: Sequence[ActionDict] = []
+        for action in default_actions:
+            # Data docs are not relevant to Cloud and should be excluded
+            if action["action"]["class_name"] != "UpdateDataDocsAction":
+                cloud_actions.append(action)
+
+        return cloud_actions
+
     def list_checkpoints(self) -> Union[List[str], List[ConfigurationIdentifier]]:
         return self.checkpoint_store.list_checkpoints(ge_cloud_mode=True)
 

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -3004,7 +3004,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def action_list(self) -> Sequence[ActionDict]:
-        return self._action_list  # type: ignore[return-value]
+        return self._action_list
 
     @action_list.setter
     def action_list(self, value: Sequence[ActionDict]) -> None:

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2855,9 +2855,7 @@ class CheckpointConfig(BaseYamlConfig):
             self._expectation_suite_name = expectation_suite_name
             self._expectation_suite_ge_cloud_id = expectation_suite_ge_cloud_id
             self._batch_request = batch_request or {}
-            if action_list is None:
-                action_list = DataContextConfigDefaults.DEFAULT_ACTION_LIST.value  # type: ignore[assignment]
-            self._action_list = action_list
+            self._action_list = action_list or []
             self._evaluation_parameters = evaluation_parameters or {}
             self._runtime_configuration = runtime_configuration or {}
             self._validations = validations or []

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -576,7 +576,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
         "run_name_template": "%Y-%M-foo-bar-template-test",
         "expectation_suite_name": None,
         "batch_request": None,
-        "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+        "action_list": [],
         "profilers": [],
     }
 
@@ -1272,7 +1272,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         "expectation_suite_name": "users.delivery",
         "run_name_template": None,
         "batch_request": None,
-        "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+        "action_list": [],
         "evaluation_parameters": {},
         "runtime_configuration": {},
         "profilers": [],
@@ -3013,7 +3013,7 @@ def test_newstyle_checkpoint_config_substitution_nested(
             {
                 "name": "store_evaluation_params",
                 "action": {
-                    "class_name": "StoreEvaluationParametersAction",
+                    "class_name": "MyCustomStoreEvaluationParametersActionTemplate2",
                 },
             },
             {

--- a/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
@@ -121,7 +121,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
         "run_name_template": "%Y-%M-foo-bar-template-test",
         "expectation_suite_name": None,
         "batch_request": None,
-        "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+        "action_list": [],
         "profilers": [],
     }
 
@@ -550,7 +550,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         "expectation_suite_name": "users.delivery",
         "run_name_template": None,
         "batch_request": None,
-        "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+        "action_list": [],
         "evaluation_parameters": {},
         "runtime_configuration": {},
         "profilers": [],

--- a/tests/cli/test_checkpoint.py
+++ b/tests/cli/test_checkpoint.py
@@ -1305,20 +1305,6 @@ def test_checkpoint_run_on_checkpoint_with_batch_load_problem_raises_error(
                     "anonymized_name": "ca68117150c32e08330af3cebad565ce",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -1762,20 +1748,6 @@ def test_checkpoint_run_happy_path_with_successful_validation_pandas(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -1989,20 +1961,6 @@ def test_checkpoint_run_happy_path_with_successful_validation_sql(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -2218,20 +2176,6 @@ def test_checkpoint_run_happy_path_with_successful_validation_spark(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -2451,20 +2395,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_pandas(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -2668,20 +2598,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_sql(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -2892,20 +2808,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_spark(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -3120,20 +3022,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_pandas
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -3333,20 +3221,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_sql(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {
@@ -3560,20 +3434,6 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_spark(
                     "anonymized_name": "eb2d802f924a3e764afc605de3495c5c",
                     "config_version": 1.0,
                     "anonymized_run_name_template": "21e9677f05fd2b0d83bb9285a688d5c5",
-                    "anonymized_action_list": [
-                        {
-                            "anonymized_name": "8e3e134cd0402c3970a02f40d2edfc26",
-                            "parent_class": "StoreValidationResultAction",
-                        },
-                        {
-                            "anonymized_name": "40e24f0c6b04b6d4657147990d6f39bd",
-                            "parent_class": "StoreEvaluationParametersAction",
-                        },
-                        {
-                            "anonymized_name": "2b99b6b280b8a6ad1176f37580a16411",
-                            "parent_class": "UpdateDataDocsAction",
-                        },
-                    ],
                     "anonymized_validations": [
                         {
                             "anonymized_batch_request": {

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -978,7 +978,7 @@ def test_checkpoint_config_and_nested_objects_are_serialized(
         pytest.param(
             "checkpoint_config_with_schema_spark",
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -741,7 +741,7 @@ def test_checkpoint_config_print(
                 ],
             ),
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,
@@ -789,7 +789,7 @@ def test_checkpoint_config_print(
                 ],
             ),
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,
@@ -839,7 +839,7 @@ def test_checkpoint_config_print(
                 ],
             ),
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,
@@ -889,7 +889,7 @@ def test_checkpoint_config_print(
                 ],
             ),
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -942,7 +942,7 @@ def test_checkpoint_config_and_nested_objects_are_serialized(
         pytest.param(
             "checkpoint_config_spark",
             {
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "class_name": "Checkpoint",
                 "config_version": 1.0,

--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -2,7 +2,6 @@ from typing import Dict, Final, List, Optional, Tuple, Union
 
 import pytest
 
-from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core import ExpectationSuite, ExpectationSuiteValidationResult
 from great_expectations.data_context.data_context_variables import (
     DataContextVariables,

--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -225,7 +225,7 @@ def serialized_configuration_bundle() -> dict:
                 "config_version": 1.0,
                 "module_name": "great_expectations.checkpoint",
                 "name": "my_checkpoint",
-                "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+                "action_list": [],
                 "batch_request": {},
                 "evaluation_parameters": {},
                 "expectation_suite_ge_cloud_id": None,

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -249,7 +249,7 @@ def test_set(
                                 ("run_name_template", None),
                                 ("expectation_suite_name", None),
                                 ("batch_request", {}),
-                                ("action_list", list(Checkpoint.DEFAULT_ACTION_LIST)),
+                                ("action_list", []),
                                 ("evaluation_parameters", {}),
                                 ("runtime_configuration", {}),
                                 ("validations", []),

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -16,7 +16,6 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
     GXCloudRESTResource,

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1422,7 +1422,7 @@ def test_get_checkpoint(empty_context_with_checkpoint):
     config = obs.get_config(mode=ConfigOutputModes.JSON_DICT)
     assert isinstance(config, dict)
     assert config == {
-        "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
+        "action_list": [],
         "batch_request": {},
         "class_name": "Checkpoint",
         "config_version": 1.0,

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -1181,6 +1181,7 @@ def test_add_or_update_checkpoint_adds_successfully(
             },
             CheckpointConfig(
                 **{
+                    "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
                     "batch_request": {},
                     "class_name": "Checkpoint",
                     "config_version": 1.0,
@@ -1219,6 +1220,7 @@ def test_add_or_update_checkpoint_adds_successfully(
             },
             CheckpointConfig(
                 **{
+                    "action_list": list(Checkpoint.DEFAULT_ACTION_LIST),
                     "batch_request": {},
                     "class_name": "Checkpoint",
                     "config_version": 1.0,


### PR DESCRIPTION
Cloud contexts should not have reference to `UpdateDataDocs`


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
