### PR TITLE
[MAINTENANCE] Arranging call arguments to `build_batch_request()` utility method to be in consistent order

### DIFF
--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -164,8 +164,8 @@ def get_batch_ids(  # noqa: PLR0913
             return None
 
         batch_request = build_batch_request(
-            domain=domain,
             batch_request=batch_request,
+            domain=domain,
             variables=variables,
             parameters=parameters,
         )


### PR DESCRIPTION
### Scope
* Minor: Arranging call arguments to `build_batch_request()` utility method to be in the order consistent with that of other methods that utilize `domain`, `variables`, and `parameters` as arguments in the `Profiler` component.

### Remarks
* JIRA: DX-594

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!