### PR TITLE
[MAINTENANCE] Reference environment consistency - unpin python version

### DIFF
--- a/examples/reference_environments/README.md
+++ b/examples/reference_environments/README.md
@@ -74,5 +74,5 @@ Alternatively you can run `docker ps` to find the container name and then run `d
 
 ### What if I want to customize the reference environment?
 
-- You can customize the reference environment by editing the files in `great_expectations/examples/reference_environments/` related to the reference environment you are interested in. For example the `docker-compose.yml` file (if it exists for your environment) defines all the services that spin up when you start the environment.
+- You can customize the reference environment by editing the files in `great_expectations/examples/reference_environments/` related to the reference environment you are interested in. For example the `compose.yml` file (if it exists for your environment) defines all the services that spin up when you start the environment.
 - Look for documentation or comments in the reference environment for help on how it is used and how to customize it.

--- a/examples/reference_environments/abs/jupyter.Dockerfile
+++ b/examples/reference_environments/abs/jupyter.Dockerfile
@@ -6,3 +6,7 @@ COPY abs_example.ipynb ./
 COPY abs_example_abs_stores.ipynb ./
 
 RUN pip install great_expectations[azure]
+
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
+# or replace develop with the branch name you want to install from:
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/abs/jupyter.Dockerfile
+++ b/examples/reference_environments/abs/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 

--- a/examples/reference_environments/bigquery/jupyter.Dockerfile
+++ b/examples/reference_environments/bigquery/jupyter.Dockerfile
@@ -8,6 +8,6 @@ COPY ./bigquery_example.ipynb ./
 # This line can be changed to `RUN pip install great_expectations[bigquery]` once they are compatible.
 RUN pip install 'great_expectations[bigquery, sqlalchemy-less-than-2]'
 
-# Use this line to install GX from the develop branch,
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
 # or replace develop with the branch name you want to install from:
-RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/bigquery/jupyter.Dockerfile
+++ b/examples/reference_environments/bigquery/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 

--- a/examples/reference_environments/gcs/jupyter.Dockerfile
+++ b/examples/reference_environments/gcs/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 

--- a/examples/reference_environments/gcs/jupyter.Dockerfile
+++ b/examples/reference_environments/gcs/jupyter.Dockerfile
@@ -8,3 +8,7 @@ COPY gcs_public_nyc_tlc_bucket_gcs_stores_example.ipynb ./
 # packages that are installed as part of `bigquery/gcs` requirements are currently not compatible with sqlachemy 2.0.
 # This line can be changed to `RUN pip install great_expectations[bigquery]` once they are compatible.
 RUN pip install 'great_expectations[bigquery, sqlalchemy-less-than-2]'
+
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
+# or replace develop with the branch name you want to install from:
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/postgres/jupyter.Dockerfile
+++ b/examples/reference_environments/postgres/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 

--- a/examples/reference_environments/postgres/jupyter.Dockerfile
+++ b/examples/reference_environments/postgres/jupyter.Dockerfile
@@ -9,6 +9,6 @@ COPY ./postgres_example_postgres_stores.ipynb ./
 
 RUN pip install great_expectations[postgresql]
 
-# Use this line to install GX from the develop branch,
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
 # or replace develop with the branch name you want to install from:
-RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/s3/jupyter.Dockerfile
+++ b/examples/reference_environments/s3/jupyter.Dockerfile
@@ -6,3 +6,7 @@ COPY s3_public_nyc_tlc_bucket_example.ipynb ./
 COPY s3_public_nyc_tlc_bucket_s3_stores_example.ipynb ./
 
 RUN pip install great_expectations[s3]
+
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
+# or replace develop with the branch name you want to install from:
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/s3/jupyter.Dockerfile
+++ b/examples/reference_environments/s3/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 

--- a/examples/reference_environments/snowflake/jupyter.Dockerfile
+++ b/examples/reference_environments/snowflake/jupyter.Dockerfile
@@ -8,6 +8,6 @@ COPY ./snowflake_example.ipynb ./
 # This line can be changed to `RUN pip install great_expectations[snowflake]` once they are compatible.
 RUN pip install 'great_expectations[snowflake, sqlalchemy-less-than-2]'
 
-# Use this line to install GX from the develop branch,
+# Uncomment this line to install GX from the develop branch (requires a `--rebuild`),
 # or replace develop with the branch name you want to install from:
-RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop
+# RUN pip install git+https://github.com/great-expectations/great_expectations.git@develop

--- a/examples/reference_environments/snowflake/jupyter.Dockerfile
+++ b/examples/reference_environments/snowflake/jupyter.Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/minimal-notebook:python-3.10
+# To use a specific python version, replace the first line with the following,
+# where 3.10 is the version you want to use (requires a `--rebuild`):
+# FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook
 
 WORKDIR /gx
 


### PR DESCRIPTION
Instead of pinning python to 3.10, now that 3.11 is supported open the pin and add instructions for manually setting the python version.