### PR TITLE
[MAINTENANCE] Unpin upper bound on Click dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 altair>=4.2.1,<5.0.0
-Click>=7.1.2,<=8.1.3 # 8.1.4 introduced mypy typing issues (https://github.com/pallets/click/issues/2558)
+Click>=7.1.2
 colorama>=0.4.3
 cryptography>=3.2
 importlib-metadata>=1.7.0 # (included in Python 3.8 by default.)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -185,7 +185,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 83
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 80
     assert sorted_packages_with_pins_or_upper_bounds == [
         ("requirements-dev-api-docs-test.txt", "docstring-parser", (("==", "0.15"),)),
         ("requirements-dev-athena.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
@@ -228,7 +228,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev-test.txt", "pika", (("==", "1.3.1"),)),
         ("requirements-dev-test.txt", "ruff", (("==", "0.0.271"),)),
         ("requirements-dev-test.txt", "snapshottest", (("==", "0.6.0"),)),
-        ("requirements-dev.txt", "Click", (("<=", "8.1.3"), (">=", "7.1.2"))),
         ("requirements-dev.txt", "PyMySQL", (("<", "0.10"), (">=", "0.9.3"))),
         ("requirements-dev.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
@@ -251,7 +250,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-dev.txt", "teradatasqlalchemy", (("==", "17.0.0.5"),)),
         ("requirements-dev.txt", "xlrd", (("<", "2.0.0"), (">=", "1.1.0"))),
-        ("requirements-types.txt", "Click", (("<=", "8.1.3"), (">=", "7.1.2"))),
         ("requirements-types.txt", "PyMySQL", (("<", "0.10"), (">=", "0.9.3"))),
         ("requirements-types.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-types.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
@@ -271,7 +269,6 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-types.txt", "sqlalchemy", (("<", "2.0.0"),)),
         ("requirements-types.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
         ("requirements-types.txt", "teradatasqlalchemy", (("==", "17.0.0.5"),)),
-        ("requirements.txt", "Click", (("<=", "8.1.3"), (">=", "7.1.2"))),
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "jsonschema", (("<", "4.18.1"), (">=", "2.5.1"))),
         ("requirements.txt", "makefun", (("<", "2"), (">=", "1.7.0"))),


### PR DESCRIPTION
Mypy issue was resolved with a later release


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
