### PR TITLE
[BUGFIX] Ensure that SQLAlchemy is installed for SQL Datasource and TableAsset Fluent Datasource Module

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -203,8 +203,10 @@ stages:
         steps:
          - task: UsePythonVersion@0
            inputs:
-             versionSpec: '3.8'
-           displayName: 'Use Python 3.8'
+             # versionSpec: '3.8'
+             versionSpec: '3.11'
+           # displayName: 'Use Python 3.8'
+           displayName: 'Use Python 3.11'
 
          - bash: python -m pip install --upgrade pip
            displayName: 'Update pip'

--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -203,10 +203,8 @@ stages:
         steps:
          - task: UsePythonVersion@0
            inputs:
-             # versionSpec: '3.8'
-             versionSpec: '3.11'
-           # displayName: 'Use Python 3.8'
-           displayName: 'Use Python 3.11'
+             versionSpec: '3.8'
+           displayName: 'Use Python 3.8'
 
          - bash: python -m pip install --upgrade pip
            displayName: 'Update pip'

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -823,7 +823,10 @@ class TableAsset(_SQLAsset):
                 "table_name cannot be empty and should default to name if not provided"
             )
 
-        return sqlalchemy.quoted_name(value=validated_table_name, quote=True)
+        if sqlalchemy.quoted_name:
+            return sqlalchemy.quoted_name(value=validated_table_name, quote=True)
+
+        return validated_table_name
 
     def test_connection(self) -> None:
         """Test the connection for the TableAsset.

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -19,7 +19,6 @@ from typing import (
 import pydantic
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
@@ -51,6 +50,7 @@ from great_expectations.execution_engine.split_and_sample.sqlalchemy_data_splitt
 if TYPE_CHECKING:
     from typing_extensions import Self
 
+    from great_expectations.compatibility import sqlalchemy
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.interfaces import (
         BatchMetadata,
@@ -822,6 +822,8 @@ class TableAsset(_SQLAsset):
             raise ValueError(
                 "table_name cannot be empty and should default to name if not provided"
             )
+
+        from great_expectations.compatibility import sqlalchemy
 
         if sqlalchemy.quoted_name:
             return sqlalchemy.quoted_name(value=validated_table_name, quote=True)

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1083,7 +1083,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = "SELECT * FROM sa.text('test');"
+        select_all = f"SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query(sa.text(select_all)).fetchall()
 
         expected = [(1, 4), (2, 4)]
@@ -1094,7 +1094,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = "SELECT * FROM sa.text('test');"
+        select_all = f"SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query_in_transaction(
             sa.text(select_all)
         ).fetchall()

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1083,7 +1083,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = f"SELECT * FROM sa.text('test');"
+        select_all = "SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query(sa.text(select_all)).fetchall()
 
         expected = [(1, 4), (2, 4)]
@@ -1094,7 +1094,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = f"SELECT * FROM sa.text('test');"
+        select_all = "SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query_in_transaction(
             sa.text(select_all)
         ).fetchall()

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1083,7 +1083,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = f"SELECT * FROM sa.text('test');"
+        select_all = f"SELECT * FROM {sa.text('test')};"
         result = execution_engine.execute_query(sa.text(select_all)).fetchall()
 
         expected = [(1, 4), (2, 4)]
@@ -1094,7 +1094,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = f"SELECT * FROM sa.text('test');"
+        select_all = f"SELECT * FROM {sa.text('test')};"
         result = execution_engine.execute_query_in_transaction(
             sa.text(select_all)
         ).fetchall()

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1083,7 +1083,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = "SELECT * FROM test;"
+        select_all = f"SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query(sa.text(select_all)).fetchall()
 
         expected = [(1, 4), (2, 4)]
@@ -1094,7 +1094,7 @@ class TestExecuteQuery:
             pd_dataframe, sa
         )
 
-        select_all = "SELECT * FROM test;"
+        select_all = f"SELECT * FROM sa.text('test');"
         result = execution_engine.execute_query_in_transaction(
             sa.text(select_all)
         ).fetchall()


### PR DESCRIPTION
### Scope
* Check for `sqlalchemy.quoted_name` is added to ensure that `SQLAlchemy` is installed for `TableAsset` in "great_expectations/datasource/fluent/sql_datasource.py".
* Fix the way literal text table name is used in `test_sqlalchemy_execution_engine.py` -- the use of `sa.text()` is required.

### Remarks
* JIRA: DX-307

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted

    ```
    black .

    ruff . --fix
    ```
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!