### PR TITLE
[BUGFIX] Fix config substitution for substrings

### DIFF
--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -53,7 +53,7 @@ class ConfigStr(SecretStr):
 
     @classmethod
     def _validate_template_str_format(cls, v):
-        if TEMPLATE_STR_REGEX.match(v):
+        if TEMPLATE_STR_REGEX.search(v):
             return v
         raise ValueError(
             cls.__name__

--- a/tests/datasource/fluent/test_config_str.py
+++ b/tests/datasource/fluent/test_config_str.py
@@ -21,7 +21,7 @@ class MyClass(FluentBaseModel):
     normal_field: str
     secret_field: SecretStr
     config_field: ConfigStr
-    config_field_w_default: ConfigStr = r"hello-${MY_SECRET}"
+    config_field_w_default: ConfigStr = r"hey-${MY_SECRET}"
 
 
 @pytest.fixture

--- a/tests/datasource/fluent/test_config_str.py
+++ b/tests/datasource/fluent/test_config_str.py
@@ -21,6 +21,7 @@ class MyClass(FluentBaseModel):
     normal_field: str
     secret_field: SecretStr
     config_field: ConfigStr
+    config_field_w_default: ConfigStr = r"hello-${MY_SECRET}"
 
 
 @pytest.fixture
@@ -65,6 +66,10 @@ def test_config_str_validation():
     ["input_value", "expected"],
     [
         (r"${VALID_CONFIG_STR}", r"${VALID_CONFIG_STR}"),
+        (
+            r"postgres://user:${VALID_CONFIG_STR}@host/dbname",
+            r"postgres://user:${VALID_CONFIG_STR}@host/dbname",
+        ),
         ("postgres://userName@hostname", "postgres://userName@hostname"),
     ],
 )
@@ -87,8 +92,13 @@ def test_config_substitution(
         normal_field="normal",
         secret_field="secret",  # type: ignore[arg-type]
         config_field=r"${MY_ENV_VAR}",  # type: ignore[arg-type]
+        config_field_w_default=r"hello-${MY_ENV_VAR}",  # type: ignore[arg-type]
     )
     assert m.config_field.get_config_value(env_config_provider) == "success"
+    assert (
+        m.config_field_w_default.get_config_value(env_config_provider)
+        == "hello-success"
+    )
 
 
 def test_config_substitution_dict(

--- a/tests/datasource/fluent/test_config_str.py
+++ b/tests/datasource/fluent/test_config_str.py
@@ -21,7 +21,7 @@ class MyClass(FluentBaseModel):
     normal_field: str
     secret_field: SecretStr
     config_field: ConfigStr
-    config_field_w_default: ConfigStr = r"hey-${MY_SECRET}"
+    config_field_w_default: ConfigStr = r"hey-${MY_SECRET}"  # type: ignore[assignment]
 
 
 @pytest.fixture


### PR DESCRIPTION
Use `re.search` instead of `re.match` to find config template strings
https://docs.python.org/3/library/re.html#re.search

```python
import great_expectations as gx

context = gx.get_context()

# this will succeed
context.sources.add_sql("my_datasource1",
    connection_string="${MY_FULL_CONN_STR}"
)

# this will fail
context.sources.add_sql("my_datasource2",
    connection_string="postgresql://postgres:${MY_DB_PW}@localhost:5432/postgres"
)
```
This PR makes it so that both examples above succeed. 

-----------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
