### PR TITLE
[FEATURE] Support DataFrame Argument in AbstractDataContext.get_validator method

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2419,7 +2419,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             )
         return keys  # type: ignore[return-value]
 
-    # @public_api
+    @public_api
     def get_validator(  # noqa: PLR0913
         self,
         datasource_name: Optional[str] = None,

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2841,7 +2841,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             isinstance(batch_request_updated, FluentBatchRequest)
             and dataframe is not None
         ):
-            data_asset = datasource.get_asset(
+            data_asset = datasource.get_asset(  # type: ignore[union-attr, return-value, arg-type]
                 asset_name=batch_request_updated.data_asset_name
             )
             batch_request_updated = data_asset.build_batch_request(dataframe=dataframe)

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2841,7 +2841,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             isinstance(batch_request_updated, FluentBatchRequest)
             and dataframe is not None
         ):
-            data_asset = datasource.get_asset(  # type: ignore[union-attr, return-value, arg-type]
+            data_asset = datasource.get_asset(  # type: ignore[union-attr]
                 asset_name=batch_request_updated.data_asset_name
             )
             batch_request_updated = data_asset.build_batch_request(dataframe=dataframe)

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -9,9 +9,6 @@ import pandas as pd
 import pytest
 from freezegun import freeze_time
 
-from great_expectations.datasource.fluent.batch_request import (
-    BatchRequest as FluentBatchRequest,
-)
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.checkpoint import Checkpoint, SimpleCheckpoint
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
@@ -42,6 +39,9 @@ from great_expectations.datasource import (
     Datasource,
     LegacyDatasource,
     SimpleSqlalchemyDatasource,
+)
+from great_expectations.datasource.fluent.batch_request import (
+    BatchRequest as FluentBatchRequest,
 )
 from great_expectations.datasource.types.batch_kwargs import PathBatchKwargs
 from great_expectations.expectations.expectation import BatchExpectation


### PR DESCRIPTION
### Scope
This change supports `dataframe` argument in `AbstractDataContext.get_validator()`.  Together with passing `validator` (instead of `batch_request`) to `Checkpoint.run()`, this provides support for ephemeral data in `Validator` and `Checkpoint` usage scenarios.

The coding pattern enabled is as follows:

```
batch_request = FluentBatchRequest(
        datasource_name='my_datasource_name',
        data_asset_name='my_asset_name',
)
```

Then:

```
validator = context.get_validator(
        expectation_suite_name="my_suite",
        batch_request=batch_request,
        dataframe=my_pandas_df,  # or my_spark_df
)
```
This then enables commands, such as `validator.expect_*`, to use the `DataFrame` (and the underlying `DataFrameAsset` as the `Batch` of data.

Finally:

```
checkpoint_result = checkpoint.run(validator=validator)
```

Where the `validator` is passed instead of `batch_request`, thereby supplying the ephemeral DataAsset to Checkpoint.

### Remarks
* If the general approach makes sense, then we can strengthen the type checking by passing not `"dataframe=my_pandas_df,  # or my_spark_df"` to `context.get_validator()`, but extending `FluentBatchRequest`, which is serializable, to the special Ephemeral subclass, which would not be serializable, but contain a `DataFrame` (Pandas or Spark -- or we can have two separate extensions, one for `Pandas`, the other for `Spark` -- to be decided).  This way, `context.get_validator()` will still accept a formal `BatchRequest` type, without the separate `dataframe` argument.
* JIRA: DX-469/DX-553


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!