### PR TITLE
[MAINTENANCE] Add --bash command for postgres reference env

### DIFF
--- a/examples/reference_environments/README.md
+++ b/examples/reference_environments/README.md
@@ -40,6 +40,16 @@ The notebook contains a quickstart which you can edit to your heart's content.
     great_expectations example postgres --stop
     ```
 
+### To hop into a bash session instead of a notebook
+
+1. Navigate to the repo root and run:
+
+    ```bash
+    great_expectations example postgres --bash
+    ```
+
+Alternatively you can run `docker ps` to find the container name and then run `docker exec -it <container_name> bash` to hop into a bash session. The above command is just a shortcut.
+
 ### What about other reference environments?
 
 - We are working on adding more reference environments. To see the full list of what's available, run:

--- a/great_expectations/cli/example.py
+++ b/great_expectations/cli/example.py
@@ -32,18 +32,24 @@ def example() -> None:
     help="Print url for jupyter notebook.",
     default=False,
 )
-def example_postgres(stop: bool, url: bool) -> None:
+@click.option(
+    "--bash",
+    is_flag=True,
+    help="Open a bash terminal in the container (container should already be running).",
+    default=False,
+)
+def example_postgres(stop: bool, url: bool, bash: bool) -> None:
     """Start a postgres database example."""
     repo_root = pathlib.Path(__file__).parents[2]
     example_directory = repo_root / "examples" / "reference_environments" / "postgres"
     assert example_directory.is_dir(), "Example directory not found"
+    container_name = "gx_postgres_example_jupyter"
     if stop:
         cli_message("<green>Stopping example containers...</green>")
         stop_commands = ["docker", "compose", "down"]
         subprocess.run(stop_commands, cwd=example_directory)
         cli_message("<green>Done stopping containers.</green>")
     elif url:
-        container_name = "gx_postgres_example_jupyter"
         url_commands = [
             "docker",
             "exec",
@@ -63,6 +69,9 @@ def example_postgres(stop: bool, url: bool) -> None:
             f"http://127.0.0.1:{raw_json['port']}/lab?token={raw_json['token']}"
         )
         cli_message(f"<green>Url for jupyter notebook:</green> {notebook_url}")
+    elif bash:
+        bash_commands = ["docker", "exec", "-it", container_name, "bash"]
+        subprocess.run(bash_commands, cwd=example_directory)
     else:
         cli_message(
             "<yellow>Reference environments are experimental, the api is likely to change.</yellow>"


### PR DESCRIPTION
Add a `--bash` option to the postgres reference environment as a shortcut to enter into a bash session in the container instead of the jupyter notebook (e.g. to use a python repl or run a script).