### PR TITLE
[MAINTENANCE] Update `test_deprecation.py` in advance of 0.17.3 release

### DIFF
--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -24,7 +24,7 @@ def files_with_deprecation_warnings() -> List[str]:
         "great_expectations/compatibility/pyspark.py",
         "great_expectations/compatibility/sqlalchemy_and_pandas.py",
         "great_expectations/compatibility/sqlalchemy_compatibility_wrappers.py",
-        "great_expectations/rule_based_profiler/altair/encodings.py",
+        "great_expectations/rule_based_profiler/altair/encodings.py",  # ignoring because of imprecise matching logic
     ]
     for file_to_exclude in files_to_exclude:
         if file_to_exclude in files:

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -20,10 +20,11 @@ def regex_for_deprecation_comments() -> Pattern:
 def files_with_deprecation_warnings() -> List[str]:
     files: List[str] = glob.glob("great_expectations/**/*.py", recursive=True)
     files_to_exclude = [
-        "great_expectations/compatibility/sqlalchemy_compatibility_wrappers.py",
-        "great_expectations/compatibility/sqlalchemy_and_pandas.py",
         "great_expectations/compatibility/google.py",
         "great_expectations/compatibility/pyspark.py",
+        "great_expectations/compatibility/sqlalchemy_and_pandas.py",
+        "great_expectations/compatibility/sqlalchemy_compatibility_wrappers.py",
+        "great_expectations/rule_based_profiler/altair/encodings.py",
     ]
     for file_to_exclude in files_to_exclude:
         if file_to_exclude in files:


### PR DESCRIPTION
The logic in this test is a bit iffy - it uses a simple match for "DeprecationWarning" without taking into account the fact that it may be a comment.

I've just decided to ignore this file until we can come back to this test to clean it up.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
