### PR TITLE
[MAINTENANCE] gitignore for GCP credentials

### DIFF
--- a/examples/reference_environments/.gitignore
+++ b/examples/reference_environments/.gitignore
@@ -1,0 +1,4 @@
+
+# Typical GCP credentials file names
+**/credentials.json
+**/creds.json


### PR DESCRIPTION
Add a .gitignore file for ignoring typical names for GCP credentials files in reference environments folders.