### PR TITLE
[MAINTENANCE] Run GH Action CI job every 3 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache-dependency-path: |
-            constraints-dev.txt
+            reqs/requirements-dev-test.txt
             setup.py
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on:
   pull_request:
+  schedule:
+    # https://crontab.guru/every-3-hours
+    - cron: "0 */3 * * *"
 
 jobs:
   static-analysis:


### PR DESCRIPTION
Schedule the CI job to run on the default branch every 3 hours.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
https://crontab.guru/every-3-hours

This may catch things like breaking tests due to an upstream dependency change, or failures that were missed because of a force merge.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
