### PR TITLE
[BUGFIX] context.delete_datasource() immediately persist changes to YAML

### DIFF
--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -238,22 +238,29 @@ def test_update_non_existant_datasource(
 class TestDeletingDatasources:
     def test_file_context(self, seeded_file_context: FileDataContext):
         context = seeded_file_context
-
         gx_yml_path = pathlib.Path(context.root_directory, context.GX_YML).resolve(
             strict=True
         )
 
-        datasource: Datasource = random.choice(
+        old_datasource: Datasource = random.choice(
             list(context.fluent_datasources.values())
         )
+        print(f"Deleting '{old_datasource.name}'")
+        context.delete_datasource(old_datasource.name)
 
-        print(f"Deleting '{datasource.name}'")
-        context.delete_datasource(datasource.name)
+        fds_after_delete1: dict = yaml.load(gx_yml_path.read_text())["fluent_datasources"]  # type: ignore[assignment] # json union
+        print(f"\nYAML Datasources\n{pf(fds_after_delete1, depth=1)}")
 
-        fds_after_delete: dict = yaml.load(gx_yml_path.read_text())["fluent_datasources"]  # type: ignore[assignment] # json union
-        print(f"\nYAML Datasources\n{pf(fds_after_delete, depth=1)}")
+        assert old_datasource.name not in fds_after_delete1
 
-        assert datasource.name not in fds_after_delete
+        new_datasource = context.sources.add_pandas("test_delete_datasource")
+        print(f"Deleting '{new_datasource.name}'")
+        context.delete_datasource(new_datasource.name)
+
+        fds_after_delete2: dict = yaml.load(gx_yml_path.read_text())["fluent_datasources"]  # type: ignore[assignment] # json union
+        print(f"\nYAML Datasources\n{pf(fds_after_delete2, depth=1)}")
+
+        assert new_datasource.name not in fds_after_delete2
 
 
 @pytest.mark.cloud


### PR DESCRIPTION
I'm unable to reproduce this reported bug.

https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1686661928268839

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
