### PR TITLE
[DOCS] Remove Outdated SQLAlchemy 2.0 Admonitions

### DIFF
--- a/docs/docusaurus/docs/guides/setup/installation/install_gx.md
+++ b/docs/docusaurus/docs/guides/setup/installation/install_gx.md
@@ -266,14 +266,6 @@ The above pip instruction will install GX with basic SQL support through SqlAlch
 
 :::
 
-:::caution SqlAlchemy version
-
-Great Expectations does not currently support SqlAlchemy 2.0.
-
-If you install SqlAlchemy independently of the above pip commands, be certain to install the most recent SqlAlchemy version prior to 2.0.
-
-:::
-
 ### Verify that GX has been installed correctly
 
 <GxVerifyInstallation />

--- a/docs/docusaurus/docs/guides/setup/optional_dependencies/cloud/connect_gx_source_data_system.md
+++ b/docs/docusaurus/docs/guides/setup/optional_dependencies/cloud/connect_gx_source_data_system.md
@@ -219,14 +219,6 @@ The above pip instruction will install GX with basic SQL support through SqlAlch
 
 :::
 
-:::caution SqlAlchemy version
-
-Great Expectations does not currently support SqlAlchemy 2.0.
-
-If you install SqlAlchemy independently of the above pip commands, be certain to install the most recent SqlAlchemy version prior to 2.0.
-
-:::
-
 ### Verify that GX has been installed correctly
 
 <GxVerifyInstallation />

--- a/docs/docusaurus/docs/guides/setup/optional_dependencies/sql_databases/how_to_setup_gx_to_work_with_sql_databases.md
+++ b/docs/docusaurus/docs/guides/setup/optional_dependencies/sql_databases/how_to_setup_gx_to_work_with_sql_databases.md
@@ -69,14 +69,6 @@ The above pip instruction will install GX with basic SQL support through SqlAlch
 
 :::
 
-:::caution SqlAlchemy version
-
-Great Expectations does not currently support SqlAlchemy 2.0.
-
-If you install SqlAlchemy independently of the above pip commands, be certain to install the most recent SqlAlchemy version prior to 2.0.
-
-:::
-
 ### 4. Verify that GX has been installed correctly
 
 <GxVerifyInstallation />


### PR DESCRIPTION
Removes outdated admonitions stating lack of SQLAlchemy 2.0 support.

Resolves #8351

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
