### PR TITLE
[MAINTENANCE] Protect `develop` with `no-commit-to-branch` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
         exclude: docs/.*|tests/.*.fixture
       - id: requirements-txt-fixer
         exclude: docs/.*
+      - id: no-commit-to-branch
+        args: [--branch, develop, --branch, main]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:


### PR DESCRIPTION
This PR adds another pre-commit hook that prevents local commits if the current branch is called `develop` or `main`.
This indirectly prevents accidentally pushing changes to develop for users who have push privileges against these branches.

https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch

![image](https://github.com/great-expectations/great_expectations/assets/13108583/4983199c-424a-45ce-9152-c4e777f7a415)


Reminder: pre-commit hooks, are opt-in. No user workflows will be impacted if they haven't run`pre-commit install`.


-------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
