### PR TITLE
[BUGFIX] Handle ValueError in agent action

### DIFF
--- a/great_expectations/agent/actions/run_onboarding_data_assistant.py
+++ b/great_expectations/agent/actions/run_onboarding_data_assistant.py
@@ -32,7 +32,7 @@ class RunOnboardingDataAssistantAction(AgentAction[RunOnboardingDataAssistantEve
             )
             # if that didn't error, this name exists, so we add the timestamp
             expectation_suite_name = f"{expectation_suite_name} {timestamp}"
-        except StoreBackendError:
+        except (StoreBackendError, ValueError):
             # resource is unique
             pass
 
@@ -40,7 +40,7 @@ class RunOnboardingDataAssistantAction(AgentAction[RunOnboardingDataAssistantEve
             self._context.get_checkpoint(name=checkpoint_name)
             # if that didn't error, this name exists, so we add the timestamp
             checkpoint_name = f"{checkpoint_name} {timestamp}"
-        except StoreBackendError:
+        except (StoreBackendError, ValueError):
             # resource is unique
             pass
 


### PR DESCRIPTION
GX recently started raising a ValueError when an expectation suite is not found. This PR updates the agent action `RunOnboardingDataAssistant` to handle the new exception.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
