### PR TITLE
[MAINTENANCE] Correcting typographical error in test method naming.

### DIFF
--- a/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -86,7 +86,7 @@ def test_instantiation_mean_unexpected_map_metric_multi_batch_parameter_builder_
 
 @pytest.mark.integration
 @pytest.mark.slow  # 1.56s
-def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_numeric_dependencies_evaluated_separately(
+def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_metric_dependencies_evaluated_separately(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     data_context: DataContext = (
@@ -199,7 +199,7 @@ def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_numeric_
 
 @pytest.mark.integration
 @pytest.mark.slow  # 1.58s
-def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_numeric_dependencies_evaluated_in_parameter_builder(
+def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_metric_dependencies_evaluated_in_parameter_builder(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     data_context: DataContext = (
@@ -299,7 +299,7 @@ def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_numeric_
 
 @pytest.mark.integration
 @pytest.mark.slow  # 1.58s
-def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_numeric_dependencies_evaluated_mixed(
+def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_metric_dependencies_evaluated_mixed(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     data_context: DataContext = (


### PR DESCRIPTION
### Scope
Correcting typographical error in test method naming for one of existing `ParameterBuilder` classes.

### Remarks
* JIRA: DX-594
* 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!