### PR TITLE
[FEATURE] Agent prints stack trace on error

### DIFF
--- a/great_expectations/agent/agent.py
+++ b/great_expectations/agent/agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 from collections import defaultdict
 from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
@@ -182,6 +183,7 @@ class GXAgent:
             )
         else:
             status = JobCompleted(success=False, error_stack_trace=str(error))
+            print(traceback.format_exc())
             print(
                 f"Failed to complete job {event_context.event.type} ({event_context.correlation_id})"
             )


### PR DESCRIPTION
If the Agent encounters an exception while running a workflow, it now prints the stack trace to the terminal.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
