### PR TITLE
[BUGFIX] Enable Pandas Column Aggregate Metrics To Support Decimal Numeric Types

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_mean.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_mean.py
@@ -11,6 +11,7 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     column_aggregate_partial,
     column_aggregate_value,
 )
+from great_expectations.util import convert_pandas_series_decimal_to_float_dtype
 
 
 class ColumnMean(ColumnAggregateMetricProvider):
@@ -21,6 +22,7 @@ class ColumnMean(ColumnAggregateMetricProvider):
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         """Pandas Mean Implementation"""
+        convert_pandas_series_decimal_to_float_dtype(data=column, inplace=True)
         return column.mean()
 
     @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
@@ -1,7 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
-
-import pandas as pd
+from typing import Optional
 
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
@@ -21,14 +19,8 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     column_aggregate_partial,
     column_aggregate_value,
 )
-from great_expectations.util import (
-    convert_ndarray_decimal_to_float_dtype,
-    does_ndarray_contain_decimal_dtype,
-)
+from great_expectations.util import convert_pandas_series_decimal_to_float_dtype
 from great_expectations.validator.metric_configuration import MetricConfiguration
-
-if TYPE_CHECKING:
-    import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +33,7 @@ class ColumnStandardDeviation(ColumnAggregateMetricProvider):
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         """Pandas Standard Deviation implementation"""
-        column_data: np.ndarray = column.to_numpy()
-        column_has_decimal: bool = does_ndarray_contain_decimal_dtype(data=column_data)
-        if column_has_decimal:
-            column_data = convert_ndarray_decimal_to_float_dtype(data=column_data)
-            column.update(pd.Series(column_data))
-
+        convert_pandas_series_decimal_to_float_dtype(data=column, inplace=True)
         return column.std()
 
     @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+import pandas as pd
 
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
@@ -19,7 +21,14 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     column_aggregate_partial,
     column_aggregate_value,
 )
+from great_expectations.util import (
+    convert_ndarray_decimal_to_float_dtype,
+    does_ndarray_contain_decimal_dtype,
+)
 from great_expectations.validator.metric_configuration import MetricConfiguration
+
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +41,12 @@ class ColumnStandardDeviation(ColumnAggregateMetricProvider):
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         """Pandas Standard Deviation implementation"""
+        column_data: np.ndarray = column.to_numpy()
+        column_has_decimal: bool = does_ndarray_contain_decimal_dtype(data=column_data)
+        if column_has_decimal:
+            column_data = convert_ndarray_decimal_to_float_dtype(data=column_data)
+            column.update(pd.Series(column_data))
+
         return column.std()
 
     @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_sum.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_sum.py
@@ -10,6 +10,7 @@ from great_expectations.expectations.metrics.column_aggregate_metric_provider im
     column_aggregate_partial,
     column_aggregate_value,
 )
+from great_expectations.util import convert_pandas_series_decimal_to_float_dtype
 
 
 class ColumnSum(ColumnAggregateMetricProvider):
@@ -17,6 +18,7 @@ class ColumnSum(ColumnAggregateMetricProvider):
 
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
+        convert_pandas_series_decimal_to_float_dtype(data=column, inplace=True)
         return column.sum()
 
     @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1715,6 +1715,28 @@ def convert_ndarray_decimal_to_float_dtype(data: np.ndarray) -> np.ndarray:
     return convert_decimal_to_float_vectorized(data)
 
 
+def convert_pandas_series_decimal_to_float_dtype(
+    data: pd.Series, inplace: bool = False
+) -> pd.Series | None:
+    """
+    Convert all elements of "pd.Series" argument from "decimal.Decimal" type to "float" type objects "pd.Series" result.
+    """
+    series_data: np.ndarray = data.to_numpy()
+    series_data_has_decimal: bool = does_ndarray_contain_decimal_dtype(data=series_data)
+    if series_data_has_decimal:
+        series_data = convert_ndarray_decimal_to_float_dtype(data=series_data)
+        if inplace:
+            data.update(pd.Series(series_data))
+            return None
+
+        return pd.Series(series_data)
+
+    if inplace:
+        return None
+
+    return data
+
+
 @overload
 def get_context(  # type: ignore[misc] # overlapping overload false positive?  # noqa: PLR0913
     project_config: DataContextConfig | Mapping | None = ...,

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -78,6 +78,47 @@ def test_basic_metric_pd():
 
 
 @pytest.mark.parametrize(
+    "build_engine,dataframe,expected_result",
+    [
+        [
+            build_pandas_engine,
+            pd.DataFrame({"a": [1, 2, 3, None]}),
+            6,
+        ],
+        [
+            build_pandas_engine,
+            pd.DataFrame({"a": [Decimal(2.0), Decimal(0.18781)]}),
+            2.18781,
+        ],
+    ],
+)
+def test_column_sum_metric_pd(build_engine, dataframe, expected_result):
+    engine = build_engine(df=dataframe)
+
+    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+    table_columns_metric: MetricConfiguration
+    results: Dict[Tuple[str, str, str], MetricValue]
+
+    table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
+    metrics.update(results)
+
+    desired_metric = MetricConfiguration(
+        metric_name="column.sum",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs=None,
+    )
+    desired_metric.metric_dependencies = {
+        "table.columns": table_columns_metric,
+    }
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(desired_metric,), metrics=metrics
+    )
+    metrics.update(results)
+    assert results == {desired_metric.id: expected_result}
+
+
+@pytest.mark.parametrize(
     "dataframe,expected_result",
     [
         [pd.DataFrame({"a": [1, 2, 3, None]}), 2],
@@ -87,7 +128,7 @@ def test_basic_metric_pd():
         ],
     ],
 )
-def test_mean_metric_pd(dataframe, expected_result):
+def test_column_mean_metric_pd(dataframe, expected_result):
     engine = build_pandas_engine(dataframe)
 
     metrics: Dict[Tuple[str, str, str], MetricValue] = {}
@@ -123,7 +164,7 @@ def test_mean_metric_pd(dataframe, expected_result):
         ],
     ],
 )
-def test_mean_metric_spark(spark_session, dataframe, expected_result):
+def test_column_mean_metric_spark(spark_session, dataframe, expected_result):
     engine = build_spark_engine(spark=spark_session, df=dataframe, batch_id="my_id")
 
     metrics: Dict[Tuple[str, str, str], MetricValue] = {}
@@ -176,7 +217,7 @@ def test_mean_metric_spark(spark_session, dataframe, expected_result):
         ],
     ],
 )
-def test_stdev_metric_pd(build_engine, dataframe, expected_result):
+def test_column_standard_deviation_metric_pd(build_engine, dataframe, expected_result):
     engine = build_engine(df=dataframe)
 
     metrics: Dict[Tuple[str, str, str], MetricValue] = {}

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -164,11 +164,20 @@ def test_mean_metric_spark(spark_session, dataframe, expected_result):
 @pytest.mark.parametrize(
     "build_engine,dataframe,expected_result",
     [
-        [build_pandas_engine, pd.DataFrame({"a": [1, 2, 3, None]}), 1],
+        [
+            build_pandas_engine,
+            pd.DataFrame({"a": [1, 2, 3, None]}),
+            1,
+        ],
+        [
+            build_pandas_engine,
+            pd.DataFrame({"a": [Decimal(2.0), Decimal(0.18781)]}),
+            1.2814118377984496,
+        ],
     ],
 )
 def test_stdev_metric_pd(build_engine, dataframe, expected_result):
-    engine = build_engine(dataframe)
+    engine = build_engine(df=dataframe)
 
     metrics: Dict[Tuple[str, str, str], MetricValue] = {}
 


### PR DESCRIPTION
### Scope
* Previously, Column Aggregate Metrics for `Pandas` did not support `Python` `Decimal` numeric type -- now they do.
* General column data conversion utility added.
* New unit test and updated existing unit tests to incorporate `Python` `Decimal` numeric type test cases.

### Remarks
* JIRA: DX-572
* Issue: https://github.com/great-expectations/great_expectations/issues/7897

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!