### PR TITLE
[MAINTENANCE] Filter `jsonschema.RefResolver`, `ErrorTree` warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -519,6 +519,13 @@ filterwarnings = [
     # Example Actual Warning:
     # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
     "ignore: Exception ignored in:UserWarning",
+    # jsonschema (altair dependency)
+    # Example Actual Warning:
+    # DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the
+    # https://github.com/python-jsonschema/referencing library,
+    # which provides more compliant referencing behavior as well as more flexible APIs for customization.
+    # A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
+    "ignore: jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning"
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -525,7 +525,10 @@ filterwarnings = [
     # https://github.com/python-jsonschema/referencing library,
     # which provides more compliant referencing behavior as well as more flexible APIs for customization.
     # A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
-    "ignore: jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning"
+    "ignore: jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning",
+    # Example Actual Warning:
+    # DeprecationWarning: Importing ErrorTree directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.
+    "ignore: Importing ErrorTree directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.:DeprecationWarning"
 
     # --------------------------------------- TEMPORARY IGNORES --------------------------------------------------------
 ]


### PR DESCRIPTION
Followup to #8244 

Filter `jsonschema.RefResolver` warnings from all tests.
Filter `ErrorTree` import warnings from all tests.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
