### PR TITLE
[FEATURE] Python 3.11 support

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -183,6 +183,8 @@ stages:
               python.version: '3.9'
             Python310:
               python.version: '3.10'
+            Python311:
+              python.version: '3.11'
         variables:
           IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]
           GE_USAGE_STATISTICS_URL: "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
@@ -228,6 +230,8 @@ stages:
               python.version: '3.9'
             Python310:
               python.version: '3.10'
+            Python311:
+              python.version: '3.11'
         services:
           postgres: postgres
         variables:
@@ -410,6 +414,8 @@ stages:
               python.version: '3.9'
             Python310:
               python.version: '3.10'
+            Python311:
+              python.version: '3.11'
         services:
           postgres: postgres
         variables:
@@ -532,6 +538,8 @@ stages:
              python.version: '3.9'
            Python310:
              python.version: '3.10'
+           Python311:
+             python.version: '3.11'
 
         steps:
          - task: UsePythonVersion@0
@@ -608,6 +616,8 @@ stages:
               python.version: '3.9'
             Python310:
               python.version: '3.10'
+            Python311:
+              python.version: '3.11'
 
         steps:
           - task: UsePythonVersion@0

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -1,14 +1,3 @@
-import sys
-
-# setup.py should restrict installing gx to Python >= 3.8
-PYTHON3_SUPPORTED_MINOR_VERSIONS = [8, 9, 10]
-if sys.version_info.minor not in PYTHON3_SUPPORTED_MINOR_VERSIONS:
-    raise ImportError(
-        "Great Expectations is only supported on Python 3.8 through 3.10. "
-        f"You are using: {sys.version}"
-    )
-
-
 # Set up version information immediately
 from ._version import get_versions  # isort:skip
 

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -23,6 +23,7 @@ from great_expectations.datasource.fluent.pandas_datasource import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.azure import BlobServiceClient
     from great_expectations.datasource.fluent.file_path_data_asset import (
         _FilePathDataAsset,
     )
@@ -51,9 +52,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
     azure_options: Dict[str, Union[ConfigStr, Any]] = {}
 
     _account_name: str = pydantic.PrivateAttr(default="")
-    _azure_client: Union[azure.BlobServiceClient, None] = pydantic.PrivateAttr(
-        default=None
-    )
+    _azure_client: Union[BlobServiceClient, None] = pydantic.PrivateAttr(default=None)
 
     def _get_azure_client(self) -> azure.BlobServiceClient:
         azure_client: Union[azure.BlobServiceClient, None] = self._azure_client

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -52,6 +52,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
     azure_options: Dict[str, Union[ConfigStr, Any]] = {}
 
     _account_name: str = pydantic.PrivateAttr(default="")
+    # on 3.11 the annotation must be type-checking import otherwise it will fail at import time
     _azure_client: Union[BlobServiceClient, None] = pydantic.PrivateAttr(default=None)
 
     def _get_azure_client(self) -> azure.BlobServiceClient:

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent.file_path_data_asset import (
         _FilePathDataAsset,
     )
+    from great_expectations.compatibility.google import Client
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +54,10 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
     bucket_or_name: str
     gcs_options: Dict[str, Union[ConfigStr, Any]] = {}
 
-    _gcs_client: Union[google.Client, None] = pydantic.PrivateAttr(default=None)
+    _gcs_client: Union[Client, None] = pydantic.PrivateAttr(default=None)
 
-    def _get_gcs_client(self) -> google.Client:
-        gcs_client: Union[google.Client, None] = self._gcs_client
+    def _get_gcs_client(self) -> Client:
+        gcs_client: Union[Client, None] = self._gcs_client
         if not gcs_client:
             # Validate that "google" libararies were successfully imported and attempt to create "gcs_client" handle.
             if google.service_account and google.storage:

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -22,10 +22,10 @@ from great_expectations.datasource.fluent.pandas_datasource import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.google import Client
     from great_expectations.datasource.fluent.file_path_data_asset import (
         _FilePathDataAsset,
     )
-    from great_expectations.compatibility.google import Client
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +56,8 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
 
     _gcs_client: Union[Client, None] = pydantic.PrivateAttr(default=None)
 
-    def _get_gcs_client(self) -> Client:
-        gcs_client: Union[Client, None] = self._gcs_client
+    def _get_gcs_client(self) -> google.Client:
+        gcs_client: Union[google.Client, None] = self._gcs_client
         if not gcs_client:
             # Validate that "google" libararies were successfully imported and attempt to create "gcs_client" handle.
             if google.service_account and google.storage:

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -54,6 +54,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
     bucket_or_name: str
     gcs_options: Dict[str, Union[ConfigStr, Any]] = {}
 
+    # on 3.11 the annotation must be type-checking import otherwise it will fail at import time
     _gcs_client: Union[Client, None] = pydantic.PrivateAttr(default=None)
 
     def _get_gcs_client(self) -> google.Client:

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 _MISSING: Final = object()
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.azure import BlobServiceClient
     from great_expectations.datasource.fluent.spark_file_path_datasource import (
         _SPARK_FILE_PATH_ASSET_TYPES_UNION,
     )
@@ -53,9 +54,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
     azure_options: Dict[str, Union[ConfigStr, Any]] = {}
 
     _account_name: str = pydantic.PrivateAttr(default="")
-    _azure_client: Union[azure.BlobServiceClient, None] = pydantic.PrivateAttr(
-        default=None
-    )
+    _azure_client: Union[BlobServiceClient, None] = pydantic.PrivateAttr(default=None)
 
     def _get_azure_client(self) -> azure.BlobServiceClient:
         azure_client: Union[azure.BlobServiceClient, None] = self._azure_client

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -54,6 +54,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
     azure_options: Dict[str, Union[ConfigStr, Any]] = {}
 
     _account_name: str = pydantic.PrivateAttr(default="")
+    # on 3.11 the annotation must be type-checking import otherwise it will fail at import time
     _azure_client: Union[BlobServiceClient, None] = pydantic.PrivateAttr(default=None)
 
     def _get_azure_client(self) -> azure.BlobServiceClient:

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -59,6 +59,7 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
     bucket_or_name: str
     gcs_options: Dict[str, Union[ConfigStr, Any]] = {}
 
+    # on 3.11 the annotation must be type-checking import otherwise it will fail at import time
     _gcs_client: Union[Client, None] = pydantic.PrivateAttr(default=None)
 
     def _get_gcs_client(self) -> google.Client:

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -26,6 +26,7 @@ from great_expectations.datasource.fluent.spark_datasource import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.google import Client
     from great_expectations.datasource.fluent.spark_file_path_datasource import (
         _SPARK_FILE_PATH_ASSET_TYPES_UNION,
     )
@@ -58,7 +59,7 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
     bucket_or_name: str
     gcs_options: Dict[str, Union[ConfigStr, Any]] = {}
 
-    _gcs_client: Union[google.Client, None] = pydantic.PrivateAttr(default=None)
+    _gcs_client: Union[Client, None] = pydantic.PrivateAttr(default=None)
 
     def _get_gcs_client(self) -> google.Client:
         gcs_client: Union[google.Client, None] = self._gcs_client


### PR DESCRIPTION
Fix import-time exceptions that prevented GX from working with Python 3.11

This was caused by annotations on pydantic models that were being evaluated differently at runtime compared to previous python versions.

My only guess as to what's happening here is that it's related to how pydantic uses `dataclass_transfrom` in 3.11 vs earlier versions.
https://docs.python.org/3/whatsnew/3.11.html#pep-681-data-class-transforms

Also updated our test matrixes to add some minimal testing of 3.11.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
