### PR TITLE
[MAINTENANCE] Reference Environments: Match the new quickstart

### DIFF
--- a/examples/reference_environments/abs/abs_example.ipynb
+++ b/examples/reference_environments/abs/abs_example.ipynb
@@ -180,9 +180,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/abs/abs_example_abs_stores.ipynb
+++ b/examples/reference_environments/abs/abs_example_abs_stores.ipynb
@@ -278,9 +278,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_example.ipynb
+++ b/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_example.ipynb
@@ -164,9 +164,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_gcs_stores_example.ipynb
+++ b/examples/reference_environments/gcs/gcs_public_nyc_tlc_bucket_gcs_stores_example.ipynb
@@ -252,9 +252,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/postgres/postgres_example.ipynb
+++ b/examples/reference_environments/postgres/postgres_example.ipynb
@@ -147,9 +147,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
+++ b/examples/reference_environments/postgres/postgres_example_postgres_stores.ipynb
@@ -183,9 +183,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_example.ipynb
+++ b/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_example.ipynb
@@ -167,9 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]

--- a/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_s3_stores_example.ipynb
+++ b/examples/reference_environments/s3/s3_public_nyc_tlc_bucket_s3_stores_example.ipynb
@@ -256,9 +256,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = gx.checkpoint.SimpleCheckpoint(\n",
+    "checkpoint = context.add_or_update_checkpoint(\n",
     "    name=\"my_quickstart_checkpoint\",\n",
-    "    data_context=context,\n",
     "    validator=validator,\n",
     ")"
    ]


### PR DESCRIPTION
Match the new quickstart `add_or_update_checkpoint` method use in all sample code for reference environments.