### PR TITLE
[FEATURE] Use PythonScript task type for custom docs ci checks

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -186,24 +186,32 @@ stages:
     - job: docs_snippet_checker
       condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-      - script: |
-          yarn install
-          python ci/checks/validate_docs_snippets.py
+      - task: PythonScript@0
+        inputs:
+          scriptSource: 'filePath'
+          scriptPath: 'ci/checks/validate_docs_snippets.py'
+          failOnStderr: true
         name: DocsSnippetChecker
 
     - job: line_number_snippet_checker
       condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-        - script: |
-            python ci/checks/check_no_line_number_snippets.py
+        - task: PythonScript@0
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: 'ci/checks/check_no_line_number_snippets.py'
+            failOnStderr: true
           name: LineNumberSnippetChecker
 
 
     - job: name_tag_snippet_checker
       condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-        - script: |
-            python ci/checks/check_only_name_tag_snippets.py
+        - task: PythonScript@0
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: 'ci/checks/check_only_name_tag_snippets.py'
+            failOnStderr: true
           name: NameTagSnippetChecker
 
     - job: public_api_report

--- a/ci/azure-pipelines-docs.yml
+++ b/ci/azure-pipelines-docs.yml
@@ -43,27 +43,36 @@ stages:
         name: LinkChecker
 
     - job: docs_snippet_checker
-      condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isDevelop, true), eq(variables.isManual, true))
+      condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-      - script: |
-          yarn install
-          python ci/checks/validate_docs_snippets.py
+      - task: PythonScript@0
+        inputs:
+          scriptSource: 'filePath'
+          scriptPath: 'ci/checks/validate_docs_snippets.py'
+          failOnStderr: true
         name: DocsSnippetChecker
 
     - job: line_number_snippet_checker
-      condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isDevelop, true), eq(variables.isManual, true))
+      condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-        - script: |
-            python ci/checks/check_no_line_number_snippets.py
+        - task: PythonScript@0
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: 'ci/checks/check_no_line_number_snippets.py'
+            failOnStderr: true
           name: LineNumberSnippetChecker
 
 
     - job: name_tag_snippet_checker
-      condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isDevelop, true), eq(variables.isManual, true))
+      condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:
-        - script: |
-            python ci/checks/check_only_name_tag_snippets.py
+        - task: PythonScript@0
+          inputs:
+            scriptSource: 'filePath'
+            scriptPath: 'ci/checks/check_only_name_tag_snippets.py'
+            failOnStderr: true
           name: NameTagSnippetChecker
+
 
     - job: public_api_report
       condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isDevelop, true), eq(variables.isManual, true))


### PR DESCRIPTION
CI custom doc checks were not correctly outputting stdout and erroring on sys.exit(1).

Using PythonScript task type resolves this. https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/python-script-v0?view=azure-pipelines&viewFallbackFrom=azure-devops

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
