### PR TITLE
[DOCS] Temporarily hardcode quickstart snippet due to substitution error

### DIFF
--- a/docs/docusaurus/docs/tutorials/quickstart/quickstart.md
+++ b/docs/docusaurus/docs/tutorials/quickstart/quickstart.md
@@ -63,7 +63,10 @@ Windows support for the open source Python version of GX is currently unavailabl
 
 - Run the following command to create two Expectations:
 
-    ```python name="tutorials/quickstart/quickstart.py create_expectation"
+    ```python 
+    validator.expect_column_values_to_not_be_null("pickup_datetime")
+    validator.expect_column_values_to_be_between("passenger_count", auto=True)
+    validator.save_expectation_suite()
     ```
 The first Expectation uses domain knowledge (the `pickup_datetime` shouldn't be null), and the second Expectation uses [`auto=True`](../../guides/expectations/how_to_use_auto_initializing_expectations.md#using-autotrue) to detect a range of values in the `passenger_count` column.
 


### PR DESCRIPTION
This particular snippet is not being substituted properly from our source code. Hardcoding while we investigate

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
