### PR TITLE
[MAINTENANCE] Add `pytest.deprecated_call` to misc usages of `add_datasource` in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3600,10 +3600,11 @@ def cloud_data_context_with_datasource_pandas_engine(
         "great_expectations.data_context.store.datasource_store.DatasourceStore.set",
         side_effect=set_side_effect,
     ):
-        context.add_datasource(
-            "my_datasource",
-            **config,
-        )
+        with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+            context.add_datasource(
+                "my_datasource",
+                **config,
+            )
     return context
 
 

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -211,22 +211,25 @@ def test_data_context_in_cloud_mode_add_datasource(
             expected_datasource_config = datasourceConfigSchema.dump(
                 block_config_datasource_config
             )
-            stored_datasource = context.add_datasource(
-                name=datasource_name,
-                **expected_datasource_config,
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    name=datasource_name,
+                    **expected_datasource_config,
+                )
         elif config_includes_name_setting == "config_includes_name":
-            stored_datasource = context.add_datasource(
-                **datasource_config_with_name.to_dict()
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    **datasource_config_with_name.to_dict()
+                )
         elif (
             config_includes_name_setting
             == "name_supplied_separately_and_included_in_config"
         ):
-            stored_datasource = context.add_datasource(
-                name=datasource_name,
-                **datasource_config_with_name.to_dict(),
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    name=datasource_name,
+                    **datasource_config_with_name.to_dict(),
+                )
         else:
             raise ValueError(
                 "Invalid value provided for 'config_includes_name_setting'"
@@ -323,25 +326,28 @@ def test_cloud_data_context_add_datasource(
             expected_datasource_config = datasourceConfigSchema.dump(
                 block_config_datasource_config
             )
-            stored_datasource = context.add_datasource(
-                name=datasource_name,
-                **expected_datasource_config,
-                save_changes=True,
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    name=datasource_name,
+                    **expected_datasource_config,
+                    save_changes=True,
+                )
         elif config_includes_name_setting == "config_includes_name":
-            stored_datasource = context.add_datasource(
-                **datasource_config_with_name.to_dict(),
-                save_changes=True,
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    **datasource_config_with_name.to_dict(),
+                    save_changes=True,
+                )
         elif (
             config_includes_name_setting
             == "name_supplied_separately_and_included_in_config"
         ):
-            stored_datasource = context.add_datasource(
-                name=datasource_name,
-                **datasource_config_with_name.to_dict(),
-                save_changes=True,
-            )
+            with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+                stored_datasource = context.add_datasource(
+                    name=datasource_name,
+                    **datasource_config_with_name.to_dict(),
+                    save_changes=True,
+                )
         else:
             raise ValueError(
                 "Invalid value provided for 'config_includes_name_setting'"


### PR DESCRIPTION
Ensure that we capture deprecation warnings for `add_datasource`


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style 
guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
