### PR TITLE
[MAINTENANCE] Add env var to avoid out of memory error when building docs

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -635,6 +635,8 @@ stages:
 
           - script: cd docs/docusaurus && yarn install && bash ../build_docs
             name: TestBuildDocs
+            env:
+              NODE_OPTIONS: --max_old_space_size=4096
 
   - stage: deploy
     condition: and(succeeded(), eq(variables.isRelease, true))


### PR DESCRIPTION
Our async build pipeline was failing due to an out of memory error while building docs. In https://github.com/great-expectations/great_expectations/pull/8125 we introduced an env variable to avoid this issue and it wasn't also implemented in the async pipeline. This PR rectifies that.