### PR TITLE
[MAINTENANCE] Add default `table_name` to `TableAsset` if omitted

### DIFF
--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -376,8 +376,7 @@
                 }
             },
             "required": [
-                "name",
-                "table_name"
+                "name"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -368,6 +368,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "default": "",
                     "type": "string"
                 },
                 "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -368,6 +368,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
                     "default": "",
                     "type": "string"
                 },

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -71,8 +71,7 @@
         }
     },
     "required": [
-        "name",
-        "table_name"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -63,6 +63,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "default": "",
             "type": "string"
         },
         "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -63,6 +63,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
             "default": "",
             "type": "string"
         },

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -373,8 +373,7 @@
                 }
             },
             "required": [
-                "name",
-                "table_name"
+                "name"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -365,6 +365,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "default": "",
                     "type": "string"
                 },
                 "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -365,6 +365,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
                     "default": "",
                     "type": "string"
                 },

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -71,8 +71,7 @@
         }
     },
     "required": [
-        "name",
-        "table_name"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -63,6 +63,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "default": "",
             "type": "string"
         },
         "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -63,6 +63,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
             "default": "",
             "type": "string"
         },

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -376,8 +376,7 @@
                 }
             },
             "required": [
-                "name",
-                "table_name"
+                "name"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -368,6 +368,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "default": "",
                     "type": "string"
                 },
                 "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -368,6 +368,7 @@
                 },
                 "table_name": {
                     "title": "Table Name",
+                    "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
                     "default": "",
                     "type": "string"
                 },

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -77,8 +77,7 @@
         }
     },
     "required": [
-        "name",
-        "table_name"
+        "name"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -69,6 +69,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "default": "",
             "type": "string"
         },
         "schema_name": {

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -69,6 +69,7 @@
         },
         "table_name": {
             "title": "Table Name",
+            "description": "Name of the SQL table. Will default to the value of `name` if not provided.",
             "default": "",
             "type": "string"
         },

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -797,7 +797,7 @@ class TableAsset(_SQLAsset):
 
     # Instance fields
     type: Literal["table"] = "table"
-    table_name: str = ""
+    table_name: str = Field("", description="Name of the SQL table. Will default to the value of `name` if not provided.")
     schema_name: Optional[str] = None
 
     @property

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -797,7 +797,7 @@ class TableAsset(_SQLAsset):
 
     # Instance fields
     type: Literal["table"] = "table"
-    table_name: str
+    table_name: Optional[str] = None
     schema_name: Optional[str] = None
 
     @property
@@ -807,6 +807,10 @@ class TableAsset(_SQLAsset):
             if self.schema_name
             else self.table_name
         )
+
+    @pydantic.validator("table_name")
+    def default_table_name_if_omitted(cls, v, values, **kwargs) -> str:
+        return v or values.get("name")
 
     def test_connection(self) -> None:
         """Test the connection for the TableAsset.

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -810,8 +810,7 @@ class TableAsset(_SQLAsset):
 
     @pydantic.validator("table_name", pre=True, always=True)
     def default_table_name(cls, table_name: str, values: dict, **kwargs) -> str:
-        validated_table_name = table_name or values.get("name")
-        if not validated_table_name:
+        if not (validated_table_name := table_name or values.get("name")):
             raise ValueError(
                 "table_name cannot be empty and should default to name if not provided"
             )

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -810,7 +810,13 @@ class TableAsset(_SQLAsset):
 
     @pydantic.validator("table_name", pre=True, always=True)
     def default_table_name(cls, table_name: str, values: dict, **kwargs) -> str:
-        return table_name or values.get("name")
+        validated_table_name = table_name or values.get("name")
+        if not validated_table_name:
+            raise ValueError(
+                "table_name cannot be empty and should default to name if not provided"
+            )
+
+        return validated_table_name
 
     def test_connection(self) -> None:
         """Test the connection for the TableAsset.

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -809,7 +809,7 @@ class TableAsset(_SQLAsset):
         )
 
     @pydantic.validator("table_name", pre=True, always=True)
-    def default_table_name(cls, table_name: str, values: dict, **kwargs) -> str:
+    def _default_table_name(cls, table_name: str, values: dict, **kwargs) -> str:
         if not (validated_table_name := table_name or values.get("name")):
             raise ValueError(
                 "table_name cannot be empty and should default to name if not provided"

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -808,9 +808,9 @@ class TableAsset(_SQLAsset):
             else self.table_name
         )
 
-    @pydantic.validator("table_name")
-    def default_table_name_if_omitted(cls, v, values, **kwargs) -> str:
-        return v or values.get("name")
+    @pydantic.validator("table_name", pre=True, always=True)
+    def default_table_name(cls, table_name, values, **kwargs) -> str:
+        return table_name or values.get("name")
 
     def test_connection(self) -> None:
         """Test the connection for the TableAsset.

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -797,7 +797,7 @@ class TableAsset(_SQLAsset):
 
     # Instance fields
     type: Literal["table"] = "table"
-    table_name: str = Field("", description="Name of the SQL table. Will default to the value of `name` if not provided.")
+    table_name: str = pydantic.Field("", description="Name of the SQL table. Will default to the value of `name` if not provided.")
     schema_name: Optional[str] = None
 
     @property

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -797,7 +797,7 @@ class TableAsset(_SQLAsset):
 
     # Instance fields
     type: Literal["table"] = "table"
-    table_name: Optional[str] = None
+    table_name: str = ""
     schema_name: Optional[str] = None
 
     @property
@@ -809,7 +809,7 @@ class TableAsset(_SQLAsset):
         )
 
     @pydantic.validator("table_name", pre=True, always=True)
-    def default_table_name(cls, table_name, values, **kwargs) -> str:
+    def default_table_name(cls, table_name: str, values: dict, **kwargs) -> str:
         return table_name or values.get("name")
 
     def test_connection(self) -> None:

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -797,7 +797,10 @@ class TableAsset(_SQLAsset):
 
     # Instance fields
     type: Literal["table"] = "table"
-    table_name: str = pydantic.Field("", description="Name of the SQL table. Will default to the value of `name` if not provided.")
+    table_name: str = pydantic.Field(
+        "",
+        description="Name of the SQL table. Will default to the value of `name` if not provided.",
+    )
     schema_name: Optional[str] = None
 
     @property

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -444,20 +444,6 @@ def test_catch_bad_top_level_config(
     [
         p(
             {
-                "name": "missing `table_name`",
-                "type": "table",
-            },
-            (
-                _FLUENT_DATASOURCES_KEY,
-                "assets",
-                0,
-                "table_name",
-            ),
-            "field required",
-            id="missing `table_name`",
-        ),
-        p(
-            {
                 "name": "unknown splitter",
                 "type": "table",
                 "table_name": "pool",

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -872,3 +872,9 @@ def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
 
     assert round_tripped_datasources["my_new_one"]
     assert round_tripped_datasources["my_sqlite_ds_w_subs"]["assets"]["new_asset"]
+
+
+def test_table_asset_omit_table_name():
+    name = "my_table"
+    asset = TableAsset(name=name)
+    assert asset.table_name == name


### PR DESCRIPTION
Utilize Pydantic to set `name` as `table_name` if the latter is not provided

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
