### PR TITLE
[MAINTENANCE] Use Available Enums Instead of Strings for Metric Name Extensions

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -885,7 +885,7 @@ def build_map_metric_rule(  # noqa: PLR0913
         ),
     ]
     column_values_attribute_mean_unexpected_value_multi_batch_parameter_builder_for_validations = MeanUnexpectedMapMetricMultiBatchParameterBuilder(
-        name=f"{map_metric_name}.unexpected_value",
+        name=f"{map_metric_name}.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}",
         map_metric_name=map_metric_name,
         total_count_parameter_builder_name=total_count_metric_multi_batch_parameter_builder_for_evaluations.name,
         null_count_parameter_builder_name=column_values_nonnull_unexpected_count_metric_multi_batch_parameter_builder_for_evaluations.name,

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -3148,6 +3148,9 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             Domain, Dict[str, List[ParameterNode]]
         ] = self._determine_attributed_metrics_by_domain_type(MetricDomainTypes.TABLE)
 
+        if not attributed_metrics_by_table_domain:
+            return []
+
         table_domain = Domain(
             domain_type=MetricDomainTypes.TABLE, rule_name="table_rule"
         )
@@ -3254,6 +3257,9 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             include_column_names,
             exclude_column_names,
         )
+
+        if not attributed_metrics_by_column_domain:
+            return [], []
 
         column_based_metric_names: Set[tuple[str, ...]] = set()
         for metrics in metric_expectation_map.keys():

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -3148,9 +3148,6 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             Domain, Dict[str, List[ParameterNode]]
         ] = self._determine_attributed_metrics_by_domain_type(MetricDomainTypes.TABLE)
 
-        if not attributed_metrics_by_table_domain:
-            return []
-
         table_domain = Domain(
             domain_type=MetricDomainTypes.TABLE, rule_name="table_rule"
         )
@@ -3257,9 +3254,6 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             include_column_names,
             exclude_column_names,
         )
-
-        if not attributed_metrics_by_column_domain:
-            return [], []
 
         column_based_metric_names: Set[tuple[str, ...]] = set()
         for metrics in metric_expectation_map.keys():


### PR DESCRIPTION
### Scope
We have adopted `Enum` structures for Metric Names -- they should be used codebase-wide.

### Remarks
* JIRA: DX-594


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!