### PR TITLE
[MAINTENANCE] Linting Errors with Ruff and Black

### DIFF
--- a/docs_rtd/feature_annotation_parser.py
+++ b/docs_rtd/feature_annotation_parser.py
@@ -64,7 +64,7 @@ def parse_feature_annotation(docstring: Union[str, List[str], None]):
                 if this_key in maturity_details_keys:
                     maturity_details_dict[this_key] = this_val
                 elif this_key == "icon":  # icon is a special cases
-                    if this_val == "":  # noqa: PLC1901
+                    if this_val == "":
                         annotation_dict[
                             this_key
                         ] = f"https://great-expectations-web-assets.s3.us-east-2.amazonaws.com/feature_maturity_icons/{id_val}.png"

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -474,7 +474,7 @@ How would you like to create your Expectation Suite?
         show_default=False,
     )
     # Default option
-    if suite_create_method == "":  # noqa: PLC1901
+    if suite_create_method == "":
         profile = False
         interactive_mode = CLISuiteInteractiveFlagCombinations.PROMPTED_CHOICE_DEFAULT
     elif suite_create_method == "1":
@@ -717,7 +717,7 @@ How would you like to edit your Expectation Suite?
             show_default=False,
         )
         # Default option
-        if suite_edit_method == "":  # noqa: PLC1901
+        if suite_edit_method == "":
             interactive_mode = (
                 CLISuiteInteractiveFlagCombinations.PROMPTED_CHOICE_DEFAULT
             )

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -892,7 +892,7 @@ def parse_cli_config_file_location(config_file_location: str) -> dict:
         }
     """
 
-    if config_file_location is not None and config_file_location != "":  # noqa: PLC1901
+    if config_file_location is not None and config_file_location != "":
         config_file_location_path = Path(config_file_location)
 
         # If the file or directory exists, treat it appropriately

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -872,7 +872,7 @@ class Expectation(metaclass=MetaExpectation):
                 for unexpected_value in partial_unexpected_list:
                     if unexpected_value:
                         string_unexpected_value = str(unexpected_value)
-                    elif unexpected_value == "":  # noqa: PLC1901
+                    elif unexpected_value == "":
                         string_unexpected_value = "EMPTY"
                     else:
                         string_unexpected_value = "null"
@@ -2605,7 +2605,7 @@ class QueryExpectation(BatchExpectation, ABC):
             parsed_query: Set[str] = {
                 x
                 for x in re.split(", |\\(|\n|\\)| |/", query)
-                if x.upper() != ""  # noqa: PLC1901
+                if x.upper() != ""
                 and x.upper() not in valid_sql_tokens_and_types
             }
             assert "{active_batch}" in parsed_query, (

--- a/great_expectations/expectations/metrics/table_metrics/table_column_types.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_column_types.py
@@ -109,7 +109,7 @@ def _get_sqlalchemy_column_metadata(engine, batch_data: SqlAlchemyBatchData):
 
 def _get_spark_column_metadata(field, parent_name="", include_nested=True):
     cols = []
-    if parent_name != "":  # noqa: PLC1901
+    if parent_name != "":
         parent_name = f"{parent_name}."
 
     if pyspark.types and isinstance(field, pyspark.types.StructType):

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -395,7 +395,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
         cls, content_block, has_failed_evr, render_object=None
     ) -> None:
         header = cls._get_header()
-        if header != "":  # noqa: PLC1901
+        if header != "":
             content_block.header = header
 
     @classmethod

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -194,7 +194,7 @@ def parse_row_condition_string_pandas_engine(
     conditions_list = [
         condition.strip()
         for condition in conditions_list
-        if condition != "" and condition != " "  # noqa: PLC1901
+        if condition != "" and condition != " "
     ]
 
     for i, condition in enumerate(conditions_list):
@@ -261,9 +261,9 @@ def build_count_table(
         count: Optional[int] = unexpected_count_dict.get("count")
         if count:
             total_count += count
-        if value is not None and value != "":  # noqa: PLC1901
+        if value is not None and value != "":
             table_rows.append([value, count])
-        elif value == "":  # noqa: PLC1901
+        elif value == "":
             table_rows.append(["EMPTY", count])
         else:
             table_rows.append(["null", count])
@@ -325,10 +325,10 @@ def build_count_and_index_table(
 
         total_count += count
 
-        if unexpected_value is not None and unexpected_value != "":  # noqa: PLC1901
+        if unexpected_value is not None and unexpected_value != "":
             row_list.append(unexpected_value)
             row_list.append(count)
-        elif unexpected_value == "":  # noqa: PLC1901
+        elif unexpected_value == "":
             row_list.append("EMPTY")
             row_list.append(count)
         else:

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -497,7 +497,7 @@ def test_TupleFilesystemStoreBackend(tmp_path_factory):
     )
     my_store.remove_key(("BBB",))
     with pytest.raises(InvalidKeyError):
-        assert my_store.get(("BBB",)) == ""  # noqa: PLC1901
+        assert my_store.get(("BBB",)) == ""
 
     my_store_with_base_public_path = TupleFilesystemStoreBackend(
         root_directory=project_path,

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -190,7 +190,7 @@ def test_substitute_config_variable():
     # Null cases
     assert (
         config_substitutor.substitute_config_variable("", config_variables_dict)
-        == ""  # noqa: PLC1901
+        == ""
     )
     assert (
         config_substitutor.substitute_config_variable(None, config_variables_dict)


### PR DESCRIPTION



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
