### PR TITLE
[DOCS] Fix broken links and reenable link checking

### DIFF
--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -90,5 +90,5 @@ To add a new version, follow these steps:
 12. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
 13. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
 14. Add your version number to `versions.json` in the unzipped version file.
-15. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` and upload to the s3 bucket (see `docs/build_docs` for the bucket name)
+15. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
 16. Once the docs are built again, this zip file will be used for the prior versions.

--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   tagline: 'Always know what to expect from your data.',
   url: 'https://docs.greatexpectations.io', // Url to your site with no trailing slash
   baseUrl: '/',
-  onBrokenLinks: 'warn', // Temporary, please set this back to 'throw' when we have fixed all broken links.
+  onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: '/img/gx-mark.png',
   organizationName: 'great-expectations',

--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -50,6 +50,16 @@ def _paths_to_versioned_docs_after_v0_14_13() -> list[pathlib.Path]:
     return paths
 
 
+def _paths_to_versioned_docs_after_v0_15_50() -> list[pathlib.Path]:
+    data_path = _docs_dir() / "docusaurus/versioned_docs"
+    paths = [
+        f
+        for f in data_path.iterdir()
+        if f.is_dir() and ("0.14.13" not in str(f) or "0.15.50" not in str(f))
+    ]
+    return paths
+
+
 def _paths_to_versioned_code() -> list[pathlib.Path]:
     data_path = _docs_dir() / "docusaurus/versioned_code"
     paths = [f for f in data_path.iterdir() if f.is_dir()]
@@ -304,9 +314,82 @@ def _use_relative_path_for_imports_substitution_path_starting_with_forwardslash(
     return contents
 
 
+def prepend_version_info_to_name_for_md_relative_links(verbose: bool = False) -> None:
+    """Prepend version info to md relative links.
+
+    Links to ../../../../docs/guides/validation/index.md#checkpoints
+    Should link to: ../../../../docs/0.16.16/guides/validation/#checkpoints
+
+    Args:
+        verbose: Whether to print verbose output.
+    """
+
+    # Currently fixes the following:
+    # docs/docusaurus/versioned_docs/version-0.16.16/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create_and_run.md
+    # Links to ../../../../docs/guides/validation/index.md#checkpoints
+    # Should link to: ../../../../docs/0.16.16/guides/validation/#checkpoints
+    # docs/docusaurus/versioned_docs/version-0.16.16/deployment_patterns/how_to_use_gx_with_aws/components/_data_docs_build_and_view.md
+    # Links to ../../../../docs/guides/validation/index.md#actions
+    # Should link to: ../../../../docs/0.16.16/guides/validation/index.md#actions
+
+    version_from_path_name_pattern = re.compile(
+        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
+    )
+    paths = _paths_to_versioned_docs_after_v0_15_50()
+
+    method_name_for_logging = "prepend_version_info_to_name_for_md_relative_links"
+    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
+    for path in paths:
+        version = path.name
+        version_only = version_from_path_name_pattern.search(version).group("version")
+        if not version_only:
+            raise ValueError("Path does not contain a version number")
+
+        files = []
+        for extension in (".md", ".mdx"):
+            files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
+        print(
+            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+        )
+        # NOTE: update files_to_process if there are more files that use relative markdown links.
+        # Alternatively, remove this list if all files should be processed.
+        files_to_process = [
+            "_data_docs_build_and_view.md",
+            "_checkpoint_create_and_run.md",
+        ]
+        files = [file for file in files if file.split("/")[-1] in files_to_process]
+        for file_path in files:
+            with open(file_path, "r+") as f:
+                contents = f.read()
+                contents = _prepend_version_info_to_name_for_md_relative_links(
+                    contents=contents, version=version_only
+                )
+                f.seek(0)
+                f.truncate()
+                f.write(contents)
+            if verbose:
+                print(f"processed {file_path}")
+        print(
+            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+        )
+    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+
+
+def _prepend_version_info_to_name_for_md_relative_links(
+    contents: str, version: str
+) -> str:
+    pattern = re.compile(r"(?P<docs>(.*\.\./docs/))(?P<rest>(.*))")
+    contents = re.sub(pattern, rf"\g<docs>{version}/\g<rest>", contents)
+
+    return contents
+
+
 if __name__ == "__main__":
+    print("Starting to process files in prepare_prior_versions.py...")
     change_paths_for_docs_file_references()
     prepend_version_info_to_name_for_snippet_by_name_references()
     prepend_version_info_to_name_for_href_absolute_links()
     update_tag_references_for_correct_version()
     use_relative_path_for_imports()
+    prepend_version_info_to_name_for_md_relative_links()
+    print("Finished processing files in prepare_prior_versions.py")

--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -378,8 +378,10 @@ def prepend_version_info_to_name_for_md_relative_links(verbose: bool = False) ->
 def _prepend_version_info_to_name_for_md_relative_links(
     contents: str, version: str
 ) -> str:
-    pattern = re.compile(r"(?P<docs>(.*\.\./docs/))(?P<rest>(.*))")
-    contents = re.sub(pattern, rf"\g<docs>{version}/\g<rest>", contents)
+    pattern = re.compile(
+        r"(?P<docs>(.*\.\./docs/))(?P<middle>(.*))(?P<index>(index\.md))(?P<rest>(.*))"
+    )
+    contents = re.sub(pattern, rf"\g<docs>{version}/\g<middle>\g<rest>", contents)
 
     return contents
 

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -138,5 +138,5 @@ def test__prepend_version_info_to_name_for_md_relative_links():
     updated_contents = _prepend_version_info_to_name_for_md_relative_links(
         contents, version
     )
-    expected_contents = """For more information on pre-configuring a Checkpoint with a Batch Request and Expectation Suite, please see [our guides on Checkpoints](../../../../docs/0.16.16/guides/validation/index.md#checkpoints)."""
+    expected_contents = """For more information on pre-configuring a Checkpoint with a Batch Request and Expectation Suite, please see [our guides on Checkpoints](../../../../docs/0.16.16/guides/validation/#checkpoints)."""
     assert updated_contents == expected_contents

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -3,10 +3,10 @@ import pathlib
 import pytest
 
 from docs.prepare_prior_versions import (
+    _prepend_version_info_to_name_for_md_relative_links,
     _update_tag_references_for_correct_version_substitution,
     _use_relative_path_for_imports_substitution,
     _use_relative_path_for_imports_substitution_path_starting_with_forwardslash,
-    _prepend_version_info_to_name_for_md_relative_links,
 )
 
 

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -6,6 +6,7 @@ from docs.prepare_prior_versions import (
     _update_tag_references_for_correct_version_substitution,
     _use_relative_path_for_imports_substitution,
     _use_relative_path_for_imports_substitution_path_starting_with_forwardslash,
+    _prepend_version_info_to_name_for_md_relative_links,
 )
 
 
@@ -126,4 +127,16 @@ import CLIRemoval from './components/warnings/_cli_removal.md'
 <CLIRemoval />
 """
 
+    assert updated_contents == expected_contents
+
+
+@pytest.mark.unit
+def test__prepend_version_info_to_name_for_md_relative_links():
+    contents = """For more information on pre-configuring a Checkpoint with a Batch Request and Expectation Suite, please see [our guides on Checkpoints](../../../../docs/guides/validation/index.md#checkpoints)."""
+
+    version = "0.16.16"
+    updated_contents = _prepend_version_info_to_name_for_md_relative_links(
+        contents, version
+    )
+    expected_contents = """For more information on pre-configuring a Checkpoint with a Batch Request and Expectation Suite, please see [our guides on Checkpoints](../../../../docs/0.16.16/guides/validation/index.md#checkpoints)."""
     assert updated_contents == expected_contents


### PR DESCRIPTION
1. Fixes broken links found while adding v0.16.16 in https://github.com/great-expectations/great_expectations/pull/8125
2. Reverts docusaurus setting to raise an error if broken links are found: `onBrokenLinks: 'throw',`
