### PR TITLE
[MAINTENANCE] Placing BigQuery Imports Under Compatibility Pattern

### DIFF
--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -10,10 +10,7 @@ from great_expectations.cli.pretty_printing import cli_message
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
 from great_expectations.util import get_sqlalchemy_inspector
 
-try:
-    from sqlalchemy_bigquery.parse_url import parse_url as parse_bigquery_url
-except (ImportError, ModuleNotFoundError):
-    parse_bigquery_url = None
+from great_expectations.compatibility.bigquery import parse_url as parse_bigquery_url
 
 from great_expectations import exceptions as gx_exceptions
 from great_expectations.datasource import (

--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -6,24 +6,21 @@ from typing import TYPE_CHECKING, Any, Dict, Final, List, Optional, Type, Union
 
 import click
 
-from great_expectations.cli.pretty_printing import cli_message
-from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
-from great_expectations.util import get_sqlalchemy_inspector
-
-from great_expectations.compatibility.bigquery import parse_url as parse_bigquery_url
-
 from great_expectations import exceptions as gx_exceptions
+from great_expectations.cli.pretty_printing import cli_message
+from great_expectations.compatibility.bigquery import parse_url as parse_bigquery_url
 from great_expectations.datasource import (
     BaseDatasource,
     DataConnector,
     Datasource,
     SimpleSqlalchemyDatasource,
 )
+from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
 from great_expectations.execution_engine import (
     SqlAlchemyExecutionEngine,  # noqa: TCH001
 )
 from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
-from great_expectations.util import filter_properties_dict
+from great_expectations.util import filter_properties_dict, get_sqlalchemy_inspector
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/compatibility/bigquery.py
+++ b/great_expectations/compatibility/bigquery.py
@@ -21,6 +21,11 @@ try:
 except (ImportError, AttributeError):
     GEOGRAPHY = SQLALCHEMY_BIGQUERY_NOT_IMPORTED
 
+try:
+    from sqlalchemy_bigquery import parse_url
+except (ImportError, AttributeError):
+    parse_url = SQLALCHEMY_BIGQUERY_NOT_IMPORTED
+
 if sqlalchemy_bigquery:
     BIGQUERY_TYPES = {
         "INTEGER": sqlalchemy_bigquery.INTEGER,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -127,11 +127,11 @@ try:
 except (ImportError, KeyError, AttributeError):
     snowflake = None
 
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     _BIGQUERY_MODULE_NAME,
     bigquery_types_tuple,
 )
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     sqlalchemy_bigquery as sqla_bigquery,
 )
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -55,11 +55,11 @@ logger = logging.getLogger(__name__)
 
 _BIGQUERY_MODULE_NAME = "sqlalchemy_bigquery"
 BIGQUERY_GEO_SUPPORT = False
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     GEOGRAPHY,
     bigquery_types_tuple,
 )
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     sqlalchemy_bigquery as BigQueryDialect,
 )
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -52,8 +52,8 @@ except ImportError:
 
 _BIGQUERY_MODULE_NAME = "sqlalchemy_bigquery"
 
-from great_expectations.compatibility import sqlalchemy_bigquery as sqla_bigquery
-from great_expectations.compatibility.sqlalchemy_bigquery import bigquery_types_tuple
+from great_expectations.compatibility import bigquery as sqla_bigquery
+from great_expectations.compatibility.bigquery import bigquery_types_tuple
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -33,7 +33,7 @@ import numpy as np
 import pandas as pd
 from dateutil.parser import parse
 
-import great_expectations.compatibility.sqlalchemy_bigquery as BigQueryDialect
+import great_expectations.compatibility.bigquery as BigQueryDialect
 from great_expectations.compatibility import aws, pyspark, sqlalchemy, trino
 from great_expectations.compatibility.pandas_compatibility import (
     execute_pandas_to_datetime,
@@ -123,7 +123,7 @@ else:
     SQLITE_TYPES = {}
 
 
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     BIGQUERY_TYPES,
     GEOGRAPHY,
 )

--- a/tests/datasource/test_new_datasource_with_sql_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_sql_data_connector.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     sqlalchemy = None
 
-from great_expectations.compatibility.sqlalchemy_bigquery import (
+from great_expectations.compatibility.bigquery import (
     sqlalchemy_bigquery as sqla_bigquery,
 )
 

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -4,6 +4,8 @@ import shutil
 
 import pytest
 
+from nbformat import NotebookNode
+
 from great_expectations.core.expectation_suite import (
     ExpectationSuite,
     ExpectationSuiteSchema,
@@ -1441,73 +1443,79 @@ def test_notebook_execution_with_custom_notebooks(
         data_context_custom_notebooks
     ).render(suite_with_multiple_citations)
     assert isinstance(obs, dict)
-    expected = {
-        "nbformat": 4,
-        "nbformat_minor": 4,
-        "metadata": {},
-        "cells": [
-            {
-                "cell_type": "markdown",
-                "source": "# Custom header for MyCompany",
-                "metadata": {},
-            },
-            {
-                "cell_type": "code",
-                "metadata": {},
-                "execution_count": None,
-                "source": 'import datetime\nimport great_expectations as gx\nimport great_expectations.jupyter_ux\nfrom great_expectations.checkpoint import LegacyCheckpoint\nfrom great_expectations.data_context.types.resource_identifiers import (\n    ValidationResultIdentifier,\n)\n\ncontext = gx.get_context()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "critical"\nsuite = context.get_expectation_suite(expectation_suite_name)\nsuite.expectations = []\n\nbatch_kwargs = {"path": "../../3.csv", "datasource": "3"}\nbatch = context.get_batch(batch_kwargs, suite)\nbatch.head()',
-                "outputs": [],
-            },
-            {
-                "cell_type": "markdown",
-                "source": "## Create & Edit Expectations\n\nAdd expectations by calling specific expectation methods on the `batch` object. They all begin with `.expect_` which makes autocompleting easy using tab.\n\nYou can see all the available expectations in the **[expectation gallery](https://greatexpectations.io/expectations)**.",
-                "metadata": {},
-            },
-            {
-                "cell_type": "markdown",
-                "source": "### Table Expectation(s)",
-                "metadata": {},
-            },
-            {
-                "cell_type": "markdown",
-                "source": "No table level expectations are in this suite. Feel free to add some here. They all begin with `batch.expect_table_...`.",
-                "metadata": {},
-            },
-            {
-                "cell_type": "markdown",
-                "source": "### Column Expectation(s)\nwrite your column expectations here",
-                "metadata": {},
-            },
-            {"cell_type": "markdown", "source": "#### `npi`", "metadata": {}},
-            {
-                "cell_type": "code",
-                "metadata": {},
-                "execution_count": None,
-                "source": 'batch.expect_column_values_to_not_be_null(column="npi")',
-                "outputs": [],
-            },
-            {"cell_type": "markdown", "source": "#### `provider_type`", "metadata": {}},
-            {
-                "cell_type": "code",
-                "metadata": {},
-                "execution_count": None,
-                "source": 'batch.expect_column_values_to_not_be_null(column="provider_type")',
-                "outputs": [],
-            },
-            {
-                "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
-                "metadata": {},
-            },
-            {
-                "cell_type": "code",
-                "metadata": {},
-                "execution_count": None,
-                "source": 'batch.save_expectation_suite(discard_failed_expectations=False)\nrun_id = {\n    "run_name": "some_string_that_uniquely_identifies_this_run",  # insert your own run_name here\n    "run_time": datetime.datetime.now(datetime.timezone.utc),\n}\nresults = context.run_validation_operator(\n    "local", assets_to_validate=[batch], run_id=run_id\n)\nvalidation_result_identifier = results.list_validation_result_identifiers()[0]\ncontext.build_data_docs(site_names=["site_local"])\ncontext.open_data_docs(validation_result_identifier, site_name="site_local")',
-                "outputs": [],
-            },
-        ],
-    }
+    expected = NotebookNode(
+        {
+            "nbformat": 4,
+            "nbformat_minor": 4,
+            "metadata": {},
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "source": "# Custom header for MyCompany",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "execution_count": None,
+                    "source": 'import datetime\nimport great_expectations as gx\nimport great_expectations.jupyter_ux\nfrom great_expectations.checkpoint import LegacyCheckpoint\nfrom great_expectations.data_context.types.resource_identifiers import (\n    ValidationResultIdentifier,\n)\n\ncontext = gx.get_context()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "critical"\nsuite = context.get_expectation_suite(expectation_suite_name)\nsuite.expectations = []\n\nbatch_kwargs = {"path": "../../3.csv", "datasource": "3"}\nbatch = context.get_batch(batch_kwargs, suite)\nbatch.head()',
+                    "outputs": [],
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "## Create & Edit Expectations\n\nAdd expectations by calling specific expectation methods on the `batch` object. They all begin with `.expect_` which makes autocompleting easy using tab.\n\nYou can see all the available expectations in the **[expectation gallery](https://greatexpectations.io/expectations)**.",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "### Table Expectation(s)",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "No table level expectations are in this suite. Feel free to add some here. They all begin with `batch.expect_table_...`.",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "### Column Expectation(s)\nwrite your column expectations here",
+                    "metadata": {},
+                },
+                {"cell_type": "markdown", "source": "#### `npi`", "metadata": {}},
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "execution_count": None,
+                    "source": 'batch.expect_column_values_to_not_be_null(column="npi")',
+                    "outputs": [],
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "#### `provider_type`",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "execution_count": None,
+                    "source": 'batch.expect_column_values_to_not_be_null(column="provider_type")',
+                    "outputs": [],
+                },
+                {
+                    "cell_type": "markdown",
+                    "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                    "metadata": {},
+                },
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "execution_count": None,
+                    "source": 'batch.save_expectation_suite(discard_failed_expectations=False)\nrun_id = {\n    "run_name": "some_string_that_uniquely_identifies_this_run",  # insert your own run_name here\n    "run_time": datetime.datetime.now(datetime.timezone.utc),\n}\nresults = context.run_validation_operator(\n    "local", assets_to_validate=[batch], run_id=run_id\n)\nvalidation_result_identifier = results.list_validation_result_identifiers()[0]\ncontext.build_data_docs(site_names=["site_local"])\ncontext.open_data_docs(validation_result_identifier, site_name="site_local")',
+                    "outputs": [],
+                },
+            ],
+        }
+    )
     del expected["nbformat_minor"]
     del obs["nbformat_minor"]
     for obs_cell, expected_cell in zip(obs["cells"], expected["cells"]):

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -3,7 +3,6 @@ import os
 import shutil
 
 import pytest
-
 from nbformat import NotebookNode
 
 from great_expectations.core.expectation_suite import (

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -3,7 +3,6 @@ import os
 import shutil
 
 import pytest
-from nbformat import NotebookNode
 
 from great_expectations.core.expectation_suite import (
     ExpectationSuite,
@@ -553,7 +552,7 @@ def test_render_without_batch_kwargs_uses_batch_kwargs_in_citations(
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -623,7 +622,7 @@ def test_render_with_no_column_cells(critical_suite_with_citations, empty_data_c
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -707,7 +706,7 @@ def test_render_without_batch_kwargs_and_no_batch_kwargs_in_citations_uses_blank
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -792,7 +791,7 @@ def test_render_with_batch_kwargs_and_no_batch_kwargs_in_citations(
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -876,7 +875,7 @@ def test_render_with_no_batch_kwargs_and_no_citations(
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -959,7 +958,7 @@ def test_render_with_batch_kwargs_overrides_batch_kwargs_in_citations(
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -1062,7 +1061,7 @@ def test_render_with_no_batch_kwargs_multiple_batch_kwarg_citations(
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -1398,7 +1397,7 @@ def test_complex_suite(warning_suite, empty_data_context):
             },
             {
                 "cell_type": "markdown",
-                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
                 "metadata": {},
             },
             {
@@ -1442,79 +1441,73 @@ def test_notebook_execution_with_custom_notebooks(
         data_context_custom_notebooks
     ).render(suite_with_multiple_citations)
     assert isinstance(obs, dict)
-    expected = NotebookNode(
-        {
-            "nbformat": 4,
-            "nbformat_minor": 4,
-            "metadata": {},
-            "cells": [
-                {
-                    "cell_type": "markdown",
-                    "source": "# Custom header for MyCompany",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "code",
-                    "metadata": {},
-                    "execution_count": None,
-                    "source": 'import datetime\nimport great_expectations as gx\nimport great_expectations.jupyter_ux\nfrom great_expectations.checkpoint import LegacyCheckpoint\nfrom great_expectations.data_context.types.resource_identifiers import (\n    ValidationResultIdentifier,\n)\n\ncontext = gx.get_context()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "critical"\nsuite = context.get_expectation_suite(expectation_suite_name)\nsuite.expectations = []\n\nbatch_kwargs = {"path": "../../3.csv", "datasource": "3"}\nbatch = context.get_batch(batch_kwargs, suite)\nbatch.head()',
-                    "outputs": [],
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "## Create & Edit Expectations\n\nAdd expectations by calling specific expectation methods on the `batch` object. They all begin with `.expect_` which makes autocompleting easy using tab.\n\nYou can see all the available expectations in the **[expectation gallery](https://greatexpectations.io/expectations)**.",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "### Table Expectation(s)",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "No table level expectations are in this suite. Feel free to add some here. They all begin with `batch.expect_table_...`.",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "### Column Expectation(s)\nwrite your column expectations here",
-                    "metadata": {},
-                },
-                {"cell_type": "markdown", "source": "#### `npi`", "metadata": {}},
-                {
-                    "cell_type": "code",
-                    "metadata": {},
-                    "execution_count": None,
-                    "source": 'batch.expect_column_values_to_not_be_null(column="npi")',
-                    "outputs": [],
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "#### `provider_type`",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "code",
-                    "metadata": {},
-                    "execution_count": None,
-                    "source": 'batch.expect_column_values_to_not_be_null(column="provider_type")',
-                    "outputs": [],
-                },
-                {
-                    "cell_type": "markdown",
-                    "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_asset/index.html?highlight=remove_expectation&utm_source=notebook&utm_medium=edit_expectations#great_expectations.data_asset.DataAsset.remove_expectation).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
-                    "metadata": {},
-                },
-                {
-                    "cell_type": "code",
-                    "metadata": {},
-                    "execution_count": None,
-                    "source": 'batch.save_expectation_suite(discard_failed_expectations=False)\nrun_id = {\n    "run_name": "some_string_that_uniquely_identifies_this_run",  # insert your own run_name here\n    "run_time": datetime.datetime.now(datetime.timezone.utc),\n}\nresults = context.run_validation_operator(\n    "local", assets_to_validate=[batch], run_id=run_id\n)\nvalidation_result_identifier = results.list_validation_result_identifiers()[0]\ncontext.build_data_docs(site_names=["site_local"])\ncontext.open_data_docs(validation_result_identifier, site_name="site_local")',
-                    "outputs": [],
-                },
-            ],
-        }
-    )
+    expected = {
+        "nbformat": 4,
+        "nbformat_minor": 4,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": "# Custom header for MyCompany",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'import datetime\nimport great_expectations as gx\nimport great_expectations.jupyter_ux\nfrom great_expectations.checkpoint import LegacyCheckpoint\nfrom great_expectations.data_context.types.resource_identifiers import (\n    ValidationResultIdentifier,\n)\n\ncontext = gx.get_context()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "critical"\nsuite = context.get_expectation_suite(expectation_suite_name)\nsuite.expectations = []\n\nbatch_kwargs = {"path": "../../3.csv", "datasource": "3"}\nbatch = context.get_batch(batch_kwargs, suite)\nbatch.head()',
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Create & Edit Expectations\n\nAdd expectations by calling specific expectation methods on the `batch` object. They all begin with `.expect_` which makes autocompleting easy using tab.\n\nYou can see all the available expectations in the **[expectation gallery](https://greatexpectations.io/expectations)**.",
+                "metadata": {},
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### Table Expectation(s)",
+                "metadata": {},
+            },
+            {
+                "cell_type": "markdown",
+                "source": "No table level expectations are in this suite. Feel free to add some here. They all begin with `batch.expect_table_...`.",
+                "metadata": {},
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### Column Expectation(s)\nwrite your column expectations here",
+                "metadata": {},
+            },
+            {"cell_type": "markdown", "source": "#### `npi`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'batch.expect_column_values_to_not_be_null(column="npi")',
+                "outputs": [],
+            },
+            {"cell_type": "markdown", "source": "#### `provider_type`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'batch.expect_column_values_to_not_be_null(column="provider_type")',
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Review & Save Your Expectations\n\nLet's save the expectation suite as a JSON file in the `great_expectations/expectations` directory of your project.\nIf you decide not to save some expectations that you created, use [remove_expectation method](https://docs.greatexpectations.io/docs/guides/expectations/how_to_edit_an_existing_expectationsuite/#remove-the-expectationconfiguration-optional).\n\nLet's now rebuild your Data Docs, which helps you communicate about your data with both machines and humans.",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'batch.save_expectation_suite(discard_failed_expectations=False)\nrun_id = {\n    "run_name": "some_string_that_uniquely_identifies_this_run",  # insert your own run_name here\n    "run_time": datetime.datetime.now(datetime.timezone.utc),\n}\nresults = context.run_validation_operator(\n    "local", assets_to_validate=[batch], run_id=run_id\n)\nvalidation_result_identifier = results.list_validation_result_identifiers()[0]\ncontext.build_data_docs(site_names=["site_local"])\ncontext.open_data_docs(validation_result_identifier, site_name="site_local")',
+                "outputs": [],
+            },
+        ],
+    }
     del expected["nbformat_minor"]
     del obs["nbformat_minor"]
     for obs_cell, expected_cell in zip(obs["cells"], expected["cells"]):

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -6,7 +6,7 @@ from typing import cast
 import pandas as pd
 import pytest
 
-import great_expectations.compatibility.sqlalchemy_bigquery as BigQueryDialect
+import great_expectations.compatibility.bigquery as BigQueryDialect
 from great_expectations import DataContext
 from great_expectations.compatibility import sqlalchemy, trino
 from great_expectations.compatibility.sqlalchemy import (


### PR DESCRIPTION
*  Places all uses of `bigquery` under Compatibility pattern.
* `compatibility.sqlalchemy_bigquery` is renamed to `compatibility.bigquery` to be consistent with other backends

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
