### PR TITLE
[BUGFIX] Relax numpy version requirements for python 3.10

### DIFF
--- a/ci/constraints-test/py310-min-install.txt
+++ b/ci/constraints-test/py310-min-install.txt
@@ -1,3 +1,3 @@
-numpy==1.23.0
+numpy==1.22.4
 pandas==1.4.0
 sqlalchemy<2.0.0  # SQLAlchemy 2.0.0 is not compatible with pandas < 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ mistune>=0.8.4
 nbformat>=5.0
 notebook>=6.4.10
 numpy>=1.19.5; python_version == "3.8" or python_version == "3.9"
-numpy>=1.23.0; python_version >= "3.10"
+numpy>=1.21.2; python_version >= "3.10"
 packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ mistune>=0.8.4
 nbformat>=5.0
 notebook>=6.4.10
 numpy>=1.19.5; python_version == "3.8" or python_version == "3.9"
-numpy>=1.21.2; python_version >= "3.10"
+numpy>=1.22.4; python_version >= "3.10"
 packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"


### PR DESCRIPTION
Amazon Managed Airflow (MWAA) pins numpy to version 1.22.4 for airflow 2.4.3 and 2.5.1; it runs on python 3.10.

This PR relaxes the constraint on numpy for python 3.10 to include that version and allow support for the Amazon managed airflow.