### PR TITLE
[MAINTENANCE] Add tests for Batch slicing for SparkFilePathDatasource

### DIFF
--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -182,6 +182,11 @@ class _FilePathDataAsset(DataAsset):
         Returns:
             A BatchRequest object that can be used to obtain a batch list from a Datasource by calling the
             get_batch_list_from_batch_request method.
+
+        Note:
+            Option "batch_slice" is supported for all DataAsset extensions of this class "_FilePathDataAsset(DataAsset)"
+            identically under "Datasource" types for any "ExecutionEngine" that is capable of loading data from files on
+            local or cloud/remote/networked filesystems (e.g., currently Pandas and Spark.  Same mechanism serves all.
         """
         if options:
             for option, value in options.items():

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -184,9 +184,9 @@ class _FilePathDataAsset(DataAsset):
             get_batch_list_from_batch_request method.
 
         Note:
-            Option "batch_slice" is supported for all DataAsset extensions of this class "_FilePathDataAsset(DataAsset)"
-            identically under "Datasource" types for any "ExecutionEngine" that is capable of loading data from files on
-            local or cloud/remote/networked filesystems (e.g., currently Pandas and Spark.  Same mechanism serves all.
+            Option "batch_slice" is supported for all "DataAsset" extensions of this class identically.  This mechanism
+            applies to every "Datasource" type and any "ExecutionEngine" that is capable of loading data from files on
+            local and/or cloud/networked filesystems (currently, Pandas and Spark backends work with files).
         """
         if options:
             for option, value in options.items():

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -204,11 +204,6 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
             """One needs to implement "batch_request_options" on a DataAsset subclass."""
         )
 
-    def get_batch_list_from_batch_request(
-        self, batch_request: BatchRequest
-    ) -> List[Batch]:
-        raise NotImplementedError
-
     def build_batch_request(
         self,
         options: Optional[BatchRequestOptions] = None,
@@ -230,6 +225,11 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
         raise NotImplementedError(
             """One must implement "build_batch_request" on a DataAsset subclass."""
         )
+
+    def get_batch_list_from_batch_request(
+        self, batch_request: BatchRequest
+    ) -> List[Batch]:
+        raise NotImplementedError
 
     def _validate_batch_request(self, batch_request: BatchRequest) -> None:
         """Validates the batch_request has the correct form.

--- a/tests/datasource/data_connector/test_batch_filter.py
+++ b/tests/datasource/data_connector/test_batch_filter.py
@@ -12,7 +12,7 @@ from great_expectations.datasource.data_connector.batch_filter import (
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "data_connector_query_dict,parsed_batch_slice,sliced_list",
+    "data_connector_query_dict, parsed_batch_slice, sliced_list",
     [
         pytest.param(
             {

--- a/tests/datasource/fluent/test_pandas_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_pandas_filesystem_datasource.py
@@ -667,7 +667,7 @@ def test_pandas_sorter(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "batch_slice,expected_batch_count",
+    "batch_slice, expected_batch_count",
     [
         ("[-3:]", 3),
         ("[5:9]", 4),

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -989,7 +989,7 @@ def test_spark_sorter(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "batch_slice,expected_batch_count",
+    "batch_slice, expected_batch_count",
     [
         ("[-3:]", 3),
         ("[5:9]", 4),

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import re
 from dataclasses import dataclass
-from typing import List, cast
+from typing import TYPE_CHECKING, List, cast
 
 import pydantic
 import pytest
@@ -40,6 +40,10 @@ from great_expectations.datasource.fluent.spark_file_path_datasource import (
 from great_expectations.datasource.fluent.spark_filesystem_datasource import (
     SparkFilesystemDatasource,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.datasource.fluent.interfaces import BatchSlice
+
 
 logger = logging.getLogger(__name__)
 
@@ -981,6 +985,42 @@ def test_spark_sorter(
             metadata = batches[batch_index].metadata
             assert metadata[key1] == range1
             assert metadata[key2] == range2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "batch_slice,expected_batch_count",
+    [
+        ("[-3:]", 3),
+        ("[5:9]", 4),
+        ("[:10:2]", 5),
+        (slice(-3, None), 3),
+        (slice(5, 9), 4),
+        (slice(0, 10, 2), 5),
+        ("-5", 1),
+        ("-1", 1),
+        (11, 1),
+        (0, 1),
+        ([3], 1),
+        (None, 12),
+        ("", 12),
+    ],
+)
+def test_spark_slice_batch_count(
+    spark_filesystem_datasource: SparkFilesystemDatasource,
+    batch_slice: BatchSlice,
+    expected_batch_count: int,
+) -> None:
+    asset = spark_filesystem_datasource.add_csv_asset(
+        name="csv_asset",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+    )
+    batch_request = asset.build_batch_request(
+        options={"year": "2019"},
+        batch_slice=batch_slice,
+    )
+    batches = asset.get_batch_list_from_batch_request(batch_request=batch_request)
+    assert len(batches) == expected_batch_count
 
 
 def bad_batching_regex_config(


### PR DESCRIPTION
### Scope
Unit tests are provided for the use of `batch_slice` argument to `asset.build_batch_request()` under `SparkFilesystemDatasource`.

The `batch_slice` is supported for all `DataAsset` extensions of `class _FilePathDataAsset(DataAsset)` -- identically under `Pandas` and `Spark` datasource types.  These new unit tests, now being made available for `SparkFileDatasource`, clarify that this capability exists and the mechanism according to which it behaves.

### Remarks
* JIRA: DX-627

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!