### PR TITLE
[MAINTENANCE] Disable Airflow provider tests in CI due to external test failures

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -556,21 +556,24 @@ stages:
               GE_USAGE_STATISTICS_URL: ${{ variables.GE_USAGE_STATISTICS_URL }}
               SQLALCHEMY_WARN_20: true
 
-  - stage: airflow_provider
-    dependsOn: [scope_check, lint, import_ge, custom_checks, unit_tests]
-    pool:
-      vmImage: 'ubuntu-latest'
+  # 2023-07-18 - Chetan - these are being disabled due to a test failure introduced by the provider
+  # GitHub issue requiring resolution: https://github.com/astronomer/airflow-provider-great-expectations/issues/114
 
-    jobs:
-      - job: run_airflow_provider_tests
-        steps:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: '3.8'
-            displayName: 'Use Python 3.8'
+  # - stage: airflow_provider
+  #   dependsOn: [scope_check, lint, import_ge, custom_checks, unit_tests]
+  #   pool:
+  #     vmImage: 'ubuntu-latest'
 
-          - script: ./ci/checks/check_min_airflow_dependency_compatibility.sh
-            name: CheckMinAirflowDependencyCompatibility
+  #   jobs:
+  #     - job: run_airflow_provider_tests
+  #       steps:
+  #         - task: UsePythonVersion@0
+  #           inputs:
+  #             versionSpec: '3.8'
+  #           displayName: 'Use Python 3.8'
 
-          - script: ./ci/checks/run_gx_airflow_operator_tests.sh
-            name: RunAirflowProviderTests
+  #         - script: ./ci/checks/check_min_airflow_dependency_compatibility.sh
+  #           name: CheckMinAirflowDependencyCompatibility
+
+  #         - script: ./ci/checks/run_gx_airflow_operator_tests.sh
+  #           name: RunAirflowProviderTests

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -598,34 +598,37 @@ stages:
                 --cov-report=html
             displayName: 'Pytest mssql'
 
-  - stage: airflow_provider
-    dependsOn: [lint, import_ge, custom_checks]
-    pool:
-      vmImage: 'ubuntu-latest'
+  # 2023-07-18 - Chetan - these are being disabled due to a test failure introduced by the provider
+  # GitHub issue requiring resolution: https://github.com/astronomer/airflow-provider-great-expectations/issues/114
 
-    jobs:
-      - job: run_airflow_provider_tests
-        condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+  # - stage: airflow_provider
+  #   dependsOn: [lint, import_ge, custom_checks]
+  #   pool:
+  #     vmImage: 'ubuntu-latest'
 
-        strategy:
-          matrix:
-            Python38:
-              python.version: '3.8'
-            Python39:
-              python.version: '3.9'
-            Python310:
-              python.version: '3.10'
-            Python311:
-              python.version: '3.11'
+  #   jobs:
+  #     - job: run_airflow_provider_tests
+  #       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
 
-        steps:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: '$(python.version)'
-            displayName: 'Use Python $(python.version)'
+  #       strategy:
+  #         matrix:
+  #           Python38:
+  #             python.version: '3.8'
+  #           Python39:
+  #             python.version: '3.9'
+  #           Python310:
+  #             python.version: '3.10'
+  #           Python311:
+  #             python.version: '3.11'
 
-          - script: ./ci/checks/run_gx_airflow_operator_tests.sh
-            name: RunAirflowProviderTests
+  #       steps:
+  #         - task: UsePythonVersion@0
+  #           inputs:
+  #             versionSpec: '$(python.version)'
+  #           displayName: 'Use Python $(python.version)'
+
+  #         - script: ./ci/checks/run_gx_airflow_operator_tests.sh
+  #           name: RunAirflowProviderTests
 
   - stage: test_build_docs
     dependsOn: [lint, import_ge, custom_checks]


### PR DESCRIPTION
Our integration with Airflow is broken due to a bad test on their end - disabling for the time being as they work to resolve.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
