### PR TITLE
[MAINTENANCE] Use data docs container for cloud blob stores

### DIFF
--- a/examples/reference_environments/abs/README.md
+++ b/examples/reference_environments/abs/README.md
@@ -1,6 +1,9 @@
 # Azure Blob Store Reference Environment
 
-This reference environment spins up one container which contains a jupyter notebook server and some example code.
+This reference environment spins up two containers:
+
+- A jupyter notebook server
+- A server to host data docs (to view navigate to http://127.0.0.1:3000/)
 
 The example code demonstrates how to use Great Expectations with data stored in Azure Blob Storage (ABS) and by default uses data in the ``
 that is hosted in the project defined by `AZURE_STORAGE_ACOUNT_URL` env variable.

--- a/examples/reference_environments/abs/abs_example.ipynb
+++ b/examples/reference_environments/abs/abs_example.ipynb
@@ -30,6 +30,30 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "datasource_name = \"pandas_abs_example\"\n",
     "azure_options = {\n",
     "    \"account_url\": \"${AZURE_STORAGE_ACCOUNT_URL}\",\n",

--- a/examples/reference_environments/abs/abs_example_abs_stores.ipynb
+++ b/examples/reference_environments/abs/abs_example_abs_stores.ipynb
@@ -128,6 +128,30 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "datasource_name = \"pandas_abs_example\"\n",
     "azure_options = {\n",
     "    \"account_url\": \"${AZURE_STORAGE_ACCOUNT_URL}\",\n",

--- a/examples/reference_environments/abs/compose.yaml
+++ b/examples/reference_environments/abs/compose.yaml
@@ -13,3 +13,27 @@ services:
       - ABS_METADATA_STORES_CONTAINER_NAME=${ABS_METADATA_STORES_CONTAINER_NAME}
     ports:
       - "8888:8888"
+    volumes:
+      - gx_stores:/gx/gx_stores
+    networks:
+      - dbnet
+
+  data_docs:
+    image: gx/abs_data_docs
+    container_name: gx_abs_data_docs
+    build:
+      context: .
+      dockerfile: data_docs.Dockerfile
+    networks:
+      - dbnet
+    ports:
+      - "3000:3000"
+    volumes:
+      - gx_stores:/gx/gx_stores:ro
+
+networks:
+  dbnet:
+    driver: bridge
+
+volumes:
+  gx_stores:

--- a/examples/reference_environments/abs/data_docs.Dockerfile
+++ b/examples/reference_environments/abs/data_docs.Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+# Create a non-root user to own the files and run our server
+RUN adduser static
+USER static
+WORKDIR /gx/gx_stores/data_docs/
+
+CMD ["python", "-m", "http.server", "3000"]

--- a/examples/reference_environments/bigquery/bigquery_example.ipynb
+++ b/examples/reference_environments/bigquery/bigquery_example.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Explicitly create data docs site to use filesystem store with known file location.\n",
-    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
     "\n",
     "context.add_data_docs_site(\n",
     "    site_config={\n",

--- a/examples/reference_environments/gcs/README.md
+++ b/examples/reference_environments/gcs/README.md
@@ -1,6 +1,9 @@
 # GCS Reference Environment
 
-This reference environment spins up one container which contains a jupyter notebook server and some example code.
+This reference environment spins up two containers:
+
+- A jupyter notebook server
+- A server to host data docs (to view navigate to http://127.0.0.1:3000/)
 
 The example code demonstrates how to use Great Expectations with data stored in Google Cloud Storage and by default uses data in the `taxi_reference_data`
 that is hosted in the project defined by `GCP_PROJECT_NAME` env variable. It also contains a notebook with a quickstart example that optionally uses a GCS bucket to store expectation suites, validation results and data docs (instead of storing them on the filesystem). To use this notebook, set the name of your bucket in the `GCS_METADATA_STORES_BUCKET_NAME` environment variable on your host machine, or modify the notebook (see instructions in the notebook).

--- a/examples/reference_environments/gcs/compose.yaml
+++ b/examples/reference_environments/gcs/compose.yaml
@@ -14,3 +14,26 @@ services:
       - "8888:8888"
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/creds.json
+      - gx_stores:/gx/gx_stores
+    networks:
+      - dbnet
+
+  data_docs:
+    image: gx/gcs_data_docs
+    container_name: gx_gcs_data_docs
+    build:
+      context: .
+      dockerfile: data_docs.Dockerfile
+    networks:
+      - dbnet
+    ports:
+      - "3000:3000"
+    volumes:
+      - gx_stores:/gx/gx_stores:ro
+
+networks:
+  dbnet:
+    driver: bridge
+
+volumes:
+  gx_stores:

--- a/examples/reference_environments/gcs/data_docs.Dockerfile
+++ b/examples/reference_environments/gcs/data_docs.Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+# Create a non-root user to own the files and run our server
+RUN adduser static
+USER static
+WORKDIR /gx/gx_stores/data_docs/
+
+CMD ["python", "-m", "http.server", "3000"]

--- a/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_example.ipynb
+++ b/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_example.ipynb
@@ -30,6 +30,30 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "datasource_name = \"pandas_gcs_example\"\n",
     "bucket_name = \"taxi_reference_data\"\n",
     "datasource = context.sources.add_pandas_gcs(\n",

--- a/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_gcs_stores_example.ipynb
+++ b/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_gcs_stores_example.ipynb
@@ -118,6 +118,30 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "datasource_name = \"pandas_gcs_example\"\n",
     "bucket_name_with_data_to_validate = \"taxi_reference_data\"\n",
     "datasource = context.sources.add_pandas_gcs(\n",

--- a/examples/reference_environments/postgres/postgres_example.ipynb
+++ b/examples/reference_environments/postgres/postgres_example.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# Explicitly create data docs site to use filesystem store with known file location.\n",
-    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
     "\n",
     "context.add_data_docs_site(\n",
     "    site_config={\n",

--- a/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
+++ b/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "# Explicitly create data docs site to use filesystem store with known file location.\n",
-    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
     "\n",
     "context.add_data_docs_site(\n",
     "    site_config={\n",

--- a/examples/reference_environments/s3/README.md
+++ b/examples/reference_environments/s3/README.md
@@ -1,6 +1,9 @@
 # S3 Reference Environment
 
-This reference environment spins up one container which contains a jupyter notebook server and some example code.
+This reference environment spins up two containers:
+
+- A jupyter notebook server
+- A server to host data docs (to view navigate to http://127.0.0.1:3000/)
 
 The example code demonstrates how to use Great Expectations with data stored in S3 and by default uses the `nyc-tlc` bucket that is hosted by Amazon Registry of Open Data on AWS: https://registry.opendata.aws/nyc-tlc-trip-records-pds/ It also contains a notebook with a quickstart example that optionally uses an s3 bucket to store expectation suites, validation results and data docs (instead of storing them on the filesystem). To use this notebook, set the name of your bucket in the `S3_METADATA_STORES_BUCKET_NAME` environment variable on your host machine, or modify the notebook (see instructions in the notebook)
 

--- a/examples/reference_environments/s3/compose.yaml
+++ b/examples/reference_environments/s3/compose.yaml
@@ -13,3 +13,27 @@ services:
       - S3_METADATA_STORES_BUCKET_NAME=${S3_METADATA_STORES_BUCKET_NAME}
     ports:
       - "8888:8888"
+    volumes:
+      - gx_stores:/gx/gx_stores
+    networks:
+      - dbnet
+
+  data_docs:
+    image: gx/s3_data_docs
+    container_name: gx_s3_data_docs
+    build:
+      context: .
+      dockerfile: data_docs.Dockerfile
+    networks:
+      - dbnet
+    ports:
+      - "3000:3000"
+    volumes:
+      - gx_stores:/gx/gx_stores:ro
+
+networks:
+  dbnet:
+    driver: bridge
+
+volumes:
+  gx_stores:

--- a/examples/reference_environments/s3/data_docs.Dockerfile
+++ b/examples/reference_environments/s3/data_docs.Dockerfile
@@ -1,0 +1,8 @@
+FROM python
+
+# Create a non-root user to own the files and run our server
+RUN adduser static
+USER static
+WORKDIR /gx/gx_stores/data_docs/
+
+CMD ["python", "-m", "http.server", "3000"]

--- a/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_example.ipynb
+++ b/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_example.ipynb
@@ -15,6 +15,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bb7e779c",
    "metadata": {},
    "outputs": [],

--- a/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_s3_stores_example.ipynb
+++ b/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_s3_stores_example.ipynb
@@ -102,6 +102,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Explicitly create data docs site to use filesystem store with known file location.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
+    "\n",
+    "context.add_data_docs_site(\n",
+    "    site_config={\n",
+    "        \"class_name\": \"SiteBuilder\",\n",
+    "        \"store_backend\": {\n",
+    "            \"class_name\": \"TupleFilesystemStoreBackend\",\n",
+    "            \"base_directory\": \"/gx/gx_stores/data_docs\",\n",
+    "        },\n",
+    "        \"site_index_builder\": {\"class_name\": \"DefaultSiteIndexBuilder\"},\n",
+    "    },\n",
+    "    site_name=\"local_site_for_hosting\",\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bb7e779c",
    "metadata": {},
    "outputs": [],

--- a/examples/reference_environments/snowflake/snowflake_example.ipynb
+++ b/examples/reference_environments/snowflake/snowflake_example.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "# Explicitly create data docs site to use filesystem store with known file location.\n",
-    "# This is done to simplify hosting data docs, the default is to write to a temp directory.\n",
+    "# This is done to simplify hosting data docs within the containers, the default is to write to a temp directory.\n",
     "\n",
     "context.add_data_docs_site(\n",
     "    site_config={\n",


### PR DESCRIPTION
Instead of only writing data docs to a cloud store, also write to local storage in a location that can be served via a different container. 
Also update comments in existing notebooks.