### PR TITLE
[BUGFIX] Ensure DataAssistantResult.plot_expectations_and_metrics does not raise exceptions when no Metrics or Expectations are available to plot

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -3148,6 +3148,9 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             Domain, Dict[str, List[ParameterNode]]
         ] = self._determine_attributed_metrics_by_domain_type(MetricDomainTypes.TABLE)
 
+        if not attributed_metrics_by_table_domain:
+            return []
+
         table_domain = Domain(
             domain_type=MetricDomainTypes.TABLE, rule_name="table_rule"
         )
@@ -3254,6 +3257,9 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             include_column_names,
             exclude_column_names,
         )
+
+        if not attributed_metrics_by_column_domain:
+            return [], []
 
         column_based_metric_names: Set[tuple[str, ...]] = set()
         for metrics in metric_expectation_map.keys():

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -684,7 +684,10 @@ def test_onboarding_data_assistant_plot_expectations_and_metrics_correctly_handl
         include_column_names=include_column_names
     )
 
-    # This test passes only if absense of any metrics and expectations to plot does not cause exceptions to be raised.
+    """
+    This test passes only if absense of any metrics and expectations to plot does not cause exceptions to be raised.
+    Since column under test is semantically "NUMERIC", 8 (eight) numeric metrics to plot must be only remaining ones.
+    """
     column_domain_charts: List[dict] = [p.to_dict() for p in plot_result.charts[2:]]
     assert len(column_domain_charts) == 8
 

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -678,39 +678,6 @@ def test_onboarding_data_assistant_result_plot_expectations_and_metrics_correctl
 
 
 @pytest.mark.integration
-@pytest.mark.slow  # 1.67s
-def test_onboarding_data_assistant_plot_expectations_and_metrics_correctly_handle_empty_plot_data(
-    bobby_columnar_table_multi_batch_probabilistic_data_context: DataContext,
-) -> None:
-    context: DataContext = bobby_columnar_table_multi_batch_probabilistic_data_context
-
-    batch_request: dict = {
-        "datasource_name": "taxi_pandas",
-        "data_connector_name": "monthly",
-        "data_asset_name": "my_reports",
-    }
-
-    include_column_names: List[str] = [
-        "congestion_surcharge",
-    ]
-
-    data_assistant_result: DataAssistantResult = context.assistants.onboarding.run(
-        batch_request=batch_request,
-        include_column_names=include_column_names,
-    )
-    plot_result: PlotResult = data_assistant_result.plot_expectations_and_metrics(
-        include_column_names=include_column_names
-    )
-
-    """
-    This test passes only if absense of any metrics and expectations to plot does not cause exceptions to be raised.
-    Since column under test is semantically "NUMERIC", 8 (eight) numeric metrics to plot must be only remaining ones.
-    """
-    column_domain_charts: List[dict] = [p.to_dict() for p in plot_result.charts[2:]]
-    assert len(column_domain_charts) == 8
-
-
-@pytest.mark.integration
 @pytest.mark.slow  # 5.63s
 def test_onboarding_data_assistant_plot_custom_theme_overrides(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -660,6 +660,36 @@ def test_onboarding_data_assistant_plot_include_and_exclude_column_names_raises_
 
 
 @pytest.mark.integration
+@pytest.mark.slow  # 1.67s
+def test_onboarding_data_assistant_plot_expectations_and_metrics_correctly_handle_empty_plot_data(
+    bobby_columnar_table_multi_batch_probabilistic_data_context: DataContext,
+) -> None:
+    context: DataContext = bobby_columnar_table_multi_batch_probabilistic_data_context
+
+    batch_request: dict = {
+        "datasource_name": "taxi_pandas",
+        "data_connector_name": "monthly",
+        "data_asset_name": "my_reports",
+    }
+
+    include_column_names: List[str] = [
+        "congestion_surcharge",
+    ]
+
+    data_assistant_result: DataAssistantResult = context.assistants.onboarding.run(
+        batch_request=batch_request,
+        include_column_names=include_column_names,
+    )
+    plot_result: PlotResult = data_assistant_result.plot_expectations_and_metrics(
+        include_column_names=include_column_names
+    )
+
+    # This test passes only if absense of any metrics and expectations to plot does not cause exceptions to be raised.
+    column_domain_charts: List[dict] = [p.to_dict() for p in plot_result.charts[2:]]
+    assert len(column_domain_charts) == 8
+
+
+@pytest.mark.integration
 @pytest.mark.slow  # 5.63s
 def test_onboarding_data_assistant_plot_custom_theme_overrides(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -659,6 +659,24 @@ def test_onboarding_data_assistant_plot_include_and_exclude_column_names_raises_
     assert "either use `include_column_names` or `exclude_column_names`" in str(e.value)
 
 
+@pytest.mark.unit
+def test_onboarding_data_assistant_result_plot_expectations_and_metrics_correctly_handle_empty_plot_data() -> (
+    None
+):
+    data_assistant_result: DataAssistantResult = OnboardingDataAssistantResult()
+
+    include_column_names: List[str] = [
+        "congestion_surcharge",
+    ]
+    plot_result: PlotResult = data_assistant_result.plot_expectations_and_metrics(
+        include_column_names=include_column_names
+    )
+
+    # This test passes only if absense of any metrics and expectations to plot does not cause exceptions to be raised.
+    column_domain_charts: List[dict] = [p.to_dict() for p in plot_result.charts[2:]]
+    assert len(column_domain_charts) == 0
+
+
 @pytest.mark.integration
 @pytest.mark.slow  # 1.67s
 def test_onboarding_data_assistant_plot_expectations_and_metrics_correctly_handle_empty_plot_data(


### PR DESCRIPTION
### Scope
* Currently, if there are no Metrics or Expectations are available to plot, `DataAssistantResult.plot_expectations_and_metrics()` raises an `Exception`.  The present change safeguards against this situation and includes a test.

### Remarks
* JIRA: https://greatexpectations.atlassian.net/browse/DX-600
* This fix becomes critical for future, narrow-theme-focused `DataAssistant` realizations.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!