### PR TITLE
[BUGFIX] DataAssistantResult should not error on get_expectation_suite without name

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import json
 import os
+import uuid
 from collections import defaultdict, namedtuple
 from dataclasses import asdict, dataclass, field
 from typing import (
@@ -18,7 +19,6 @@ from typing import (
     Set,
     Union,
 )
-import uuid
 
 import altair as alt
 import ipywidgets as widgets

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -18,6 +18,7 @@ from typing import (
     Set,
     Union,
 )
+import uuid
 
 import altair as alt
 import ipywidgets as widgets
@@ -232,6 +233,12 @@ class DataAssistantResult(SerializableDictDot):
 
         """
         if send_usage_event:
+            if not expectation_suite_name:
+                component_name: str = self.__class__.__name__
+                expectation_suite_name = (
+                    f"tmp.{component_name}.suite.{str(uuid.uuid4())[:8]}"
+                )
+
             return self._get_expectation_suite_with_usage_statistics(
                 expectation_suite_name=expectation_suite_name,
                 include_profiler_config=include_profiler_config,
@@ -520,8 +527,8 @@ class DataAssistantResult(SerializableDictDot):
                 for key, value in citation.items()
                 if key != "profiler_config"
             }
-
-        expectation_suite.add_citation(**citation)
+        if citation:
+            expectation_suite.add_citation(**citation)
 
         return expectation_suite
 

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -56,6 +56,8 @@ from great_expectations.rule_based_profiler.data_assistant_result.plot_result im
     PlotResult,
 )
 from great_expectations.rule_based_profiler.helpers.util import (
+    TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX,
+    TEMPORARY_EXPECTATION_SUITE_NAME_STEM,
     get_or_create_expectation_suite,
     sanitize_parameter_name,
 )
@@ -235,9 +237,7 @@ class DataAssistantResult(SerializableDictDot):
         if send_usage_event:
             if not expectation_suite_name:
                 component_name: str = self.__class__.__name__
-                expectation_suite_name = (
-                    f"tmp.{component_name}.suite.{str(uuid.uuid4())[:8]}"
-                )
+                expectation_suite_name = f"{TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX}.{component_name}.{TEMPORARY_EXPECTATION_SUITE_NAME_STEM}.{str(uuid.uuid4())[:8]}"
 
             return self._get_expectation_suite_with_usage_statistics(
                 expectation_suite_name=expectation_suite_name,

--- a/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
+++ b/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 import altair as alt
 import pandas as pd
 import pytest
+from great_expectations.core.expectation_suite import ExpectationSuite
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.rule_based_profiler.data_assistant_result import (
@@ -56,3 +57,22 @@ def test_get_chart_titles():
         DataAssistantResult._get_chart_titles(charts=[layer_a])
 
     assert e.value.message == "All DataAssistantResult charts must have a title."
+
+
+def test_get_expectation_suite_should_use_default_name_if_none():
+    data_assistant_result: DataAssistantResult = DataAssistantResult()
+
+    # Should not raise an error
+    expectation_suite = data_assistant_result.get_expectation_suite(
+        expectation_suite_name=None, send_usage_event=False
+    )
+    assert expectation_suite
+    assert isinstance(expectation_suite, ExpectationSuite)
+    assert expectation_suite.expectation_suite_name
+
+    expectation_suite = data_assistant_result.get_expectation_suite(
+        expectation_suite_name=None, send_usage_event=True
+    )
+    assert expectation_suite
+    assert isinstance(expectation_suite, ExpectationSuite)
+    assert expectation_suite.expectation_suite_name


### PR DESCRIPTION
We were seeing this error:

![Capture-2023-07-20-100909](https://github.com/great-expectations/great_expectations/assets/2117313/e638f6ab-3bf5-42fc-86ee-3c40e489cd10)

`get_or_create_expectation_suite` would [generate a expectation suite name](https://github.com/great-expectations/great_expectations/blob/a78f850d32a511db1729f1ffdd1e1266275ecf4c/great_expectations/rule_based_profiler/helpers/util.py#L1044) if none was given. But when triggering the capture of usage stats, the args would be [passed to the capture function](https://github.com/great-expectations/great_expectations/blob/a53e156e093932cd8435b64353f91553200a5922/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py#L480) without this generation. The solution is to generate prior to calling `_get_expectation_suite_with_usage_statistics`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
