### PR TITLE
[MAINTENANCE] Remove --verbose pytest default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
         run: pip install -c constraints-dev.txt ".[test]"
 
       - name: Run the unit tests
-        run: invoke tests --cloud --unit --timeout=1.5
+        run: invoke tests --cloud --unit --timeout=1.5 --slowest=8

--- a/tasks.py
+++ b/tasks.py
@@ -378,6 +378,7 @@ def tests(  # noqa: PLR0913
     timeout: float = UNIT_TEST_DEFAULT_TIMEOUT,
     package: str | None = None,
     full_cov: bool = False,
+    verbose: bool = False,
 ):
     """
     Run tests. Runs unit tests by default.
@@ -401,8 +402,10 @@ def tests(  # noqa: PLR0913
         f"--durations={slowest}",
         cov_param,
         "--cov-report term",
-        "-vv",
+        "-rEf",  # show extra test summary info for errors & failed tests
     ]
+    if verbose:
+        cmds.append("-vv")
     if not ignore_markers:
         cmds += ["-m", f"'{marker_text}'"]
     if unit and not ignore_markers:


### PR DESCRIPTION
Reading through a test failure in CI requires too much scrolling due to the use of the `pytest --verbose` flag.
Change this so that it isn't used by default when running `invoke tests`

Also adds the `-rEf` flag so that failures and errors are always summarized at the bottom of the output.

![image](https://github.com/great-expectations/great_expectations/assets/13108583/2a4ae827-2316-4145-a78e-94f620f0a5c0)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
