### PR TITLE
[MAINTENANCE] Add detect-private-key pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         exclude: docs/.*
       - id: no-commit-to-branch
         args: [--branch, develop, --branch, main]
+      - id: detect-private-key
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:


### PR DESCRIPTION
- Add the detect-private-key pre commit hook: https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/detect_private_key.py
- This is from the list of supported hooks: https://pre-commit.com/hooks.html