### PR TITLE
[MAINTENANCE] Rename `cloud` marker to `gx_cloud` for clarity in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -533,7 +533,7 @@ filterwarnings = [
 ]
 junit_family="xunit2"
 markers = [
-    "cloud: mark test as being relevant to Great Expectations Cloud.",
+    "gx_cloud: mark test as being relevant to Great Expectations Cloud.",
     "docs: mark a test as a docs test.",
     "e2e: mark test as an E2E test.",
     "external_sqldialect: mark test as requiring install of an external sql dialect.",

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -649,7 +649,7 @@ def test_api_action_run(
 #
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_sns_notification_action(
     sns,
     validation_result_suite,

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -4712,7 +4712,7 @@ def fake_cloud_context_with_slack(_fake_cloud_context_setup, monkeypatch):
 
 
 @pytest.mark.integration
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_use_validation_url_from_cloud(fake_cloud_context_basic):
     context = fake_cloud_context_basic
     checkpoint_name = "my_checkpoint"
@@ -4726,7 +4726,7 @@ def test_use_validation_url_from_cloud(fake_cloud_context_basic):
 
 
 @pytest.mark.integration
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_use_validation_url_from_cloud_with_slack(fake_cloud_context_with_slack):
     context, slack_counter = fake_cloud_context_with_slack
     checkpoint_name = "my_checkpoint"

--- a/tests/cli/test_toolkit.py
+++ b/tests/cli/test_toolkit.py
@@ -306,46 +306,46 @@ def test_parse_cli_config_file_location_windows_paths(tmp_path_factory):
     # We are unable to create files with windows paths on our unix test CI
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_local_posix():
     assert not is_cloud_file_url("bucket/files/ ")
     assert not is_cloud_file_url("./bucket/files/ ")
     assert not is_cloud_file_url("/full/path/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_file_url():
     assert not is_cloud_file_url("file://bucket/files/ ")
     assert not is_cloud_file_url("file://./bucket/files/ ")
     assert not is_cloud_file_url("file:///full/path/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_ftp_url():
     assert is_cloud_file_url("ftp://bucket/files/ ")
     assert is_cloud_file_url("ftp://./bucket/files/ ")
     assert is_cloud_file_url("ftp:///full/path/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_s3():
     assert is_cloud_file_url("s3://bucket/files/")
     assert is_cloud_file_url(" s3://bucket/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_google_storage():
     assert is_cloud_file_url("gs://bucket/files/")
     assert is_cloud_file_url(" gs://bucket/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_azure_storage():
     assert is_cloud_file_url("wasb://bucket/files/")
     assert is_cloud_file_url(" wasb://bucket/files/ ")
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_is_cloud_file_path_http_url():
     assert is_cloud_file_url("http://bucket/files/")
     assert is_cloud_file_url(" http://bucket/files/ ")

--- a/tests/core/test_config_provider.py
+++ b/tests/core/test_config_provider.py
@@ -13,7 +13,7 @@ access_token = "1009d2fe-54b3-43b8-8297-ba2d517f9752"
 organization_id = "0dcf5ce1-806f-4199-9e69-e24dfba5e62a"
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "cloud_config,expected_values",

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -317,7 +317,7 @@ def test_find_expectation_indexes(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_find_expectation_indexes_with_ge_cloud_suite(ge_cloud_suite, ge_cloud_id):
     # All expectations in `ge_cloud_suite` have our desired id
     res = ge_cloud_suite.find_expectation_indexes(ge_cloud_id=ge_cloud_id)
@@ -328,7 +328,7 @@ def test_find_expectation_indexes_with_ge_cloud_suite(ge_cloud_suite, ge_cloud_i
     assert res == []
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_find_expectation_indexes_without_necessary_args(ge_cloud_suite):
     with pytest.raises(TypeError) as err:
         ge_cloud_suite.find_expectation_indexes(
@@ -339,7 +339,7 @@ def test_find_expectation_indexes_without_necessary_args(ge_cloud_suite):
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_find_expectation_indexes_with_invalid_config_raises_error(ge_cloud_suite):
     with pytest.raises(InvalidExpectationConfigurationError) as err:
         ge_cloud_suite.find_expectation_indexes(
@@ -377,7 +377,7 @@ def test_find_expectations(exp2, exp3, exp4, exp5, domain_success_runtime_suite)
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_find_expectations_without_necessary_args(ge_cloud_suite):
     with pytest.raises(TypeError) as err:
         ge_cloud_suite.find_expectations(
@@ -604,7 +604,7 @@ def test_add_expectation(
     ]
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -674,7 +674,7 @@ def test_remove_all_expectations_of_type(
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_replace_expectation_replaces_expectation(ge_cloud_suite, ge_cloud_id, exp1):
     # The state of the first expectation before update
     expectation_before_update = ge_cloud_suite.expectations[0]
@@ -702,7 +702,7 @@ def test_replace_expectation_replaces_expectation(ge_cloud_suite, ge_cloud_id, e
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_replace_expectation_without_necessary_args(ge_cloud_suite):
     with pytest.raises(TypeError) as err:
         ge_cloud_suite.replace_expectation(
@@ -716,7 +716,7 @@ def test_replace_expectation_without_necessary_args(ge_cloud_suite):
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_replace_expectation_finds_too_many_matches(ge_cloud_suite, ge_cloud_id):
     new_expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -735,7 +735,7 @@ def test_replace_expectation_finds_too_many_matches(ge_cloud_suite, ge_cloud_id)
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_replace_expectation_finds_no_matches(ge_cloud_suite, ge_cloud_id, exp4):
     with pytest.raises(ValueError) as err:
         ge_cloud_suite.replace_expectation(

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -188,7 +188,7 @@ def mocked_get_by_name_response_0_results(
     return _mocked_get_by_name_response
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_get_checkpoint_by_name(
     empty_cloud_data_context: CloudDataContext,
@@ -230,7 +230,7 @@ def test_cloud_backed_data_context_get_checkpoint_by_name(
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_get_checkpoint_no_identifier_raises_error(
     empty_cloud_data_context: CloudDataContext,
@@ -241,7 +241,7 @@ def test_get_checkpoint_no_identifier_raises_error(
         context.get_checkpoint()
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_add_checkpoint(
     empty_cloud_data_context: CloudDataContext,
@@ -299,7 +299,7 @@ def test_cloud_backed_data_context_add_checkpoint(
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
     empty_cloud_data_context: CloudDataContext,
@@ -356,7 +356,7 @@ def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
     assert checkpoint.ge_cloud_id == checkpoint_id
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_adds(
     empty_cloud_data_context: CloudDataContext,
@@ -414,7 +414,7 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds(
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
@@ -472,7 +472,7 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_pre
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_present(
     empty_cloud_data_context: CloudDataContext,
@@ -533,7 +533,7 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_pres
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
@@ -591,7 +591,7 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_not_
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_update_checkpoint_updates_when_id_present(
     empty_cloud_data_context: CloudDataContext,
@@ -660,7 +660,7 @@ def test_cloud_backed_data_context_update_checkpoint_updates_when_id_present(
     assert checkpoint.validations[1]["id"] == validation_id_2
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_update_non_existent_checkpoint_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
@@ -692,7 +692,7 @@ def test_cloud_backed_data_context_update_non_existent_checkpoint_when_id_not_pr
             )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_update_checkpoint_updates_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
@@ -762,7 +762,7 @@ def test_cloud_backed_data_context_update_checkpoint_updates_when_id_not_present
     strict=True,
 )
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_cloud_backed_data_context_add_checkpoint_e2e(
     mock_save_project_config: mock.MagicMock,
@@ -784,7 +784,7 @@ def test_cloud_backed_data_context_add_checkpoint_e2e(
 
 
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_data_context_run_checkpoint_e2e():
     """
     What does this test do and why?
@@ -975,7 +975,7 @@ def mock_get_all_checkpoints_json(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_list_checkpoints(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,

--- a/tests/data_context/cloud_data_context/test_data_docs_api.py
+++ b/tests/data_context/cloud_data_context/test_data_docs_api.py
@@ -9,7 +9,7 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 
 
 @pytest.mark.integration
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_view_validation_result(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_result: CheckpointResult,

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -22,7 +22,7 @@ from great_expectations.datasource.new_datasource import Datasource
 from tests.data_context.conftest import MockResponse
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "save_changes",
@@ -155,7 +155,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
         assert stored_data_connector.name == data_connector_name
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "config_includes_name_setting",
@@ -270,7 +270,7 @@ def test_data_context_in_cloud_mode_add_datasource(
         assert stored_data_connector.name == data_connector_name
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "config_includes_name_setting",
@@ -389,7 +389,7 @@ def test_cloud_data_context_add_datasource(
 
 
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_datasource_crud_e2e() -> None:
     context = cast(CloudDataContext, gx.get_context(cloud_mode=True))
     datasource_name = f"OSSTestDatasource_{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))}"

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -254,7 +254,7 @@ def mock_expectations_store_has_key() -> mock.MagicMock:
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_list_expectation_suites(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -294,7 +294,7 @@ def test_list_expectation_suites(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_create_expectation_suite_saves_suite_to_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mocked_post_response: Callable[[], MockResponse],
@@ -315,7 +315,7 @@ def test_create_expectation_suite_saves_suite_to_cloud(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_create_expectation_suite_overwrites_existing_suite(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_list_expectation_suite_names: mock.MagicMock,
@@ -347,7 +347,7 @@ def test_create_expectation_suite_overwrites_existing_suite(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_create_expectation_suite_namespace_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_list_expectation_suite_names: mock.MagicMock,
@@ -365,7 +365,7 @@ def test_create_expectation_suite_namespace_collision_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_delete_expectation_suite_by_id_deletes_suite_in_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -386,7 +386,7 @@ def test_delete_expectation_suite_by_id_deletes_suite_in_cloud(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_delete_expectation_suite_by_name_deletes_suite_in_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -406,7 +406,7 @@ def test_delete_expectation_suite_by_name_deletes_suite_in_cloud(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_delete_expectation_suite_nonexistent_suite_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -423,7 +423,7 @@ def test_delete_expectation_suite_nonexistent_suite_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_get_expectation_suite_by_name_retrieves_suite_from_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -448,7 +448,7 @@ def test_get_expectation_suite_by_name_retrieves_suite_from_cloud(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_get_expectation_suite_nonexistent_suite_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext, mocked_404_response
 ) -> None:
@@ -466,7 +466,7 @@ def test_get_expectation_suite_nonexistent_suite_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_get_expectation_suite_no_identifier_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
 ) -> None:
@@ -477,7 +477,7 @@ def test_get_expectation_suite_no_identifier_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_save_expectation_suite_saves_suite_to_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mocked_post_response: Callable[[], MockResponse],
@@ -499,7 +499,7 @@ def test_save_expectation_suite_saves_suite_to_cloud(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_save_expectation_suite_overwrites_existing_suite(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -535,7 +535,7 @@ def test_save_expectation_suite_overwrites_existing_suite(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_expectations_store_has_key: mock.MagicMock,
@@ -560,7 +560,7 @@ def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
@@ -591,7 +591,7 @@ def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_add_or_update_expectation_suite_adds_new_obj(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
 ):
@@ -617,7 +617,7 @@ def test_add_or_update_expectation_suite_adds_new_obj(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_add_expectation_suite_without_name_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
 ):
@@ -628,7 +628,7 @@ def test_add_expectation_suite_without_name_raises_error(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_expectation_suite_gx_cloud_identifier_requires_id_or_resource_name(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
 ):
@@ -641,7 +641,7 @@ def test_expectation_suite_gx_cloud_identifier_requires_id_or_resource_name(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_add_or_update_expectation_suite_updates_existing_obj(
     empty_base_data_context_in_cloud_mode: CloudDataContext, mocked_get_by_name_response
 ):

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -18,7 +18,7 @@ from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @responses.activate
 def test_cloud_backed_data_context_add_or_update_expectation_suite_include_rendered_content(
     empty_cloud_data_context: CloudDataContext,
@@ -96,7 +96,7 @@ def test_cloud_backed_data_context_add_or_update_expectation_suite_include_rende
         }
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_cloud_backed_data_context_expectation_validation_result_include_rendered_content(
     empty_cloud_data_context: CloudDataContext,

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -96,7 +96,7 @@ def mocked_post_response(
     return _mocked_post_response
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
@@ -147,7 +147,7 @@ def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
     assert return_profiler.ge_cloud_id == profiler_with_id.ge_cloud_id
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
@@ -201,7 +201,7 @@ def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
 
 
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 @pytest.mark.xfail(
     strict=False,
@@ -336,7 +336,7 @@ def mock_get_all_profilers_json(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_list_profilers(
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -122,7 +122,7 @@ def assert_stdout_is_accurate_and_properly_ordered(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test__send_configuration_bundle_sends_valid_http_request(
     serialized_configuration_bundle: dict,
     migrator_with_mock_context: CloudMigrator,
@@ -151,7 +151,7 @@ def test__send_configuration_bundle_sends_valid_http_request(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test__send_validation_results_sends_valid_http_request(
     migrator_with_mock_context: CloudMigrator,
     ge_cloud_base_url: str,
@@ -192,7 +192,7 @@ def test__send_validation_results_sends_valid_http_request(
     assert mock_post.call_count == 5
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 class TestUsageStats:
     def test_migrate_successful_event(
@@ -243,7 +243,7 @@ class TestUsageStats:
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize("test_migrate", [True, False])
 @pytest.mark.parametrize("include_datasources", [True, False])
 @pytest.mark.parametrize("enable_usage_stats", [True, False])
@@ -297,7 +297,7 @@ def test__migrate_to_cloud_outputs_warnings(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "test_migrate,expected_statements",
     [
@@ -359,7 +359,7 @@ def test__migrate_to_cloud_happy_path_prints_to_stdout(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test__migrate_to_cloud_bad_bundle_request_prints_to_stdout(
     migrator_with_stub_base_data_context: CloudMigrator,
     capsys,
@@ -401,7 +401,7 @@ def test__migrate_to_cloud_bad_bundle_request_prints_to_stdout(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test__migrate_to_cloud_bad_validations_request_prints_to_stdout(
     migrator_with_stub_base_data_context: CloudMigrator,
     capsys,

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -10,7 +10,7 @@ from great_expectations.data_context.migrator.configuration_bundle import (
 from tests.data_context.migrator.conftest import StubBaseDataContext
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 class TestConfigurationBundleCreate:
     def test_configuration_bundle_created(
@@ -68,7 +68,7 @@ class TestConfigurationBundleCreate:
         assert not config_bundle.is_usage_stats_enabled()
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 class TestConfigurationBundleSerialization:
     def test_configuration_bundle_serialization_all_fields(

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -286,7 +286,7 @@ store_backend:
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
     store = CheckpointStore(store_name="checkpoint_store")
 
@@ -381,7 +381,7 @@ def test_list_checkpoints(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_list_checkpoints_cloud_mode(
     checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock]
 ) -> None:
@@ -408,7 +408,7 @@ def test_delete_checkpoint(
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_delete_checkpoint_with_cloud_id(
     checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock]

--- a/tests/data_context/store/test_data_context_store.py
+++ b/tests/data_context/store/test_data_context_store.py
@@ -17,7 +17,7 @@ def test_serialize(basic_data_context_config: DataContextConfig):
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_serialize_cloud_mode(basic_data_context_config: DataContextConfig):
     store = DataContextStore(store_name="data_context_store")
 

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -15,7 +15,7 @@ from great_expectations.exceptions import StoreBackendError
 from tests.data_context.conftest import MockResponse
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_datasource_store_set(
     ge_cloud_base_url: str,
@@ -73,7 +73,7 @@ def test_datasource_store_set(
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_datasource_store_get_by_id(
     ge_cloud_base_url: str,
@@ -113,7 +113,7 @@ def test_datasource_store_get_by_id(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_datasource_store_get_by_name(
     ge_cloud_base_url: str,
@@ -159,7 +159,7 @@ def test_datasource_store_get_by_name(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_datasource_store_delete_by_id(
     ge_cloud_base_url: str,

--- a/tests/data_context/store/test_evaluation_parameter_store.py
+++ b/tests/data_context/store/test_evaluation_parameter_store.py
@@ -273,7 +273,7 @@ def test_database_evaluation_parameter_store_get_bind_params(param_store):
 @mock.patch(
     "great_expectations.data_context.store.tuple_store_backend.TupleStoreBackend.list_keys"
 )
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.integration
 def test_evaluation_parameter_store_calls_proper_cloud_tuple_store_methods(
     mock_parent_list_keys,

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -240,7 +240,7 @@ store_backend:
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
     store = ExpectationsStore(store_name="expectations_store")
 

--- a/tests/data_context/store/test_ge_cloud_store_backend.py
+++ b/tests/data_context/store/test_ge_cloud_store_backend.py
@@ -12,7 +12,7 @@ from great_expectations.data_context.store.gx_cloud_store_backend import (
 )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_ge_cloud_store_backend_is_alias_of_gx_cloud_store_backend(
     ge_cloud_access_token: str,
@@ -32,7 +32,7 @@ def test_ge_cloud_store_backend_is_alias_of_gx_cloud_store_backend(
     assert isinstance(backend, GXCloudStoreBackend)
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "key",

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -71,7 +71,7 @@ def construct_ge_cloud_store_backend(
     ],
 )
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_construct_url(
     base_url: str,
     organization_id: str,
@@ -185,7 +185,7 @@ def test_construct_url(
     ],
 )
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_construct_json_payload(
     resource_type: str,
     organization_id: str,
@@ -206,7 +206,7 @@ def test_construct_json_payload(
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_set(
     construct_ge_cloud_store_backend: Callable[
@@ -263,7 +263,7 @@ def test_set(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_list_keys(
     construct_ge_cloud_store_backend: Callable[
@@ -280,7 +280,7 @@ def test_list_keys(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_remove_key_with_only_id(
     construct_ge_cloud_store_backend: Callable[
@@ -314,7 +314,7 @@ def test_remove_key_with_only_id(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_remove_key_with_id_and_name(
     construct_ge_cloud_store_backend: Callable[
@@ -345,7 +345,7 @@ def test_remove_key_with_id_and_name(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_remove_key_with_only_name(
     construct_ge_cloud_store_backend: Callable[
@@ -366,7 +366,7 @@ def test_remove_key_with_only_name(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_appropriate_casting_of_str_resource_type_to_GXCloudRESTResource(
     construct_ge_cloud_store_backend: Callable[
@@ -393,7 +393,7 @@ def test_appropriate_casting_of_str_resource_type_to_GXCloudRESTResource(
         ),
     ],
 )
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_allowed_set_kwargs(
     resource_type: GXCloudRESTResource,
@@ -433,7 +433,7 @@ def test_allowed_set_kwargs(
         ),
     ],
 )
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_validate_set_kwargs(
     kwargs: dict,
@@ -448,7 +448,7 @@ def test_validate_set_kwargs(
     assert store_backend.validate_set_kwargs(kwargs) == expected
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_config_property_and_defaults(
     construct_ge_cloud_store_backend: Callable[

--- a/tests/data_context/store/test_profiler_store.py
+++ b/tests/data_context/store/test_profiler_store.py
@@ -105,7 +105,7 @@ def test_profiler_store_integration(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_ge_cloud_response_json_to_object_dict(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ) -> None:

--- a/tests/data_context/store/test_validations_store.py
+++ b/tests/data_context/store/test_validations_store.py
@@ -355,7 +355,7 @@ store_backend:
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
     store = ValidationsStore(store_name="validations_store")
 

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -259,7 +259,7 @@ def prepare_validator_for_cloud_e2e() -> (
     strict=True,
 )
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_cloud_backend(
     mock_save_project_config: mock.MagicMock,
@@ -295,7 +295,7 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
     strict=True,
 )
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_validator_e2e_workflow_with_cloud_enabled_context(
     mock_save_project_config: mock.MagicMock,

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -52,7 +52,7 @@ def pandas_enabled_datasource_config() -> dict:
 
 
 @pytest.mark.integration
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_data_context_instantiates_gx_cloud_store_backend_with_cloud_config(
     tmp_path: pathlib,
     data_context_config_with_datasources: DataContextConfig,
@@ -193,7 +193,7 @@ def test_get_datasource_cache_miss(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_DataContext_add_datasource_updates_cache_and_store(
     cloud_data_context_in_cloud_mode_with_datasource_pandas_engine: DataContext,
     datasource_config_with_names: DatasourceConfig,
@@ -226,7 +226,7 @@ def test_DataContext_add_datasource_updates_cache_and_store(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_DataContext_update_datasource_updates_existing_value_in_cache_and_store(
     cloud_data_context_in_cloud_mode_with_datasource_pandas_engine: DataContext,
     pandas_enabled_datasource_config: dict,
@@ -268,7 +268,7 @@ def test_DataContext_update_datasource_updates_existing_value_in_cache_and_store
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_DataContext_update_datasource_creates_new_value_in_cache_and_store(
     cloud_data_context_in_cloud_mode_with_datasource_pandas_engine: DataContext,
     pandas_enabled_datasource_config: dict,
@@ -300,7 +300,7 @@ def test_DataContext_update_datasource_creates_new_value_in_cache_and_store(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_DataContext_delete_datasource_updates_cache(
     cloud_data_context_in_cloud_mode_with_datasource_pandas_engine: DataContext,
 ) -> None:

--- a/tests/data_context/test_data_context_deprecation.py
+++ b/tests/data_context/test_data_context_deprecation.py
@@ -40,7 +40,7 @@ ge_cloud_config = GXCloudConfig(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "cloud_args,expected_resolved_args",
     [
@@ -74,7 +74,7 @@ def test_BaseDataContext_resolve_cloud_args(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "cloud_args,expected_resolved_args",
     [
@@ -122,7 +122,7 @@ def test_DataContext_resolve_cloud_args(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "cloud_args,expected_resolved_args",
     [
@@ -166,7 +166,7 @@ def test_CloudDataContext_resolve_cloud_args(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "cloud_args,expected_resolved_args",
     [
@@ -247,7 +247,7 @@ def test_get_context_resolve_cloud_args(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.parametrize(
     "id, ge_cloud_id, expected",
     [
@@ -266,7 +266,7 @@ def test_data_context__resolve_id_and_ge_cloud_id_success(
 
 
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_data_context__resolve_id_and_ge_cloud_id_failure():
     id = "abc123"
     ge_cloud_id = "def456"

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -12,7 +12,7 @@ from great_expectations.exceptions.exceptions import GXCloudConfigurationError
 from great_expectations.util import get_context
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_data_context_ge_cloud_mode_with_incomplete_cloud_config_should_throw_error():
     # Don't want to make a real request in a unit test so we simply patch the config fixture
@@ -26,7 +26,7 @@ def test_data_context_ge_cloud_mode_with_incomplete_cloud_config_should_throw_er
 
 @responses.activate
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_data_context_ge_cloud_mode_makes_successful_request_to_cloud_api(
     request_headers: dict,
     ge_cloud_runtime_base_url,
@@ -59,7 +59,7 @@ def test_data_context_ge_cloud_mode_makes_successful_request_to_cloud_api(
 
 @responses.activate
 @pytest.mark.unit
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch("requests.Session.get")
 def test_data_context_ge_cloud_mode_with_bad_request_to_cloud_api_should_throw_error(
     mock_request,
@@ -80,7 +80,7 @@ def test_data_context_ge_cloud_mode_with_bad_request_to_cloud_api_should_throw_e
 
 
 @responses.activate
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 @mock.patch("requests.Session.get")
 def test_data_context_in_cloud_mode_passes_base_url_to_store_backend(

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -318,7 +318,7 @@ def test_sanitize_config_doesnt_change_config_without_datasources(
     assert config_without_creds == basic_data_context_config_dict
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_sanitize_config_masks_cloud_store_backend_access_tokens(
     data_context_config_dict_with_cloud_backed_stores, ge_cloud_access_token
 ):
@@ -457,7 +457,7 @@ def test_sanitize_config_regardless_of_parent_key():
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_sanitize_config_masks_cloud_access_token(ge_cloud_access_token):
     # expect the access token to be found and masked
     config = {

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -586,7 +586,7 @@ def test_file_data_context_variables_e2e(
 
 
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     cloud_data_context: CloudDataContext,
     data_context_config: DataContextConfig,
@@ -604,7 +604,7 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
 
 
 @pytest.mark.e2e
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @mock.patch(
     "great_expectations.data_context.data_context.serializable_data_context.SerializableDataContext._save_project_config"
 )

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -145,7 +145,7 @@ def test_base_context_invalid_root_dir(clear_env_vars, tmp_path):
 
 
 @pytest.mark.parametrize("ge_cloud_mode", [True, None])
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_env(
     set_up_cloud_envs, empty_ge_cloud_data_context_config, ge_cloud_mode
 ):
@@ -160,7 +160,7 @@ def test_cloud_context_env(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -169,7 +169,7 @@ def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
         assert isinstance(gx.get_context(cloud_mode=False), FileDataContext)
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_missing_env_throws_exception(
     clear_env_vars, empty_ge_cloud_data_context_config
 ):
@@ -178,7 +178,7 @@ def test_cloud_missing_env_throws_exception(
 
 
 @pytest.mark.parametrize("params", [GX_CLOUD_PARAMS_REQUIRED, GX_CLOUD_PARAMS_ALL])
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_params(monkeypatch, empty_ge_cloud_data_context_config, params):
     with mock.patch.object(
         CloudDataContext,
@@ -191,7 +191,7 @@ def test_cloud_context_params(monkeypatch, empty_ge_cloud_data_context_config, p
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_with_in_memory_config_overrides(
     monkeypatch, empty_ge_cloud_data_context_config
 ):
@@ -246,7 +246,7 @@ def test_get_context_with_no_arguments_returns_ephemeral_with_sensible_defaults(
 
 
 @pytest.mark.parametrize("ge_cloud_mode", [True, None])
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_include_rendered_content(
     set_up_cloud_envs, empty_ge_cloud_data_context_config, ge_cloud_mode
 ):

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -52,7 +52,7 @@ def taxi_data_samples_dir() -> pathlib.Path:
     ).resolve(strict=True)
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_add_fluent_datasource_are_persisted(
     cloud_api_fake: RequestsMock,
     empty_cloud_context_fluent: CloudDataContext,
@@ -96,7 +96,7 @@ def test_add_fluent_datasource_are_persisted_without_duplicates(
     assert datasource_name not in yaml_dict["datasources"]
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_splitters_are_persisted_on_creation(
     empty_cloud_context_fluent: CloudDataContext,
     cloud_api_fake_db: FakeDBTypedDict,
@@ -152,7 +152,7 @@ def test_assets_are_persisted_on_creation_and_removed_on_deletion(
     assert asset_name not in fds_after_delete[datasource_name].get("assets", {})
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_context_add_or_update_datasource(
     cloud_api_fake: RequestsMock,
     empty_contexts: CloudDataContext | FileDataContext,
@@ -193,7 +193,7 @@ def test_context_add_or_update_datasource(
     )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_add_or_update_datasource_kw_vs_positional(
     cloud_api_fake: RequestsMock,
     empty_cloud_context_fluent: CloudDataContext,
@@ -218,7 +218,7 @@ def test_cloud_add_or_update_datasource_kw_vs_positional(
     assert datasource1 == datasource2 == datasource3
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_context_add_and_then_update_datasource(
     cloud_api_fake: RequestsMock,
     empty_contexts: CloudDataContext | FileDataContext,
@@ -245,7 +245,7 @@ def test_context_add_and_then_update_datasource(
     assert datasource2 == datasource3
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_update_non_existant_datasource(
     cloud_api_fake: RequestsMock,
     empty_contexts: CloudDataContext | FileDataContext,
@@ -259,7 +259,7 @@ def test_update_non_existant_datasource(
         )
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 def test_cloud_context_delete_datasource(
     cloud_api_fake: RequestsMock,
     empty_cloud_context_fluent: CloudDataContext,
@@ -327,7 +327,7 @@ def verify_asset_names_mock(cloud_api_fake: RequestsMock, cloud_details: CloudDe
     return cloud_api_fake
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 class TestPandasDefaultWithCloud:
     def test_payload_sent_to_cloud(
         self,

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1187,7 +1187,7 @@ def test_add_profiler(
     mock_data_context.profiler_store.add.asset_called_once()
 
 
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_add_profiler_ge_cloud_mode(
     ge_cloud_profiler_id: str,
@@ -1355,7 +1355,7 @@ def test_list_profilers(mock_profiler_store: mock.MagicMock):
 
 
 @mock.patch("great_expectations.data_context.store.ProfilerStore")
-@pytest.mark.cloud
+@pytest.mark.gx_cloud
 @pytest.mark.unit
 def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):
     store = mock_profiler_store()


### PR DESCRIPTION
* As discussed in our kick off meeting, rename the `cloud` pytest marker to `gx_cloud` for clarity. 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
