### PR TITLE
[FEATURE] View data docs inside snowflake and bigquery reference environments

### DIFF
--- a/examples/reference_environments/README.md
+++ b/examples/reference_environments/README.md
@@ -27,11 +27,11 @@ This example will show you how to start a reference environment for a postgres d
 
 2. Click on the jupyter notebook link in the output to open the notebook in your browser.
 
-If there are more than one URL being displayed, you can use the following command to only show the URL for the notebook.
+If there are more than one URL being displayed, you can use the following command to only show the URL for the notebook:
 
-    ```bash
-    great_expectations example postgres --url
-    ```
+```bash
+great_expectations example postgres --url
+```
 
 That's it!
 
@@ -52,6 +52,14 @@ The notebook contains a quickstart which you can edit to your heart's content.
 
     ```bash
     great_expectations example postgres --bash
+    ```
+
+### To rebuild a reference environment
+
+1. Navigate to the repo root and run:
+
+    ```bash
+    great_expectations example postgres --build
     ```
 
 Alternatively you can run `docker ps` to find the container name and then run `docker exec -it <container_name> bash` to hop into a bash session. The above command is just a shortcut.

--- a/examples/reference_environments/bigquery/README.md
+++ b/examples/reference_environments/bigquery/README.md
@@ -1,18 +1,21 @@
 # BigQuery Reference Environment
 
-This reference environment spins up a single container:
+This reference environment spins up two containers:
 
 - A jupyter notebook server
+- A server to host data docs (to view navigate to http://127.0.0.1:3000/)
 
 The jupyter notebook server contains a notebook with a quickstart for using Great Expectations with BigQuery.
 
-GX will use the `sqlalchemy-bigquery` connector to connect to BigQuery. 
+GX will use the `sqlalchemy-bigquery` connector to connect to BigQuery.
 
 You can connect to BigQuery by setting up 2 environment variables:
 
-First, the `GOOGLE_APPLICATION_CREDENTIALS` variable is used for authentication, and can point to a credential configuration JSON file. 
+First, the `GOOGLE_APPLICATION_CREDENTIALS` variable is used for authentication, and can point to a credential configuration JSON file.
 The second variable needed is the `BIGQUERY_CONNECTION_STRING`, which has the format `bigquery://gcp_project/bigquery_dataset`.
 
 More information on authentication can be found in the [Google Cloud Authentication Documentation](https://cloud.google.com/docs/authentication/application-default-credentials#GAC).
 
 Please also note that the jupyter notebook will use the default ports, so please make sure you don't have anything else running on those ports, or take steps to avoid port conflicts.
+
+The container serving the jupyter notebook will install Great Expectations with the appropriate dependencies based on the latest release, then install from the latest on the `develop` branch. To modify this e.g. install from the latest release only or from a different branch, edit `jupyter.Dockerfile`.

--- a/examples/reference_environments/bigquery/bigquery_example.ipynb
+++ b/examples/reference_environments/bigquery/bigquery_example.ipynb
@@ -35,6 +35,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/reference_environments/bigquery/compose.yaml
+++ b/examples/reference_environments/bigquery/compose.yaml
@@ -22,9 +22,6 @@ services:
     build:
       context: .
       dockerfile: data_docs.Dockerfile
-    depends_on:
-      db:
-        condition: service_healthy
     networks:
       - dbnet
     ports:

--- a/examples/reference_environments/bigquery/compose.yaml
+++ b/examples/reference_environments/bigquery/compose.yaml
@@ -12,3 +12,29 @@ services:
       - "8888:8888"
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/creds.json
+      - gx_stores:/gx/gx_stores
+    networks:
+      - dbnet
+
+  data_docs:
+    image: gx/data_docs
+    container_name: gx_data_docs
+    build:
+      context: .
+      dockerfile: data_docs.Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - dbnet
+    ports:
+      - "3000:3000"
+    volumes:
+      - gx_stores:/gx/gx_stores:ro
+
+networks:
+  dbnet:
+    driver: bridge
+
+volumes:
+  gx_stores:

--- a/examples/reference_environments/bigquery/compose.yaml
+++ b/examples/reference_environments/bigquery/compose.yaml
@@ -17,8 +17,8 @@ services:
       - dbnet
 
   data_docs:
-    image: gx/data_docs
-    container_name: gx_data_docs
+    image: gx/bigquery_data_docs
+    container_name: gx_bigquery_data_docs
     build:
       context: .
       dockerfile: data_docs.Dockerfile

--- a/examples/reference_environments/bigquery/data_docs.Dockerfile
+++ b/examples/reference_environments/bigquery/data_docs.Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+# Create a non-root user to own the files and run our server
+RUN adduser static
+USER static
+WORKDIR /gx/gx_stores/data_docs/
+
+CMD ["python", "-m", "http.server", "3000"]

--- a/examples/reference_environments/bigquery/jupyter.Dockerfile
+++ b/examples/reference_environments/bigquery/jupyter.Dockerfile
@@ -7,3 +7,7 @@ COPY ./bigquery_example.ipynb ./
 # sqlalchemy-bigquery connector is currently not compatible with sqlachemy 2.0.
 # This line can be changed to `RUN pip install great_expectations[bigquery]` once they are compatible.
 RUN pip install 'great_expectations[bigquery, sqlalchemy-less-than-2]'
+
+# Use this line to install GX from the develop branch,
+# or replace develop with the branch name you want to install from:
+RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/postgres/README.md
+++ b/examples/reference_environments/postgres/README.md
@@ -28,3 +28,5 @@ docker cp jupyter_container_id:/gx/my_notebook.ipynb .
 ```
 
 Please also note that the database and jupyter notebook will use the default ports, so please make sure you don't have anything else running on those ports, or take steps to avoid port conflicts.
+
+The container serving the jupyter notebook will install Great Expectations with the appropriate dependencies based on the latest release, then install from the latest on the `develop` branch. To modify this e.g. install from the latest release only or from a different branch, edit `jupyter.Dockerfile`.

--- a/examples/reference_environments/postgres/compose.yaml
+++ b/examples/reference_environments/postgres/compose.yaml
@@ -40,8 +40,8 @@ services:
       - gx_stores:/gx/gx_stores
 
   data_docs:
-    image: gx/data_docs
-    container_name: gx_data_docs
+    image: gx/postgres_data_docs
+    container_name: gx_postgres_data_docs
     build:
       context: .
       dockerfile: data_docs.Dockerfile

--- a/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
+++ b/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
@@ -65,6 +65,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bb7e779c",
    "metadata": {},
    "outputs": [],

--- a/examples/reference_environments/snowflake/README.md
+++ b/examples/reference_environments/snowflake/README.md
@@ -1,12 +1,13 @@
 # Snowflake Reference Environment
 
-This reference environment spins up a single container:
+This reference environment spins up two containers:
 
 - A jupyter notebook server
+- A server to host data docs (to view navigate to http://127.0.0.1:3000/)
 
 The jupyter notebook server contains a notebook with a quickstart for using Great Expectations with snowflake.
 
-GX will use the `snowflake-sqlalchemy` connector to connect to Snowflake. 
+GX will use the `snowflake-sqlalchemy` connector to connect to Snowflake.
 
 You can connect to the database by setting up your Snowflake connection string as an environment variable named `SNOWFLAKE_CONNECTION_STRING`:
 ```bash
@@ -17,3 +18,5 @@ More information on the Connection Parameters you can use with the `sqlalchemy-s
 ).
 
 Please also note that the jupyter notebook will use the default ports, so please make sure you don't have anything else running on those ports, or take steps to avoid port conflicts.
+
+The container serving the jupyter notebook will install Great Expectations with the appropriate dependencies based on the latest release, then install from the latest on the `develop` branch. To modify this e.g. install from the latest release only or from a different branch, edit `jupyter.Dockerfile`.

--- a/examples/reference_environments/snowflake/compose.yaml
+++ b/examples/reference_environments/snowflake/compose.yaml
@@ -15,8 +15,8 @@ services:
       - dbnet
 
   data_docs:
-    image: gx/data_docs
-    container_name: gx_data_docs
+    image: gx/snowflake_data_docs
+    container_name: gx_snowflake_data_docs
     build:
       context: .
       dockerfile: data_docs.Dockerfile

--- a/examples/reference_environments/snowflake/compose.yaml
+++ b/examples/reference_environments/snowflake/compose.yaml
@@ -20,9 +20,6 @@ services:
     build:
       context: .
       dockerfile: data_docs.Dockerfile
-    depends_on:
-      db:
-        condition: service_healthy
     networks:
       - dbnet
     ports:

--- a/examples/reference_environments/snowflake/compose.yaml
+++ b/examples/reference_environments/snowflake/compose.yaml
@@ -9,3 +9,30 @@ services:
       SNOWFLAKE_CONNECTION_STRING: ${SNOWFLAKE_CONNECTION_STRING}
     ports:
       - "8888:8888"
+    volumes:
+      - gx_stores:/gx/gx_stores
+    networks:
+      - dbnet
+
+  data_docs:
+    image: gx/data_docs
+    container_name: gx_data_docs
+    build:
+      context: .
+      dockerfile: data_docs.Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - dbnet
+    ports:
+      - "3000:3000"
+    volumes:
+      - gx_stores:/gx/gx_stores:ro
+
+networks:
+  dbnet:
+    driver: bridge
+
+volumes:
+  gx_stores:

--- a/examples/reference_environments/snowflake/data_docs.Dockerfile
+++ b/examples/reference_environments/snowflake/data_docs.Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+# Create a non-root user to own the files and run our server
+RUN adduser static
+USER static
+WORKDIR /gx/gx_stores/data_docs/
+
+CMD ["python", "-m", "http.server", "3000"]

--- a/examples/reference_environments/snowflake/jupyter.Dockerfile
+++ b/examples/reference_environments/snowflake/jupyter.Dockerfile
@@ -7,3 +7,7 @@ COPY ./snowflake_example.ipynb ./
 # snowflake-sqlalchemy connector is currently not compatible with sqlachemy 2.0.
 # This line can be changed to `RUN pip install great_expectations[snowflake]` once they are compatible.
 RUN pip install 'great_expectations[snowflake, sqlalchemy-less-than-2]'
+
+# Use this line to install GX from the develop branch,
+# or replace develop with the branch name you want to install from:
+RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/snowflake/snowflake_example.ipynb
+++ b/examples/reference_environments/snowflake/snowflake_example.ipynb
@@ -24,6 +24,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/great_expectations/cli/example.py
+++ b/great_expectations/cli/example.py
@@ -88,6 +88,9 @@ def example_snowflake(
         cli_message(
             "<green>To connect to the jupyter server, please use the links at the end of the log messages.</green>"
         )
+        cli_message(
+            "<green>To view data docs, visit localhost port 3000 e.g. http://127.0.0.1:3000/</green>"
+        )
         print_green_line()
         setup_commands = ["docker", "compose", "up"]
         subprocess.run(setup_commands, cwd=example_directory)
@@ -334,6 +337,9 @@ def example_bigquery(
         )
         cli_message(
             "<green>To connect to the jupyter server, please use the links at the end of the log messages.</green>"
+        )
+        cli_message(
+            "<green>To view data docs, visit localhost port 3000 e.g. http://127.0.0.1:3000/</green>"
         )
         print_green_line()
         setup_commands = ["docker", "compose", "up"]

--- a/great_expectations/cli/example.py
+++ b/great_expectations/cli/example.py
@@ -149,6 +149,9 @@ def example_postgres(
         cli_message(
             "<green>To connect to the jupyter server, please use the links at the end of the log messages.</green>"
         )
+        cli_message(
+            "<green>To view data docs, visit localhost port 3000 e.g. http://127.0.0.1:3000/</green>"
+        )
         print_green_line()
         setup_commands = ["docker", "compose", "up"]
         subprocess.run(setup_commands, cwd=example_directory)


### PR DESCRIPTION
- This PR adds a separate container that serves data docs for easy viewing in the bigquery and snowflake reference environments.
- It also fixes a few items for consistency and adds more description to a few readme files.