### PR TITLE
[BUGFIX] Patch additional `pytest.deprecated_call` around adding datasource with Cloud

### DIFF
--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -404,7 +404,8 @@ def test_cloud_context_datasource_crud_e2e() -> None:
         },
     )
 
-    context.add_datasource(datasource=datasource)
+    with pytest.deprecated_call():  # non-FDS datasources discouraged in Cloud
+        context.add_datasource(datasource=datasource)
 
     saved_datasource = context.get_datasource(datasource_name)
     assert saved_datasource is not None and saved_datasource.name == datasource_name


### PR DESCRIPTION
Missed an instance in an E2E test

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
