### PR TITLE
[MAINTENANCE] Do not run CI on draft pull requests, enable running manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # https://crontab.guru/every-3-hours
     - cron: "0 */3 * * *"
+  workflow_dispatch:  # allows manual triggering with branch picker
 
 jobs:
   static-analysis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   workflow_dispatch:  # allows manual triggering with branch picker
 
 jobs:
+  ci-does-not-run-on-draft-pull-requests:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == true
+    steps:
+      - run: echo "CI jobs are not running because this is a draft pull request."
+
   static-analysis:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:  # allows manual triggering with branch picker
 
 jobs:
+  if: github.event.pull_request.draft == false
   ci-does-not-run-on-draft-pull-requests:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == true
@@ -16,7 +17,6 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout
@@ -42,7 +42,6 @@ jobs:
           invoke type-check --ci --pretty  --check-stub-sources
 
   unit-tests:
-    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -69,7 +68,6 @@ jobs:
         run: invoke tests --cloud --unit --timeout=1.5 --slowest=8
 
   marker-tests:
-    if: github.event.pull_request.draft == false
     services:
       postgres:
         # Docker hub image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   static-analysis:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout
@@ -35,6 +36,7 @@ jobs:
           invoke type-check --ci --pretty  --check-stub-sources
 
   unit-tests:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -61,6 +63,7 @@ jobs:
         run: invoke tests --cloud --unit --timeout=1.5 --slowest=8
 
   marker-tests:
+    if: github.event.pull_request.draft == false
     services:
       postgres:
         # Docker hub image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == true
     steps:
-      - run: echo "CI jobs are not running because this is a draft pull request."
+      - run: echo "CI jobs won't run because this is a draft pull request."
 
   static-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:  # allows manual triggering with branch picker
 
 jobs:
-  if: github.event.pull_request.draft == false
   ci-does-not-run-on-draft-pull-requests:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == true
@@ -17,6 +16,7 @@ jobs:
 
   static-analysis:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout
@@ -42,6 +42,7 @@ jobs:
           invoke type-check --ci --pretty  --check-stub-sources
 
   unit-tests:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -68,6 +69,7 @@ jobs:
         run: invoke tests --cloud --unit --timeout=1.5 --slowest=8
 
   marker-tests:
+    if: github.event.pull_request.draft == false
     services:
       postgres:
         # Docker hub image


### PR DESCRIPTION
- Add ability to run CI manually
- Don't run CI on draft PRs
- Stage with descriptive name runs on draft PRs and describes why CI is not running
- I also tried to look for a method (using the conditional `if:` or the `on:`) to skip all jobs (so we don't have to duplicate the conditional on all jobs) but I was not successful. This issue explores some of these options: https://github.com/orgs/community/discussions/25722

When the PR is a draft PR, note the `ci / ci-does-not-run-on-draft-pull-requests (pull_request)` job and other jobs are skipped:
![image](https://github.com/great-expectations/great_expectations/assets/9903066/377f4f11-1561-4a64-a0e1-1616bd351bbb)
