### PR TITLE
[MAINTENANCE] remove integration markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           # `not e2e` because 1 test & 1 fixture need access token
           - cloud and not e2e
           - filesystem
+          - docs
           - openpyxl or pyarrow or project or sqlite
           #- spark
           - postgresql

--- a/ci/azure-pipelines-docs-integration.yml
+++ b/ci/azure-pipelines-docs-integration.yml
@@ -87,7 +87,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration tests/integration/test_script_runner.py
+            pytest -v --docs-tests tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_spark

--- a/ci/azure-pipelines-docs-integration.yml
+++ b/ci/azure-pipelines-docs-integration.yml
@@ -112,7 +112,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --spark tests/integration/test_script_runner.py
+            pytest -v --docs-tests --spark tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_mysql
@@ -152,7 +152,7 @@ stages:
           displayName: 'Configure mysql'
 
         - script: |
-            pytest -v --docs-tests -m integration --mysql tests/integration/test_script_runner.py
+            pytest -v --docs-tests --mysql tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_postgresql
@@ -179,7 +179,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --postgresql tests/integration/test_script_runner.py
+            pytest -v --docs-tests --postgresql tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_bigquery
@@ -220,7 +220,7 @@ stages:
           displayName: 'Install and setup Google Cloud SDK'
 
         - script: |
-            pytest -v --docs-tests -m integration --bigquery tests/integration/test_script_runner.py
+            pytest -v --docs-tests --bigquery tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # GCP credentials
@@ -252,7 +252,7 @@ stages:
 
         - script: |
             # Note expect_column_values_to_only_contain_vowels is skipped because metrics are not implemented for MSSQL.
-            pytest -v --docs-tests -m integration --mssql -k "not test_docs[expect_column_values_to_only_contain_vowels]" tests/integration/test_script_runner.py
+            pytest -v --docs-tests --mssql -k "not test_docs[expect_column_values_to_only_contain_vowels]" tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_snowflake
@@ -272,7 +272,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --snowflake tests/integration/test_script_runner.py
+            pytest -v --docs-tests --snowflake tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # snowflake credentials
@@ -301,7 +301,7 @@ stages:
             pip install --constraint constraints-dev.txt ".[test, redshift]" pytest-azurepipelines "pandas<2.0.0"
           displayName: 'Install dependencies'
         - script: |
-            pytest -v --docs-tests -m integration --redshift tests/integration/test_script_runner.py
+            pytest -v --docs-tests --redshift tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             # redshift credentials
@@ -333,7 +333,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --aws tests/integration/test_script_runner.py
+            pytest -v --docs-tests --aws tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
@@ -371,7 +371,7 @@ stages:
             pip install --constraint constraints-dev.txt ".[test, spark]" pytest-azurepipelines git+https://github.com/awslabs/aws-glue-libs.git
           displayName: 'Install dependencies'
         - script: |
-            pytest -v --docs-tests -m integration --aws --spark tests/integration/test_script_runner.py
+            pytest -v --docs-tests --aws --spark tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
@@ -395,7 +395,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --azure tests/integration/test_script_runner.py
+            pytest -v --docs-tests --azure tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             AZURE_CREDENTIAL: $(AZURE_CREDENTIAL)
@@ -419,7 +419,7 @@ stages:
             pip install --constraint constraints-dev.txt ".[test, trino]" pytest-azurepipelines
           displayName: 'Install dependencies'
         - script: |
-            pytest -v --docs-tests -m integration --trino tests/integration/test_script_runner.py
+            pytest -v --docs-tests --trino tests/integration/test_script_runner.py
           displayName: 'pytest'
 
     - job: test_docs_athena
@@ -439,7 +439,7 @@ stages:
           displayName: 'Install dependencies'
 
         - script: |
-            pytest -v --docs-tests -m integration --athena tests/integration/test_script_runner.py
+            pytest -v --docs-tests --athena tests/integration/test_script_runner.py
           displayName: 'pytest'
           env:
             ATHENA_DB_NAME: $(ATHENA_DB_NAME)
@@ -489,5 +489,5 @@ stages:
           displayName: 'Configure mysql'
 
         - script: |
-            pytest -v --docs-tests -m integration --mysql --postgresql tests/integration/test_script_runner.py
+            pytest -v --docs-tests --mysql --postgresql tests/integration/test_script_runner.py
           displayName: 'pytest'

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
@@ -117,7 +117,7 @@ def bobby_profile_data_profiler_structured_data_assistant_result(
     return cast(DataProfilerStructuredDataAssistantResult, data_assistant_result)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 6.90s
 def test_profile_data_profiler_structured_data_assistant_result_serialization(
     bobby_profile_data_profiler_structured_data_assistant_result: DataProfilerStructuredDataAssistantResult,
@@ -141,7 +141,7 @@ def test_profile_data_profiler_structured_data_assistant_result_serialization(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -168,7 +168,7 @@ def test_profile_data_profiler_structured_data_assistant_result_get_expectation_
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_profile_data_profiler_structured_data_assistant_metrics_count(
     bobby_profile_data_profiler_structured_data_assistant_result: DataProfilerStructuredDataAssistantResult,
 ) -> None:
@@ -205,7 +205,7 @@ def test_profile_data_profiler_structured_data_assistant_metrics_count(
     )  # 2 * ((numeric_rule: 6 int + 9 float + 1 string) + (float_rule: 9 float))
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_profile_data_profiler_structured_data_assistant_result_batch_id_to_batch_identifier_display_name_map_coverage(
     bobby_profile_data_profiler_structured_data_assistant_result: DataProfilerStructuredDataAssistantResult,
 ):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/domain_builder/test_data_profiler_column_domain_builder.py
@@ -34,7 +34,7 @@ test_root_path: str = os.path.dirname(  # noqa: PTH120
 )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.21s
 def test_data_profiler_column_domain_builder_with_profile_path_as_value(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
@@ -306,7 +306,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_value(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.21s
 def test_data_profiler_column_domain_builder_with_profile_path_as_default_reference(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
@@ -579,7 +579,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_default_refere
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.21s
 def test_data_profiler_column_domain_builder_with_profile_path_as_reference(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
@@ -852,7 +852,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.21s
 def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with_exclude_column_names_with_exclude_column_name_suffixes(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,
@@ -1060,7 +1060,7 @@ def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.21s
 def test_data_profiler_column_domain_builder_with_profile_path_as_reference_with_partial_column_list_in_profiler_report(
     bobby_columnar_table_multi_batch_deterministic_data_context: FileDataContext,

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -116,7 +116,7 @@ def quentin_implicit_invocation_result_frozen_time(
     return cast(GrowthNumericDataAssistantResult, data_assistant_result)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 6.90s
 def test_growth_numeric_data_assistant_result_serialization(
     bobby_growth_numeric_data_assistant_result: GrowthNumericDataAssistantResult,
@@ -135,7 +135,7 @@ def test_growth_numeric_data_assistant_result_serialization(
     assert len(bobby_growth_numeric_data_assistant_result.profiler_config.rules) == 4
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -162,7 +162,7 @@ def test_growth_numeric_data_assistant_result_get_expectation_suite(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_growth_numeric_data_assistant_metrics_count(
     bobby_growth_numeric_data_assistant_result: GrowthNumericDataAssistantResult,
 ) -> None:
@@ -194,7 +194,7 @@ def test_growth_numeric_data_assistant_metrics_count(
     assert num_metrics == 121
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_growth_numeric_data_assistant_result_batch_id_to_batch_identifier_display_name_map_coverage(
     bobby_growth_numeric_data_assistant_result: GrowthNumericDataAssistantResult,
 ):
@@ -220,7 +220,7 @@ def test_growth_numeric_data_assistant_result_batch_id_to_batch_identifier_displ
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 39.26s
 def test_growth_numeric_data_assistant_get_metrics_and_expectations_using_implicit_invocation_with_variables_directives(
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -266,7 +266,7 @@ def test_growth_numeric_data_assistant_get_metrics_and_expectations_using_implic
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 38.26s
 def test_growth_numeric_data_assistant_get_metrics_and_expectations_using_implicit_invocation_with_estimation_directive(
     quentin_columnar_table_multi_batch_data_context,
@@ -292,7 +292,7 @@ def test_growth_numeric_data_assistant_get_metrics_and_expectations_using_implic
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 19s
 def test_pandas_happy_path_growth_numeric_data_assistant(empty_data_context) -> None:
     """
@@ -397,7 +397,7 @@ def test_pandas_happy_path_growth_numeric_data_assistant(empty_data_context) -> 
     assert results.success is False
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 149 seconds
 def test_spark_happy_path_growth_numeric_data_assistant(
     empty_data_context, spark_df_taxi_data_schema
@@ -499,7 +499,7 @@ def test_spark_happy_path_growth_numeric_data_assistant(
     assert results.success is False
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 104 seconds
 def test_sql_happy_path_growth_numeric_data_assistant(
     empty_data_context, test_backends, sa

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
@@ -81,7 +81,7 @@ def test_statistics_data_assistant_result_serialization(
     assert len(bobby_statistics_data_assistant_result.profiler_config.rules) == 5
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_statistics_data_assistant_metrics_count(
     bobby_statistics_data_assistant_result: StatisticsDataAssistantResult,
 ) -> None:
@@ -113,7 +113,7 @@ def test_statistics_data_assistant_metrics_count(
     assert num_metrics == 153
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_statistics_data_assistant_result_batch_id_to_batch_identifier_display_name_map_coverage(
     bobby_statistics_data_assistant_result: StatisticsDataAssistantResult,
 ):
@@ -139,7 +139,7 @@ def test_statistics_data_assistant_result_batch_id_to_batch_identifier_display_n
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_statistics_data_assistant_result_normalized_metrics_vector_output(
     bobby_statistics_data_assistant_result: StatisticsDataAssistantResult,
 ):
@@ -219,7 +219,7 @@ def test_statistics_data_assistant_result_normalized_metrics_vector_output(
     assert np.allclose(normalized_metrics_vector_magnitude, 1.0)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 19s
 def test_pandas_happy_path_statistics_data_assistant(empty_data_context) -> None:
     """
@@ -291,7 +291,7 @@ def test_pandas_happy_path_statistics_data_assistant(empty_data_context) -> None
     assert len(result.metrics_by_domain) == 35
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 104 seconds
 def test_sql_happy_path_statistics_data_assistant(
     empty_data_context, test_backends, sa
@@ -361,7 +361,7 @@ def test_sql_happy_path_statistics_data_assistant(
     assert len(result.metrics_by_domain) == 35
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 149 seconds
 def test_spark_happy_path_statistics_data_assistant(
     empty_data_context, spark_df_taxi_data_schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -541,7 +541,6 @@ markers = [
     "e2e: mark test as an E2E test.",
     "external_sqldialect: mark test as requiring install of an external sql dialect.",
     "filesystem: mark tests using the filesystem as the storage backend.",
-    "integration: mark test as an integration test.",
     "slow: mark tests taking longer than 1 second.",
     "unit: mark a test as a unit test.",
     "clickhouse: mark a test as Clickhouse-dependent.",

--- a/tasks.py
+++ b/tasks.py
@@ -797,11 +797,18 @@ MARKER_DEPENDENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
     "cloud": TestDependencies(
         ("reqs/requirements-dev-cloud.txt",), exta_pytest_args=("--cloud",)
     ),
+    "docs": TestDependencies(
+        requirement_files=(
+            "reqs/requirements-dev-test.txt",
+            "reqs/requirements-dev-spark.txt",
+        ),
+        exta_pytest_args=("--docs-tests",),
+    ),
     "external_sqldialect": TestDependencies(("reqs/requirements-dev-sqlalchemy.txt",)),
     "pyarrow": TestDependencies(("reqs/requirements-dev-arrow.txt",)),
     "postgresql": TestDependencies(
         ("reqs/requirements-dev-postgresql.txt",),
-        services=["postgresql"],
+        services=("postgresql",),
         exta_pytest_args=("--postgresql",),
     ),
     "spark": TestDependencies(

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -442,7 +442,6 @@ def test_basic_checkpoint_config_validation(  # noqa: PLR0915
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -580,7 +579,6 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.74s
 def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_test_yaml_config(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -701,7 +699,6 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -917,7 +914,6 @@ def test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_y
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.75s
 def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1052,7 +1048,6 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 3.10s
 def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1257,7 +1252,6 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.25s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1302,7 +1296,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_with_checkpoint_name_in_meta_when_run(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     store_validation_result_action,
@@ -1457,7 +1450,6 @@ def test_newstyle_checkpoint_raises_error_if_expectation_suite_name_in_validatio
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.15s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_with_validator_specified_in_constructor(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1630,7 +1622,6 @@ def test_newstyle_checkpoint_raises_error_if_expectation_suite_name_is_specified
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.15s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_with_validator_specified_in_run(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1662,7 +1653,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.15s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_object(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1700,7 +1690,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_object_pandasdf(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1741,7 +1730,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_object_sparkdf(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -1785,7 +1773,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -2187,7 +2174,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_object_multi_validation_sparkdf(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -2256,7 +2242,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.08s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
     data_context_with_datasource_sqlalchemy_engine,
@@ -2298,7 +2283,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -2355,7 +2339,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_raise_error_when_run_when_missing_batch_request_and_validations(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -2383,7 +2366,6 @@ def test_newstyle_checkpoint_raise_error_when_run_when_missing_batch_request_and
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_top_level_batch_request(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -2424,7 +2406,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_top_level_batch_request_pandasdf(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -2462,7 +2443,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_top_level_batch_request_sparkdf(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -2503,7 +2483,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 @pytest.mark.slow  # 1.09s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_top_level_batch_request_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -2550,7 +2529,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_top_level_batch_request_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -2598,7 +2576,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_config_substitution_simple(
     monkeypatch,
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
@@ -2860,7 +2837,6 @@ def test_newstyle_checkpoint_config_substitution_simple(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_config_substitution_nested(
     monkeypatch,
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
@@ -3167,7 +3143,6 @@ def test_newstyle_checkpoint_config_substitution_nested(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_checkpoint_run(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -3207,7 +3182,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_query_in_checkpoint_run(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -3248,7 +3222,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 @pytest.mark.slow  # 1.11s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_checkpoint_run_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3294,7 +3267,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_checkpoint_run_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3341,7 +3313,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_checkpoint_run_pandas(  # noqa: F811 # TODO: review test for duplication
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3387,7 +3358,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_in_checkpoint_run_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3434,7 +3404,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_context_run_checkpoint(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -3479,7 +3448,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_context_run_checkpoint_pandasdf(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -3522,7 +3490,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_context_run_checkpoint_sparkdf(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -3566,7 +3533,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_query_in_context_run_checkpoint(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -3612,7 +3578,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_context_run_checkpoint_pandasdf(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -3656,7 +3621,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_context_run_checkpoint_sparkdf(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -3702,7 +3666,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 @pytest.mark.slow  # 1.18s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_context_run_checkpoint_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3753,7 +3716,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_context_run_checkpoint_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3805,7 +3767,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_context_run_checkpoint_pandas(  # noqa: F811 # TODO: review test for duplication
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3857,7 +3818,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_in_context_run_checkpoint_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -3910,7 +3870,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_result_with_batch_data(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -3948,7 +3907,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_re
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_runtime_parameters_error_contradictory_batch_request_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -4018,7 +3976,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_runtime_parameters_erro
 
 @pytest.mark.slow  # 1.75s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4093,7 +4050,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.35s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4182,7 +4138,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 1.91s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_context_run_checkpoint(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4258,7 +4213,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.46s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_context_run_checkpoint(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4348,7 +4302,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_does_not_pass_dataframes_via_batch_request_into_checkpoint_store(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -4389,7 +4342,6 @@ def test_newstyle_checkpoint_does_not_pass_dataframes_via_batch_request_into_che
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_does_not_pass_dataframes_via_validations_into_checkpoint_store(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -4431,7 +4383,6 @@ def test_newstyle_checkpoint_does_not_pass_dataframes_via_validations_into_check
 
 @pytest.mark.slow  # 1.19s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_result_can_be_pickled(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4464,7 +4415,6 @@ def test_newstyle_checkpoint_result_can_be_pickled(
 
 @pytest.mark.slow  # 1.19s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_result_validations_include_rendered_content(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -4511,7 +4461,6 @@ def test_newstyle_checkpoint_result_validations_include_rendered_content(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.22s
 def test_newstyle_checkpoint_result_validations_include_rendered_content_data_context_variable(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -4558,7 +4507,6 @@ def test_newstyle_checkpoint_result_validations_include_rendered_content_data_co
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "checkpoint_config,expected_validation_id",
     [
@@ -4767,7 +4715,6 @@ def fake_cloud_context_with_slack(_fake_cloud_context_setup, monkeypatch):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.cloud
 def test_use_validation_url_from_cloud(fake_cloud_context_basic):
     context = fake_cloud_context_basic
@@ -4782,7 +4729,6 @@ def test_use_validation_url_from_cloud(fake_cloud_context_basic):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.cloud
 def test_use_validation_url_from_cloud_with_slack(fake_cloud_context_with_slack):
     context, slack_counter = fake_cloud_context_with_slack
@@ -4794,7 +4740,6 @@ def test_use_validation_url_from_cloud_with_slack(fake_cloud_context_with_slack)
 
 ### SparkDF Tests
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_running_spark_checkpoint(
     context_with_single_csv_spark_and_suite,
     common_action_list,
@@ -4830,7 +4775,6 @@ def test_running_spark_checkpoint(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_run_spark_checkpoint_with_schema(
     context_with_single_csv_spark_and_suite,
     common_action_list,
@@ -4923,7 +4867,6 @@ def test_context_checkpoint_crud_conflicting_validator_and_validation_args_raise
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_checkpoint_with_validator_creates_validations_list(
     ephemeral_context_with_defaults: EphemeralDataContext,
     csv_path: pathlib.Path,

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -349,7 +349,6 @@ def _add_expectations_and_checkpoint(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -404,7 +403,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_with_query(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -461,7 +459,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_complete_output_with_query(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_column_pairs_table: dict,
@@ -516,7 +513,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_comp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_summary_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_column_pairs_table: dict,
@@ -564,7 +560,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_summ
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation_complete_output_with_query(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_multi_column_sum_table: dict,
@@ -634,7 +629,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation_summary_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_multi_column_sum_table: dict,
@@ -685,7 +679,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_no_query(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -738,7 +731,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -789,7 +781,6 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_limit_1(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -836,7 +827,6 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_incorrect_column(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -872,7 +862,6 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_two_expectation_complete_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -936,7 +925,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_two_expectation_complete_out
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_summary_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -983,7 +971,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_summary_outp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_basic_output(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -1031,7 +1018,6 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_basic_output
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_sql_complete_output_no_id_pk_fallback(
     data_context_with_connection_to_metrics_db: FileDataContext,
     reference_sql_checkpoint_config_for_animal_names_table: dict,
@@ -1079,7 +1065,6 @@ def test_sql_complete_output_no_id_pk_fallback(
 
 # pandas
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1129,7 +1114,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_with_query(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1180,7 +1164,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_no_query(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1228,7 +1211,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_partial_unexpected_count_1(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1280,7 +1262,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1326,7 +1307,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_summary_output_limit_1(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1365,7 +1345,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_incorrect_column(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1399,7 +1378,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1464,7 +1442,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1514,7 +1491,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_o
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1552,7 +1528,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_summary_output_limit_1(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1585,7 +1560,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_incorrect_column(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1619,7 +1593,6 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_output(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1676,7 +1649,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_output(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1716,7 +1688,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_o
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_basic_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -1756,7 +1727,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_basic_out
 
 # spark
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -1805,7 +1775,6 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_o
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -1860,7 +1829,6 @@ def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_ex
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_with_query(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -1918,7 +1886,6 @@ def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_ex
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_no_query(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -1971,7 +1938,6 @@ def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_ex
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expectation_complete_output_incorrect_column(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2010,7 +1976,6 @@ def test_spark_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_ex
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_two_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2079,7 +2044,6 @@ def test_spark_result_format_in_checkpoint_pk_defined_two_expectation_complete_o
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2130,7 +2094,6 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_ou
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_output_limit_1(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2188,7 +2151,6 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_ou
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_basic_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2238,7 +2200,6 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_basic_outp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_column_pair_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_column_pair: dict,
@@ -2294,7 +2255,6 @@ def test_spark_result_format_in_checkpoint_one_column_pair_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_column_pair_expectation_summary_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_column_pair: dict,
@@ -2343,7 +2303,6 @@ def test_spark_result_format_in_checkpoint_one_column_pair_expectation_summary_o
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_column_pair_expectation_basic_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_column_pair: dict,
@@ -2390,7 +2349,6 @@ def test_spark_result_format_in_checkpoint_one_column_pair_expectation_basic_out
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_multicolumn_sum: dict,
@@ -2452,7 +2410,6 @@ def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_compl
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_summary_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_multicolumn_sum: dict,
@@ -2500,7 +2457,6 @@ def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_summa
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_basic_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index_multicolumn_sum: dict,
@@ -2546,7 +2502,6 @@ def test_spark_result_format_in_checkpoint_one_multicolumn_map_expectation_basic
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_spark_complete_output_no_id_pk_fallback(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_spark_unexpected_rows_and_index: dict,
@@ -2594,7 +2549,6 @@ def test_spark_complete_output_no_id_pk_fallback(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_output_partial_unexpected_count_1(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -2641,7 +2595,6 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_one_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -2714,7 +2667,6 @@ def test_pandas_result_format_in_checkpoint_named_index_one_index_column(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_one_index_column_wrong_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -2769,7 +2721,6 @@ def test_pandas_result_format_in_checkpoint_named_index_one_index_column_wrong_c
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_two_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -2843,7 +2794,6 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -2907,7 +2857,6 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set(  # noqa: F811 # TODO: review test for duplication
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -2978,7 +2927,6 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_different_column_specified_in_result_format(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -3036,7 +2984,6 @@ def test_pandas_result_format_in_checkpoint_named_index_different_column_specifi
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_named_index_two_index_column_set(
     in_memory_runtime_context: AbstractDataContext,
     pandas_animals_dataframe_for_unexpected_rows_and_index: dict,
@@ -3108,7 +3055,6 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column_set(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index: dict,
@@ -3147,7 +3093,6 @@ def test_pandas_result_format_in_checkpoint_one_expectation_complete_output(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index_column_pair: dict,
@@ -3201,7 +3146,6 @@ def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete_output_one_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_column_pairs_dataframe_for_unexpected_rows_and_index: dict,
@@ -3275,7 +3219,6 @@ def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete_output_two_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_column_pairs_dataframe_for_unexpected_rows_and_index: dict,
@@ -3349,7 +3292,6 @@ def test_pandas_result_format_in_checkpoint_one_column_pair_expectation_complete
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_complete_output(
     in_memory_runtime_context: AbstractDataContext,
     batch_request_for_pandas_unexpected_rows_and_index_multicolumn_sum: dict,
@@ -3410,7 +3352,6 @@ def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_comp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_complete_output_one_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_multicolumn_sum_dataframe_for_unexpected_rows_and_index: dict,
@@ -3488,7 +3429,6 @@ def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_comp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_complete_output_two_index_column(
     in_memory_runtime_context: AbstractDataContext,
     pandas_multicolumn_sum_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
@@ -3576,7 +3516,6 @@ def test_pandas_result_format_in_checkpoint_one_multicolumn_map_expectation_comp
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_pandas_result_format_in_checkpoint_one_expectation_complete_output_fluent_batch_request_with_slice(
     empty_data_context: AbstractDataContext,
     reference_checkpoint_config_for_unexpected_column_names: dict,

--- a/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -180,7 +179,6 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.74s
 def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_test_yaml_config(
     monkeypatch,
@@ -287,7 +285,6 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.75s
 def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
     monkeypatch,
@@ -415,7 +412,6 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 3.10s
 def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
     monkeypatch,
@@ -589,7 +585,6 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.25s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -628,7 +623,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_with_checkpoint_name_in_meta_when_run(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     store_validation_result_action,
@@ -681,7 +675,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_with_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.15s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_with_validator_specified_in_constructor(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -711,7 +704,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.15s
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_with_validator_specified_in_run(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -744,7 +736,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 @pytest.mark.slow  # 1.19s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_result_can_be_pickled(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -776,7 +767,6 @@ def test_newstyle_checkpoint_result_can_be_pickled(
 
 @pytest.mark.slow  # 1.19s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_result_validations_include_rendered_content(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -822,7 +812,6 @@ def test_newstyle_checkpoint_result_validations_include_rendered_content(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.22s
 def test_newstyle_checkpoint_result_validations_include_rendered_content_data_context_variable(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -868,7 +857,6 @@ def test_newstyle_checkpoint_result_validations_include_rendered_content_data_co
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "checkpoint_config,expected_validation_id",
     [
@@ -1002,7 +990,6 @@ def test_checkpoint_run_adds_validation_ids_to_expectation_suite_validation_resu
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1030,7 +1017,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1058,7 +1044,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_validations_batch_request_sql_asset_in_checkpoint_run_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1090,7 +1075,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -1157,7 +1141,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_multi_validation_batch_request_sql_asset_objects_in_validations_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1198,7 +1181,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_batch_data_in_top_level_batch_request_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1229,7 +1211,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_batch_data_in_top_level_batch_request_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1260,7 +1241,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_in_top_level_batch_request_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1293,7 +1273,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_in_checkpoint_run_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1325,7 +1304,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_dataframe_asset_in_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1361,7 +1339,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_dataframe_asset_in_context_run_checkpoint_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1397,7 +1374,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_in_context_run_checkpoint_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1434,7 +1410,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_validations_batch_request_dataframe_in_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1471,7 +1446,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_validations_batch_request_dataframe_in_context_run_checkpoint_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1508,7 +1482,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_validations_batch_request_sql_asset_in_context_run_checkpoint_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1546,7 +1519,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_result_with_batch_request_dataframe_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1577,7 +1549,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_re
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_result_with_batch_request_dataframe_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1609,7 +1580,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_printable_validation_re
 
 @pytest.mark.slow  # 1.75s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_checkpoint_run_pandas(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -1686,7 +1656,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 1.75s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_checkpoint_run_spark(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -1763,7 +1732,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.35s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_checkpoint_run_pandas(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -1858,7 +1826,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.35s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_checkpoint_run_spark(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -1953,7 +1920,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 1.91s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_context_run_checkpoint_pandas(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -2030,7 +1996,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 1.91s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_context_run_checkpoint_spark(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -2107,7 +2072,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.46s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_context_run_checkpoint_pandas(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -2202,7 +2166,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 @pytest.mark.slow  # 2.46s
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_context_run_checkpoint_spark(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
     common_action_list,
@@ -2296,7 +2259,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_sql_asset_in_validations_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -80,7 +80,6 @@ def two_validations(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_default_properties_with_no_optional_arguments(
     empty_data_context,
     common_action_list,
@@ -123,7 +122,6 @@ def test_simple_checkpoint_raises_error_on_invalid_slack_webhook(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_has_slack_action_with_defaults_when_slack_webhook_is_present(
     empty_data_context,
     common_action_list,
@@ -189,7 +187,6 @@ def test_simple_checkpoint_raises_error_on_invalid_notify_with(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_notify_with_all_has_data_docs_action_with_none_specified(
     empty_data_context,
     slack_notification_action,
@@ -297,7 +294,6 @@ def test_simple_checkpoint_raises_errors_on_site_name_that_does_not_exist_on_dat
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_has_update_data_docs_action_that_should_update_selected_sites_when_sites_are_selected(
     empty_data_context,
     store_validation_result_action,
@@ -634,7 +630,6 @@ def test_simple_checkpoint_runtime_kwargs_processing_all_special_kwargs_without_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.23s
 def test_simple_checkpoint_runtime_kwargs_processing_all_kwargs(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
@@ -728,7 +723,6 @@ def test_simple_checkpoint_runtime_kwargs_processing_all_kwargs(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.50s
 def test_simple_checkpoint_defaults_run_and_basic_run_params_with_persisted_checkpoint_loaded_from_store(
     context_with_data_source_and_empty_suite,
@@ -795,7 +789,6 @@ def test_simple_checkpoint_error_with_invalid_top_level_batch_request(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.61s
 def test_simple_checkpoint_defaults_run_multiple_validations_without_persistence(
     context_with_data_source_and_empty_suite,
@@ -816,7 +809,6 @@ def test_simple_checkpoint_defaults_run_multiple_validations_without_persistence
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.62s
 def test_simple_checkpoint_defaults_run_multiple_validations_with_persisted_checkpoint_loaded_from_store(
     context_with_data_source_and_empty_suite,
@@ -846,7 +838,6 @@ def test_simple_checkpoint_defaults_run_multiple_validations_with_persisted_chec
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector_creates_config(
     context_with_data_source_and_empty_suite,
     common_action_list,
@@ -887,7 +878,6 @@ def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_batch_data_in_validations_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -926,7 +916,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_batch_data_in_validations_spark(
     data_context_with_datasource_spark_engine, common_action_list, spark_session
 ):
@@ -965,7 +954,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1006,7 +994,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1063,7 +1050,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_raise_error_when_run_when_missing_batch_request_and_validations(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1091,7 +1077,6 @@ def test_simple_checkpoint_raise_error_when_run_when_missing_batch_request_and_v
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_top_level_batch_request(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1133,7 +1118,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_top_level_batch_request_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1172,7 +1156,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_top_level_batch_request_spark(
     data_context_with_datasource_spark_engine,
     common_action_list,
@@ -1213,7 +1196,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.08s
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_top_level_batch_request_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1262,7 +1244,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_top_level_batch_request_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1311,7 +1292,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_checkpoint_run(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1352,7 +1332,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_checkpoint_run_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1391,7 +1370,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_checkpoint_run_spark(
     data_context_with_datasource_spark_engine, common_action_list, spark_session
 ):
@@ -1430,7 +1408,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_query_in_checkpoint_run(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1471,7 +1448,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_checkpoint_run_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1510,7 +1486,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_checkpoint_run_spark(
     data_context_with_datasource_spark_engine, common_action_list, spark_session
 ):
@@ -1549,7 +1524,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.06s
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_checkpoint_run_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1597,7 +1571,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_checkpoint_run_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1645,7 +1618,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.07s
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_checkpoint_run_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -1693,7 +1665,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_in_checkpoint_run_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -1741,7 +1712,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_query_in_context_run_checkpoint(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1786,7 +1756,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_context_run_checkpoint_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1829,7 +1798,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_batch_data_in_context_run_checkpoint_spark(
     data_context_with_datasource_spark_engine, common_action_list, spark_session
 ):
@@ -1872,7 +1840,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_query_in_context_run_checkpoint(
     data_context_with_datasource_sqlalchemy_engine,
     common_action_list,
@@ -1917,7 +1884,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_context_run_checkpoint_pandas(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -1960,7 +1926,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_data_in_context_run_checkpoint_spark(
     data_context_with_datasource_spark_engine, common_action_list, spark_session
 ):
@@ -2003,7 +1968,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.13s
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_context_run_checkpoint_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -2055,7 +2019,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_path_in_context_run_checkpoint_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -2107,7 +2070,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.16s
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_context_run_checkpoint_pandas(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
@@ -2159,7 +2121,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_path_in_context_run_checkpoint_spark(
     titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -2211,7 +2172,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_printable_validation_result_with_batch_data(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -2249,7 +2209,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_printable_validation_resu
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_runtime_parameters_error_contradictory_batch_request_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -2318,7 +2277,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_runtime_parameters_error_
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.73s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -2393,7 +2351,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 2.32s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_checkpoint_run(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -2482,7 +2439,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.87s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_context_run_checkpoint(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -2558,7 +2514,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 2.44s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_context_run_checkpoint(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -2649,7 +2604,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_does_not_pass_dataframes_via_batch_request_into_checkpoint_store(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -2690,7 +2644,6 @@ def test_simple_checkpoint_does_not_pass_dataframes_via_batch_request_into_check
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_does_not_pass_dataframes_via_validations_into_checkpoint_store(
     data_context_with_datasource_pandas_engine,
     common_action_list,
@@ -2731,7 +2684,6 @@ def test_simple_checkpoint_does_not_pass_dataframes_via_validations_into_checkpo
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.16s
 def test_simple_checkpoint_result_validations_include_rendered_content(
     titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -2776,7 +2728,6 @@ def test_simple_checkpoint_result_validations_include_rendered_content(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_running_spark_simplecheckpoint(
     context_with_single_csv_spark_and_suite, spark_df_taxi_data_schema
 ):
@@ -2808,7 +2759,6 @@ def test_running_spark_simplecheckpoint(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_run_spark_checkpoint_with_schema(
     context_with_single_csv_spark_and_suite,
     update_data_docs_action,

--- a/tests/checkpoint/test_simple_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_simple_checkpoint_with_fluent_datasources.py
@@ -62,7 +62,6 @@ def two_validations(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_defaults_run_and_basic_run_params_without_persisting_checkpoint(
     simple_checkpoint_defaults, one_validation
 ):
@@ -132,7 +131,6 @@ def test_simple_checkpoint_runtime_kwargs_processing_site_names_only_without_per
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.23s
 def test_simple_checkpoint_runtime_kwargs_processing_all_kwargs(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
@@ -247,7 +245,6 @@ def test_simple_checkpoint_defaults_run_with_top_level_batch_request_and_suite(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.61s
 def test_simple_checkpoint_defaults_run_multiple_validations_without_persistence(
     context_with_data_source_and_empty_suite,
@@ -270,7 +267,6 @@ def test_simple_checkpoint_defaults_run_multiple_validations_without_persistence
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.62s
 def test_simple_checkpoint_defaults_run_multiple_validations_with_persisted_checkpoint_loaded_from_store(
     context_with_data_source_and_empty_suite,
@@ -300,7 +296,6 @@ def test_simple_checkpoint_defaults_run_multiple_validations_with_persisted_chec
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_dataframe_batch_request_in_validations_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -332,7 +327,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_dataframe_batch_request_data_in_validations_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -364,7 +358,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_batch_request_sql_asset_object_in_validations_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -398,7 +391,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_batch_request_sql_asset_objects_in_validations_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -440,7 +432,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_top_level_batch_request_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -472,7 +463,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_top_level_batch_request_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -504,7 +494,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_object_in_top_level_batch_request_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -538,7 +527,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_checkpoint_run_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -570,7 +558,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_checkpoint_run_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -602,7 +589,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_object_in_checkpoint_run_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -635,7 +621,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_validations_in_checkpoint_run_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -667,7 +652,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_validations_in_checkpoint_run_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -699,7 +683,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_validations_batch_request_sql_asset_object_in_checkpoint_run_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -732,7 +715,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -768,7 +750,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_batch_request_in_context_run_checkpoint_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -804,7 +785,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_sql_asset_object_in_context_run_checkpoint_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -841,7 +821,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_validations_in_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -877,7 +856,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_dataframe_validations_in_context_run_checkpoint_sparkdf(
     titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -913,7 +891,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_validations_batch_request_sql_asset_object_in_context_run_checkpoint_sqlalchemy(
     titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoints_v1_with_empty_store_stats_enabled,
     common_action_list,
@@ -950,7 +927,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_simple_checkpoint_instantiates_and_produces_a_printable_validation_result_with_dataframe_batch_request_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_checkpoints_v1_with_templates,
     common_action_list,
@@ -981,7 +957,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_printable_validation_resu
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.73s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_dataframe_batch_request_in_checkpoint_yml_and_checkpoint_run_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -1046,7 +1021,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 2.32s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_checkpoint_run_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -1125,7 +1099,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.87s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_batch_request_in_checkpoint_yml_and_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -1191,7 +1164,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 2.44s
 def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result_validations_in_checkpoint_yml_and_context_run_checkpoint_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,
@@ -1272,7 +1244,6 @@ def test_simple_checkpoint_instantiates_and_produces_a_correct_validation_result
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 1.16s
 def test_simple_checkpoint_result_validations_include_rendered_content_pandasdf(
     titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expectation_suite_with_one_expectation,

--- a/tests/core/test_evaluation_parameters.py
+++ b/tests/core/test_evaluation_parameters.py
@@ -125,7 +125,6 @@ def test_parse_evaluation_parameter():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_query_store_results_in_evaluation_parameters(data_context_with_query_store):
     TITANIC_ROW_COUNT = 1313  # taken from the titanic db conftest
     DISTINCT_TITANIC_ROW_COUNT = 4
@@ -304,7 +303,6 @@ def test_deduplicate_evaluation_parameter_dependencies():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "dataframe,evaluation_parameters,expectation_type,expectation_kwargs,expected_expectation_validation_result",
     [

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -406,7 +406,7 @@ class TestIsEquivalentTo:
         return_value = suite_with_single_expectation.isEquivalentTo(UnsupportedClass())
         assert return_value == NotImplemented
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_classes_true_with_changes_to_non_considered_attributes(
         self, suite_with_single_expectation: ExpectationSuite
     ):
@@ -424,7 +424,7 @@ class TestIsEquivalentTo:
             suite_with_single_expectation
         )
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_classes_false(
         self, suite_with_single_expectation: ExpectationSuite
     ):
@@ -444,7 +444,7 @@ class TestIsEquivalentTo:
             suite_with_single_expectation
         )
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_classes_false_multiple_equivalent_expectations(
         self, suite_with_single_expectation: ExpectationSuite
     ):

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -347,7 +347,6 @@ def test_batch_request_deepcopy():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_checkpoint_config_deepcopy(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
     monkeypatch,
@@ -482,7 +481,6 @@ def test_checkpoint_config_deepcopy(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_checkpoint_config_print(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
     monkeypatch,
@@ -1037,7 +1035,6 @@ def test_checkpoint_config_and_nested_objects_are_serialized(
     ],
 )
 @pytest.mark.spark
-@pytest.mark.integration
 def test_checkpoint_config_and_nested_objects_are_serialized_spark(
     checkpoint_config_fixture_name: str,
     expected_serialized_checkpoint_config: dict,
@@ -1187,7 +1184,6 @@ def test_checkpoint_config_and_nested_objects_are_serialized_spark(
     ],
 )
 @pytest.mark.spark
-@pytest.mark.integration
 def test_datasource_config_and_nested_objects_are_serialized_spark(
     datasource_config: Union[DatasourceConfig, str],
     expected_serialized_datasource_config: dict,
@@ -1257,7 +1253,6 @@ def test_datasource_config_and_nested_objects_are_serialized_spark(
     ],
 )
 @pytest.mark.spark
-@pytest.mark.integration
 def test_data_connector_and_nested_objects_are_serialized_spark(
     data_connector_config: DataConnectorConfig,
     expected_serialized_data_connector_config: dict,
@@ -1324,7 +1319,6 @@ def test_data_connector_and_nested_objects_are_serialized_spark(
     ],
 )
 @pytest.mark.spark
-@pytest.mark.integration
 def test_asset_and_nested_objects_are_serialized_spark(
     asset_config: AssetConfig,
     expected_serialized_asset_config: dict,

--- a/tests/core/test_yaml_handler.py
+++ b/tests/core/test_yaml_handler.py
@@ -50,7 +50,6 @@ def test_load_incorrect_input(yaml_handler: YAMLHandler) -> None:
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_file_output(tmp_path: Path, yaml_handler: YAMLHandler) -> None:
     simplest_yaml: str = "abc: 1"
     test_file: str = os.path.join(tmp_path, "out.yaml")  # noqa: PTH118

--- a/tests/core/usage_statistics/test_package_dependencies.py
+++ b/tests/core/usage_statistics/test_package_dependencies.py
@@ -54,7 +54,6 @@ def test__get_dependency_names():
 
 
 @pytest.mark.project
-@pytest.mark.integration
 def test_required_dependency_names_match_requirements_file():
     """If there is a mismatch, GXDependencies should change to match our requirements.txt file.
 
@@ -68,7 +67,6 @@ def test_required_dependency_names_match_requirements_file():
 
 
 @pytest.mark.project
-@pytest.mark.integration
 def test_dev_dependency_names_match_requirements_file():
     """If there is a mismatch, GXDependencies should change to match our requirements-dev*.txt files.
 

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -189,7 +189,6 @@ def mocked_get_by_name_response_0_results(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_get_checkpoint_by_name(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -242,7 +241,6 @@ def test_get_checkpoint_no_identifier_raises_error(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_add_checkpoint(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -300,7 +298,6 @@ def test_cloud_backed_data_context_add_checkpoint(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_config: dict,
@@ -357,7 +354,6 @@ def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_adds(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -415,7 +411,6 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -473,7 +468,6 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_pre
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -534,7 +528,6 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_pres
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -592,7 +585,6 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_updates_when_id_not_
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_update_checkpoint_updates_when_id_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
@@ -661,7 +653,6 @@ def test_cloud_backed_data_context_update_checkpoint_updates_when_id_present(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_update_non_existent_checkpoint_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_config_with_ids: dict,
@@ -693,7 +684,6 @@ def test_cloud_backed_data_context_update_non_existent_checkpoint_when_id_not_pr
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_update_checkpoint_updates_when_id_not_present(
     empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,

--- a/tests/data_context/cloud_data_context/test_data_docs_api.py
+++ b/tests/data_context/cloud_data_context/test_data_docs_api.py
@@ -8,8 +8,6 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 )
 
 
-@pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.cloud
 def test_view_validation_result(
     empty_cloud_data_context: CloudDataContext,

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -1,4 +1,6 @@
 """This file is meant for integration tests related to datasource CRUD."""
+from __future__ import annotations
+
 import copy
 import random
 import string
@@ -8,8 +10,7 @@ from unittest import mock
 import pytest
 
 import great_expectations as gx
-from great_expectations import DataContext
-from great_expectations.data_context import BaseDataContext, CloudDataContext
+from great_expectations.data_context import CloudDataContext
 from great_expectations.data_context.types.base import (
     DatasourceConfig,
     datasourceConfigSchema,
@@ -23,8 +24,6 @@ from tests.data_context.conftest import MockResponse
 
 
 @pytest.mark.cloud
-@pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "save_changes",
     [
@@ -47,7 +46,7 @@ from tests.data_context.conftest import MockResponse
 def test_base_data_context_in_cloud_mode_add_datasource(
     save_changes: bool,
     config_includes_name_setting: str,
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     block_config_datasource_config: DatasourceConfig,
     datasource_config_with_names_and_ids: DatasourceConfig,
     fake_datasource_id: str,
@@ -61,7 +60,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
     with save_changes=True and not save when save_changes=False. When saving, it should use the id from the response
     to create the datasource."""
 
-    context: BaseDataContext = empty_base_data_context_in_cloud_mode
+    context: CloudDataContext = empty_base_data_context_in_cloud_mode
     # Make sure the fixture has the right configuration
     assert isinstance(context, CloudDataContext)
     assert len(context.list_datasources()) == 0
@@ -157,8 +156,6 @@ def test_base_data_context_in_cloud_mode_add_datasource(
 
 
 @pytest.mark.cloud
-@pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "config_includes_name_setting",
     [
@@ -173,7 +170,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
 )
 def test_data_context_in_cloud_mode_add_datasource(
     config_includes_name_setting: str,
-    empty_data_context_in_cloud_mode: DataContext,
+    empty_data_context_in_cloud_mode: CloudDataContext,
     block_config_datasource_config: DatasourceConfig,
     datasource_config_with_names_and_ids: DatasourceConfig,
     fake_datasource_id: str,
@@ -186,7 +183,7 @@ def test_data_context_in_cloud_mode_add_datasource(
     """A DataContext in cloud mode should save to the cloud backed Datasource store when calling add_datasource. When saving, it should use the id from the response
     to create the datasource."""
 
-    context: DataContext = empty_data_context_in_cloud_mode
+    context: CloudDataContext = empty_data_context_in_cloud_mode
     # Make sure the fixture has the right configuration
     assert isinstance(context, CloudDataContext)
     assert len(context.list_datasources()) == 0
@@ -273,8 +270,6 @@ def test_data_context_in_cloud_mode_add_datasource(
 
 
 @pytest.mark.cloud
-@pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "config_includes_name_setting",
     [

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -666,7 +666,7 @@ def test_add_or_update_expectation_suite_updates_existing_obj(
     mock_put.assert_called_once()  # persist resource
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_expectation_suite_include_rendered_content_prescriptive(
     empty_data_context,
 ):

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -97,7 +97,6 @@ def test_cloud_backed_data_context_add_or_update_expectation_suite_include_rende
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_cloud_backed_data_context_expectation_validation_result_include_rendered_content(
     empty_cloud_data_context: CloudDataContext,
 ) -> None:

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -97,7 +97,6 @@ def mocked_post_response(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     profiler_with_id: RuleBasedProfiler,
@@ -148,7 +147,6 @@ def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     profiler_without_id: RuleBasedProfiler,

--- a/tests/data_context/datasource/test_data_context_datasource_non_sql_methods_sparkdf_execution_engine.py
+++ b/tests/data_context/datasource/test_data_context_datasource_non_sql_methods_sparkdf_execution_engine.py
@@ -97,7 +97,7 @@ def context_with_single_titanic_csv_spark(
     return context
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_validator(context_with_single_titanic_csv_spark):
     context: AbstractDataContext = context_with_single_titanic_csv_spark
     batch_request_dict: Union[dict, BatchRequest] = {
@@ -120,7 +120,7 @@ def test_get_validator(context_with_single_titanic_csv_spark):
     assert len(my_validator.active_batch.data.dataframe.columns) == 7
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_validator_bad_batch_request(context_with_single_titanic_csv_spark):
     context: AbstractDataContext = context_with_single_titanic_csv_spark
     batch_request_dict: Union[dict, BatchRequest] = {
@@ -136,7 +136,7 @@ def test_get_validator_bad_batch_request(context_with_single_titanic_csv_spark):
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_spark_engine_inferred_assets(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -215,7 +215,7 @@ data_connectors:
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_datasource_with_runtime_data_connector(
     empty_data_context, tmp_path_factory, spark_session
 ):
@@ -271,7 +271,7 @@ data_connectors:
     assert len(batch.data.dataframe.columns) == 2
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_configured_assets_testing_query(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -370,7 +370,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_datasource_with_spark_engine_configured_assets_limit_and_filter(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -466,7 +466,7 @@ def test_get_batch_list_from_datasource_with_spark_engine_configured_assets_limi
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_datasource_with_spark_engine_configured_assets_limit_and_custom_filter_limit_param_ignored(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -581,7 +581,7 @@ def test_get_batch_list_from_datasource_with_spark_engine_configured_assets_limi
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_new_style_datasource_assets_testing_limit_in_get_batch_list_with_batch_request(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -673,7 +673,7 @@ def test_get_batch_list_from_new_style_datasource_assets_testing_limit_in_get_ba
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_datasource_schema_in_datasource_config_serialized(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):
@@ -771,7 +771,7 @@ def test_get_batch_list_from_datasource_schema_in_datasource_config_serialized(
     assert batch.data.dataframe.schema == schema_for_spark_testset
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_get_batch_list_from_datasource_schema_in_datasource_config_non_serialized(
     empty_data_context, tmp_path_factory, spark_session, schema_for_spark_testset
 ):

--- a/tests/data_context/migrator/test_file_migrator.py
+++ b/tests/data_context/migrator/test_file_migrator.py
@@ -45,7 +45,6 @@ def construct_file_migrator() -> Callable:
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_migrate_scaffolds_filesystem(
     tmp_path: pathlib.Path, file_migrator: FileMigrator
 ):
@@ -69,7 +68,6 @@ def test_migrate_scaffolds_filesystem(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_migrate_transfers_store_contents(
     tmp_path: pathlib.Path,
     construct_file_migrator: Callable,
@@ -102,7 +100,6 @@ def test_migrate_transfers_store_contents(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_migrate_transfers_datasources(
     tmp_path: pathlib.Path,
     construct_file_migrator: Callable,
@@ -140,7 +137,6 @@ def test_migrate_transfers_datasources(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_migrate_transfers_fluent_datasources(
     tmp_path: pathlib.Path,
     construct_file_migrator: Callable,
@@ -173,7 +169,6 @@ def test_migrate_transfers_fluent_datasources(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_migrate_transfers_doc_sites(
     tmp_path: pathlib.Path,
     construct_file_migrator: Callable,

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -40,7 +40,6 @@ def checkpoint_store_with_mock_backend() -> Tuple[CheckpointStore, mock.MagicMoc
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_checkpoint_store(empty_data_context):
     store_name: str = "checkpoint_store"
     base_directory: str = str(Path(empty_data_context.root_directory) / "checkpoints")
@@ -247,7 +246,6 @@ def test_checkpoint_store(empty_data_context):
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-@pytest.mark.integration
 @pytest.mark.filesystem
 def test_instantiation_with_test_yaml_config(
     mock_emit, caplog, empty_data_context_stats_enabled

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -82,7 +82,6 @@ class SampleConfigurationStore(ConfigurationStore):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_v3_configuration_store(tmp_path_factory):
     root_directory_path: str = "test_v3_configuration_store"
     root_directory: str = str(tmp_path_factory.mktemp(root_directory_path))

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.sqlalchemy_version_compatibility
 pytestmark = pytest.mark.postgresql
 
 
-@pytest.mark.integration
+@pytest.mark.postgresql
 def test_database_store_backend_schema_spec(caplog, sa, test_backends):
     if "postgresql" not in test_backends:
         pytest.skip("test_database_store_backend_get_url_for_key requires postgresql")
@@ -44,7 +44,7 @@ def test_database_store_backend_schema_spec(caplog, sa, test_backends):
         connection.execute(sa.text(f"DROP TABLE {store_backend._table};"))
 
 
-@pytest.mark.integration
+@pytest.mark.postgresql
 def test_database_store_backend_get_url_for_key(caplog, sa, test_backends):
     if "postgresql" not in test_backends:
         pytest.skip("test_database_store_backend_get_url_for_key requires postgresql")
@@ -71,7 +71,7 @@ def test_database_store_backend_get_url_for_key(caplog, sa, test_backends):
     assert "postgresql://test_ci/not_here" == store_backend.get_url_for_key(key)
 
 
-@pytest.mark.integration
+@pytest.mark.postgresql
 def test_database_store_backend_duplicate_key_violation(caplog, sa, test_backends):
     if "postgresql" not in test_backends:
         pytest.skip(
@@ -114,7 +114,7 @@ def test_database_store_backend_duplicate_key_violation(caplog, sa, test_backend
     assert "Integrity error" in str(exc.value)
 
 
-@pytest.mark.integration
+@pytest.mark.postgresql
 def test_database_store_backend_url_instantiation(caplog, sa, test_backends):
     if "postgresql" not in test_backends:
         pytest.skip("test_database_store_backend_get_url_for_key requires postgresql")
@@ -150,7 +150,7 @@ def test_database_store_backend_url_instantiation(caplog, sa, test_backends):
     assert "postgresql://test_ci/not_here" == store_backend.get_url_for_key(key)
 
 
-@pytest.mark.integration
+@pytest.mark.postgresql
 def test_database_store_backend_id_initialization(caplog, sa, test_backends):
     """
     What does this test and why?

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -171,7 +171,6 @@ def test__assert_serialized_datasource_configs_are_equal(
 
 
 @pytest.mark.unit
-@pytest.mark.integration
 def test_datasource_store_retrieval(
     empty_datasource_store: DatasourceStore,
     block_config_datasource_config: DatasourceConfig,
@@ -196,7 +195,6 @@ def test_datasource_store_retrieval(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_datasource_store_set_cloud_mode(
     block_config_datasource_config: DatasourceConfig,
     datasource_config_with_names_and_ids: DatasourceConfig,
@@ -263,7 +261,6 @@ def test_datasource_store_set_cloud_mode(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_datasource_store_with_inline_store_backend(
     block_config_datasource_config: DatasourceConfig, empty_data_context: DataContext
 ) -> None:
@@ -339,7 +336,6 @@ def test_datasource_store_set(
 
 
 @pytest.mark.unit
-@pytest.mark.integration
 def test_datasource_store_retrieve_by_name(
     fake_datasource_name,
     block_config_datasource_config: DatasourceConfig,
@@ -379,7 +375,6 @@ def test_datasource_store_delete(
 
 
 @pytest.mark.unit
-@pytest.mark.integration
 def test_datasource_store_update_by_name(
     fake_datasource_name,
     block_config_datasource_config: DatasourceConfig,
@@ -433,7 +428,6 @@ def test_datasource_store_update_raises_error_if_datasource_doesnt_exist(
 
 
 @pytest.mark.unit
-@pytest.mark.integration
 def test_datasource_store_with_inline_store_backend_config_with_names_does_not_store_datasource_name(
     datasource_config_with_names: DatasourceConfig,
     block_config_datasource_config: DatasourceConfig,
@@ -480,7 +474,6 @@ def test_datasource_store_with_inline_store_backend_config_with_names_does_not_s
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_datasource_store_with_inline_store_backend_config_with_names_does_not_store_dataconnector_name(
     datasource_config_with_names: DatasourceConfig,
     block_config_datasource_config: DatasourceConfig,

--- a/tests/data_context/store/test_evaluation_parameter_store.py
+++ b/tests/data_context/store/test_evaluation_parameter_store.py
@@ -92,7 +92,6 @@ def in_memory_param_store(request, test_backends):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_evaluation_parameter_store_methods(
     data_context_parameterized_expectation_suite: DataContext,
 ):
@@ -181,7 +180,6 @@ def test_evaluation_parameter_store_methods(
 
 
 @pytest.mark.postgresql
-@pytest.mark.integration
 def test_database_evaluation_parameter_store_basics(param_store):
     run_id = RunIdentifier(
         run_name=datetime.datetime.now(datetime.timezone.utc).strftime(
@@ -203,7 +201,6 @@ def test_database_evaluation_parameter_store_basics(param_store):
 
 
 @pytest.mark.postgresql
-@pytest.mark.integration
 def test_database_evaluation_parameter_store_store_backend_id(in_memory_param_store):
     """
     What does this test and why?
@@ -218,7 +215,6 @@ def test_database_evaluation_parameter_store_store_backend_id(in_memory_param_st
 
 @freeze_time("09/26/2019 13:42:41")
 @pytest.mark.postgresql
-@pytest.mark.integration
 def test_database_evaluation_parameter_store_get_bind_params(param_store):
     # Bind params must be expressed as a string-keyed dictionary.
     # Verify that the param_store supports that
@@ -278,7 +274,6 @@ def test_database_evaluation_parameter_store_get_bind_params(param_store):
     "great_expectations.data_context.store.tuple_store_backend.TupleStoreBackend.list_keys"
 )
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_evaluation_parameter_store_calls_proper_cloud_tuple_store_methods(
     mock_parent_list_keys,
     mock_s3_list_keys,
@@ -310,7 +305,6 @@ def test_evaluation_parameter_store_calls_proper_cloud_tuple_store_methods(
 @mock.patch(
     "great_expectations.data_context.store.tuple_store_backend.TupleStoreBackend.list_keys"
 )
-@pytest.mark.integration
 @pytest.mark.big
 def test_evaluation_parameter_store_calls_proper_azure_tuple_store_methods(
     mock_parent_list_keys,
@@ -345,7 +339,6 @@ def test_evaluation_parameter_store_calls_proper_azure_tuple_store_methods(
 @mock.patch(
     "great_expectations.data_context.store.tuple_store_backend.TupleStoreBackend.list_keys"
 )
-@pytest.mark.integration
 @pytest.mark.big
 def test_evaluation_parameter_store_calls_proper_gcs_tuple_store_methods(
     mock_parent_list_keys,
@@ -376,7 +369,6 @@ def test_evaluation_parameter_store_calls_proper_gcs_tuple_store_methods(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_instantiation_with_test_yaml_config(
     mock_emit, caplog, empty_data_context_stats_enabled
 ):

--- a/tests/data_context/store/test_evaluation_parameter_store_pre_v013.py
+++ b/tests/data_context/store/test_evaluation_parameter_store_pre_v013.py
@@ -80,7 +80,6 @@ def in_memory_param_store(request, test_backends):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_evaluation_parameter_store_methods(
     data_context_parameterized_expectation_suite_no_checkpoint_store,
 ):
@@ -169,7 +168,6 @@ def test_evaluation_parameter_store_methods(
 
 
 @pytest.mark.postgresql
-@pytest.mark.integration
 def test_database_evaluation_parameter_store_basics(param_store):
     run_id = RunIdentifier(
         run_name=datetime.datetime.now(datetime.timezone.utc).strftime(
@@ -190,7 +188,7 @@ def test_database_evaluation_parameter_store_basics(param_store):
     assert value == metric_value
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_database_evaluation_parameter_store_store_backend_id(in_memory_param_store):
     """
     What does this test and why?
@@ -205,7 +203,6 @@ def test_database_evaluation_parameter_store_store_backend_id(in_memory_param_st
 
 @freeze_time("09/26/2019 13:42:41")
 @pytest.mark.postgresql
-@pytest.mark.integration
 def test_database_evaluation_parameter_store_get_bind_params(param_store):
     # Bind params must be expressed as a string-keyed dictionary.
     # Verify that the param_store supports that

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -17,7 +17,6 @@ from tests.core.usage_statistics.util import (
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_expectations_store(empty_data_context):
     context: DataContext = empty_data_context
     my_store = ExpectationsStore()
@@ -55,7 +54,6 @@ def test_expectations_store(empty_data_context):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_ExpectationsStore_with_DatabaseStoreBackend(sa, empty_data_context):
     context: DataContext = empty_data_context
     # Use sqlite so we don't require postgres for this test.
@@ -141,7 +139,6 @@ def test_expectations_store_report_store_backend_id_in_memory_store_backend():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_expectations_store_report_same_id_with_same_configuration_TupleFilesystemStoreBackend(
     tmp_path_factory,
 ):
@@ -204,7 +201,6 @@ def test_expectations_store_report_same_id_with_same_configuration_TupleFilesyst
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_instantiation_with_test_yaml_config(
     mock_emit, caplog, empty_data_context_stats_enabled
 ):

--- a/tests/data_context/store/test_html_site_store.py
+++ b/tests/data_context/store/test_html_site_store.py
@@ -18,7 +18,6 @@ from great_expectations.util import gen_directory_tree_str
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @freeze_time("09/26/2019 13:42:41")
 def test_HtmlSiteStore_filesystem_backend(tmp_path_factory):
     full_test_dir = tmp_path_factory.mktemp(
@@ -97,7 +96,6 @@ def test_HtmlSiteStore_filesystem_backend(tmp_path_factory):
 @freeze_time("09/26/2019 13:42:41")
 @mock_s3
 @pytest.mark.big
-@pytest.mark.integration
 def test_HtmlSiteStore_S3_backend():
     bucket = "test_validation_store_bucket"
     prefix = "test/prefix"

--- a/tests/data_context/store/test_profiler_store.py
+++ b/tests/data_context/store/test_profiler_store.py
@@ -38,7 +38,6 @@ def test_profiler_store_set_adds_valid_key(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_profiler_store_integration(
     empty_data_context: DataContext,
     profiler_store_name: str,

--- a/tests/data_context/store/test_query_store.py
+++ b/tests/data_context/store/test_query_store.py
@@ -48,7 +48,6 @@ def sqlalchemy_query_store_specified_return_type(titanic_sqlite_db):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_basic_query(basic_sqlalchemy_query_store):
     assert (
         basic_sqlalchemy_query_store.get("q1") == "SELECT DISTINCT PClass FROM titanic;"
@@ -63,7 +62,6 @@ def test_basic_query(basic_sqlalchemy_query_store):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_query_connection_string(basic_sqlalchemy_query_store_connection_string):
     assert (
         basic_sqlalchemy_query_store_connection_string.get("q1")
@@ -72,7 +70,6 @@ def test_query_connection_string(basic_sqlalchemy_query_store_connection_string)
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_queries_with_return_types(sqlalchemy_query_store_specified_return_type):
     default_result = sqlalchemy_query_store_specified_return_type.get_query_result("q1")
     list_result = sqlalchemy_query_store_specified_return_type.get_query_result("q2")
@@ -99,7 +96,6 @@ def test_init_query_store_with_dict_credentials(mock_sqlalchemy):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_query_store_store_backend_id(basic_sqlalchemy_query_store):
     """
     What does this test and why?

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -208,7 +208,6 @@ def check_store_backend_store_backend_id_functionality(
 
 @pytest.mark.filesystem
 @pytest.mark.big
-@pytest.mark.integration
 @mock_s3
 def test_StoreBackend_id_initialization(tmp_path_factory):
     """
@@ -352,7 +351,6 @@ def test_StoreBackend_id_initialization(tmp_path_factory):
 
 
 @mock_s3
-@pytest.mark.integration
 @pytest.mark.big
 def test_TupleS3StoreBackend_store_backend_id():
     # TupleS3StoreBackend
@@ -412,7 +410,6 @@ def test_InMemoryStoreBackend():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_tuple_filesystem_store_filepath_prefix_error(tmp_path_factory):
     path = str(
         tmp_path_factory.mktemp("test_tuple_filesystem_store_filepath_prefix_error")
@@ -437,7 +434,6 @@ def test_tuple_filesystem_store_filepath_prefix_error(tmp_path_factory):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_FilesystemStoreBackend_two_way_string_conversion(tmp_path_factory):
     path = str(
         tmp_path_factory.mktemp(
@@ -467,7 +463,6 @@ def test_FilesystemStoreBackend_two_way_string_conversion(tmp_path_factory):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_TupleFilesystemStoreBackend(tmp_path_factory):
     path = "dummy_str"
     full_test_dir = tmp_path_factory.mktemp("test_TupleFilesystemStoreBackend__dir")
@@ -517,7 +512,6 @@ def test_TupleFilesystemStoreBackend(tmp_path_factory):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_TupleFilesystemStoreBackend_ignores_jupyter_notebook_checkpoints(
     tmp_path_factory,
 ):
@@ -556,7 +550,6 @@ def test_TupleFilesystemStoreBackend_ignores_jupyter_notebook_checkpoints(
 
 
 @mock_s3
-@pytest.mark.integration
 @pytest.mark.big
 def test_TupleS3StoreBackend_with_prefix():
     """
@@ -758,7 +751,6 @@ def test_TupleS3StoreBackend_with_prefix():
 
 
 @mock_s3
-@pytest.mark.integration
 @pytest.mark.big
 def test_tuple_s3_store_backend_slash_conditions():  # noqa: PLR0915
     bucket = "my_bucket"
@@ -949,7 +941,6 @@ def test_tuple_s3_store_backend_slash_conditions():  # noqa: PLR0915
 
 @mock_s3
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleS3StoreBackend_with_empty_prefixes():
     """
     What does this test test and why?
@@ -1008,7 +999,6 @@ def test_TupleS3StoreBackend_with_empty_prefixes():
 
 @mock_s3
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleS3StoreBackend_with_s3_put_options():
     bucket = "leakybucket"
     conn = boto3.client("s3", region_name="us-east-1")
@@ -1049,7 +1039,6 @@ def test_TupleS3StoreBackend_with_s3_put_options():
     reason="google is not installed",
 )
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleGCSStoreBackend_base_public_path():
     """
     What does this test and why?
@@ -1103,7 +1092,6 @@ def test_TupleGCSStoreBackend_base_public_path():
 )
 @pytest.mark.slow  # 1.35s
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleGCSStoreBackend():  # noqa: PLR0915
     # pytest.importorskip("google-cloud-storage")
     """
@@ -1218,7 +1206,6 @@ def test_TupleGCSStoreBackend():  # noqa: PLR0915
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleAzureBlobStoreBackend_connection_string():
     pytest.importorskip("azure.storage.blob")
     pytest.importorskip("azure.identity")
@@ -1261,7 +1248,6 @@ def test_TupleAzureBlobStoreBackend_connection_string():
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_TupleAzureBlobStoreBackend_account_url():
     pytest.importorskip("azure.storage.blob")
     pytest.importorskip("azure.identity")
@@ -1298,8 +1284,6 @@ def test_TupleAzureBlobStoreBackend_account_url():
 @mock_s3
 @pytest.mark.slow  # 14.36s
 @pytest.mark.big
-@pytest.mark.big
-@pytest.mark.integration
 def test_TupleS3StoreBackend_list_over_1000_keys():
     """
     What does this test test and why?
@@ -1365,7 +1349,6 @@ def test_TupleS3StoreBackend_list_over_1000_keys():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
     inline_store_backend: InlineStoreBackend = InlineStoreBackend(
         data_context=empty_data_context,
@@ -1475,7 +1458,6 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_InlineStoreBackend_with_mocked_fs(empty_data_context: DataContext) -> None:
     path_to_great_expectations_yml: str = os.path.join(  # noqa: PTH118
         empty_data_context.root_directory, empty_data_context.GX_YML

--- a/tests/data_context/store/test_validations_store.py
+++ b/tests/data_context/store/test_validations_store.py
@@ -26,7 +26,6 @@ from tests.core.usage_statistics.util import (
     "ignore:String run_ids are deprecated*:DeprecationWarning:great_expectations.data_context.types.resource_identifiers"
 )
 @pytest.mark.big
-@pytest.mark.integration
 def test_ValidationsStore_with_TupleS3StoreBackend():
     bucket = "test_validation_store_bucket"
     prefix = "test/prefix"
@@ -103,7 +102,6 @@ def test_ValidationsStore_with_TupleS3StoreBackend():
 
 @freeze_time("09/26/2019 13:42:41")
 @pytest.mark.big
-@pytest.mark.integration
 def test_ValidationsStore_with_InMemoryStoreBackend():
     my_store = ValidationsStore(
         store_backend={
@@ -160,7 +158,6 @@ def test_ValidationsStore_with_InMemoryStoreBackend():
 
 
 @pytest.mark.big
-@pytest.mark.integration
 @freeze_time("09/26/2019 13:42:41")
 @pytest.mark.filterwarnings(
     "ignore:String run_ids are deprecated*:DeprecationWarning:great_expectations.data_context.types.resource_identifiers"
@@ -256,7 +253,6 @@ def test_ValidationsStore_with_TupleFileSystemStoreBackend(tmp_path_factory):
     "ignore:String run_ids are deprecated*:DeprecationWarning:great_expectations.data_context.types.resource_identifiers"
 )
 @pytest.mark.big
-@pytest.mark.integration
 def test_ValidationsStore_with_DatabaseStoreBackend(sa):
     # Use sqlite so we don't require postgres for this test.
     connection_kwargs = {"drivername": "sqlite"}
@@ -320,7 +316,6 @@ def test_ValidationsStore_with_DatabaseStoreBackend(sa):
     "ignore:String run_ids are deprecated*:DeprecationWarning:great_expectations.data_context.types.resource_identifiers"
 )
 @pytest.mark.big
-@pytest.mark.integration
 def test_instantiation_with_test_yaml_config(
     mock_emit, caplog, empty_data_context_stats_enabled
 ):

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -211,7 +211,6 @@ def test_save_expectation_suite(data_context_parameterized_expectation_suite):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_save_expectation_suite_include_rendered_content(
     data_context_parameterized_expectation_suite,
 ):
@@ -245,7 +244,6 @@ def test_save_expectation_suite_include_rendered_content(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_get_expectation_suite_include_rendered_content(
     data_context_parameterized_expectation_suite,
 ):
@@ -1495,7 +1493,6 @@ def test_get_checkpoint(empty_context_with_checkpoint):
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_run_checkpoint_new_style(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
 ):
@@ -2849,7 +2846,6 @@ def test_modifications_to_config_vars_is_recognized_within_same_program_executio
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_check_for_usage_stats_sync_finds_diff(
     empty_data_context_stats_enabled: DataContext,
     data_context_config_with_datasources: DataContextConfig,
@@ -2869,7 +2865,6 @@ def test_check_for_usage_stats_sync_finds_diff(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_check_for_usage_stats_sync_does_not_find_diff(
     empty_data_context_stats_enabled: DataContext,
 ) -> None:
@@ -2888,7 +2883,6 @@ def test_check_for_usage_stats_sync_does_not_find_diff(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_check_for_usage_stats_sync_short_circuits_due_to_disabled_usage_stats(
     empty_data_context: DataContext,
     data_context_config_with_datasources: DataContextConfig,
@@ -2929,7 +2923,6 @@ class ExpectSkyToBeColor(BatchExpectation):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_unrendered_and_failed_prescriptive_renderer_behavior(
     empty_data_context: DataContext,
 ):

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -417,7 +417,6 @@ def test_get_site_names_with_three_sites(tmpdir, basic_data_context_config):
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_view_validation_result(
     checkpoint_result: CheckpointResult,
 ):

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -56,7 +56,6 @@ def pandas_enabled_datasource_config() -> dict:
     return config
 
 
-@pytest.mark.integration
 @pytest.mark.cloud
 def test_data_context_instantiates_gx_cloud_store_backend_with_cloud_config(
     tmp_path: pathlib.Path,
@@ -82,7 +81,6 @@ def test_data_context_instantiates_gx_cloud_store_backend_with_cloud_config(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_data_context_instantiates_inline_store_backend_with_filesystem_config(
     tmp_path: pathlib.Path,
     data_context_config_with_datasources: DataContextConfig,
@@ -462,7 +460,6 @@ def test_list_datasources() -> None:
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_get_available_data_assets_names(empty_data_context) -> None:
     datasource_name = "my_fluent_pandas_datasource"
     datasource = empty_data_context.sources.add_pandas(datasource_name)

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -1517,7 +1517,6 @@ def test_test_yaml_config_supported_types_have_self_check():
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_test_yaml_config_on_datasource_sanitizes_instantiated_objs_config(
     empty_data_context_stats_enabled,
     monkeypatch,
@@ -1563,7 +1562,6 @@ data_connectors:
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_test_yaml_config_on_datasources_persists_object_id(
     empty_data_context_stats_enabled,
 ):

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -527,7 +527,6 @@ def test_data_context_variables_repr_and_str_only_reveal_config(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 def test_file_data_context_variables_e2e(
     monkeypatch,
     file_data_context: FileDataContext,

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -264,7 +264,6 @@ def test_cloud_context_include_rendered_content(
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 def test_get_context_with_context_root_dir_scaffolds_filesystem(tmp_path: pathlib.Path):
     root = tmp_path / "root"
     context_root_dir = root.joinpath("great_expectations")

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -26,7 +26,6 @@ yaml = YAMLHandler()
 
 
 @pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.slow  # 1.05s
 def test__get_full_file_path_for_asset_pandas(fs: FakeFilesystem):
     """
@@ -142,7 +141,6 @@ def test__get_full_file_path_for_asset_pandas(fs: FakeFilesystem):
 
 
 @pytest.mark.spark
-@pytest.mark.integration
 def test__get_full_file_path_for_asset_spark(basic_spark_df_execution_engine, fs):
     """
     What does this test and why?

--- a/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.big
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test__get_full_file_path_pandas(fs: FakeFilesystem):
     """
     What does this test and why?
@@ -94,7 +94,7 @@ def test__get_full_file_path_pandas(fs: FakeFilesystem):
     assert batch_spec.path == f"{base_directory}/path/A-100.csv"
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test__get_full_file_path_spark(basic_spark_df_execution_engine, fs):
     """
     What does this test and why?

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -1895,7 +1895,6 @@ def test_full_config_instantiation_and_execution_of_InferredAssetSqlDataConnecto
 
 
 @pytest.mark.sqlite
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "splitter_method,splitter_kwargs,table_name,first_3_batch_identifiers_expected,last_3_batch_identifiers_expected",
     [
@@ -2066,7 +2065,6 @@ def test_ConfiguredAssetSqlDataConnector_sorting(
 
 
 @pytest.mark.sqlite
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "data_connector_yaml,expected_batch_identifiers_list",
     [
@@ -2157,7 +2155,6 @@ def test_ConfiguredAssetSqlDataConnector_return_all_batch_definitions_sorted(
 
 
 @pytest.mark.sqlite
-@pytest.mark.integration
 def test_introspect_db(
     test_cases_for_sql_data_connector_sqlite_execution_engine,
 ):
@@ -2480,7 +2477,6 @@ def test_introspect_db(
 
 
 @pytest.mark.mysql
-@pytest.mark.integration
 def test_include_schema_name_introspection(mysql_engine):
     execution_engine = SqlAlchemyExecutionEngine(
         name="test_sql_execution_engine",
@@ -2523,7 +2519,6 @@ def test_include_schema_name_introspection(mysql_engine):
 
 
 @pytest.mark.mysql
-@pytest.mark.integration
 def test_include_schema_name_get_available_data_assets(
     mysql_engine,
 ):

--- a/tests/datasource/fluent/data_asset/data_connector/test_azure_blob_storage_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_azure_blob_storage_data_connector.py
@@ -312,7 +312,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
 
 
 # TODO: <Alex>ALEX-UNCOMMENT_WHEN_SORTERS_ARE_INCLUDED_AND_TEST_SORTED_BATCH_DEFINITION_LIST</Alex>
-# @pytest.mark.integration
+# @pytest.mark.big
 # @mock.patch(
 #     "great_expectations.datasource.fluent.data_asset.data_connector.azure_blob_storage_data_connector.list_azure_keys"
 # )

--- a/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
@@ -296,7 +296,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
 
 # TODO: <Alex>ALEX-UNCOMMENT_WHEN_SORTERS_ARE_INCLUDED_AND_TEST_SORTED_BATCH_DEFINITION_LIST</Alex>
 # TODO: <Alex>ALEX</Alex>
-# @pytest.mark.integration
+# @pytest.mark.big
 # @pytest.mark.slow  # creating small number of`file handles in temporary file system
 # def test_return_all_batch_definitions_sorted(tmp_path_factory):
 #     base_directory = str(

--- a/tests/datasource/fluent/data_asset/data_connector/test_google_cloud_storage_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_google_cloud_storage_data_connector.py
@@ -306,7 +306,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
 
 
 # TODO: <Alex>ALEX-UNCOMMENT_WHEN_SORTERS_ARE_INCLUDED_AND_TEST_SORTED_BATCH_DEFINITION_LIST</Alex>
-# @pytest.mark.integration
+# @pytest.mark.big
 # @mock.patch(
 #     "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 # )

--- a/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
@@ -325,7 +325,7 @@ def test_return_all_batch_definitions_unsorted():
 
 # TODO: <Alex>ALEX-UNCOMMENT_WHEN_SORTERS_ARE_INCLUDED_AND_TEST_SORTED_BATCH_DEFINITION_LIST</Alex>
 # TODO: <Alex>ALEX</Alex>
-# @pytest.mark.integration
+# @pytest.mark.big
 # @mock_s3
 # def test_return_all_batch_definitions_sorted():
 #     region_name: str = "us-east-1"
@@ -815,7 +815,7 @@ def test_foxtrot():
 
 # TODO: <Alex>ALEX-UNCOMMENT_WHEN_SORTERS_ARE_INCLUDED_AND_TEST_SORTED_BATCH_DEFINITION_LIST</Alex>
 # TODO: <Alex>ALEX</Alex>
-# @pytest.mark.integration
+# @pytest.mark.big
 # @mock_s3
 # def test_return_all_batch_definitions_sorted_sorter_named_that_does_not_match_group(
 #     tmp_path_factory,

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -948,7 +948,7 @@ def test_spark_with_batch_spec_passthrough(tmp_path_factory, spark_session):
     assert batch[0].data.dataframe.head() == pyspark.Row(x="1", y="2")
 
 
-@pytest.mark.integration
+@pytest.mark.spark
 def test_spark_with_batch_spec_passthrough_and_schema_in_batch_request(
     tmp_path_factory, spark_session, spark_df_taxi_data_schema
 ):
@@ -1013,7 +1013,7 @@ def test_spark_with_batch_spec_passthrough_and_schema_in_batch_request(
     assert batch_list[0].data.dataframe.schema == spark_df_taxi_data_schema
 
 
-@pytest.mark.integration
+@pytest.mark.spark
 def test_spark_with_batch_spec_passthrough_and_schema_in_datasource_config(
     tmp_path_factory, spark_session, spark_df_taxi_data_schema
 ):

--- a/tests/datasource/test_new_datasource_with_sql_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_sql_data_connector.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import random
@@ -9,10 +11,10 @@ from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations import DataContext
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.yaml_handler import YAMLHandler
+from great_expectations.data_context import FileDataContext
 from great_expectations.data_context.util import (
     file_relative_path,
     instantiate_class_from_config,
@@ -57,7 +59,7 @@ def data_context_with_sql_data_connectors_including_schema_for_testing_get_batch
     empty_data_context,
     test_db_connection_string,
 ):
-    context: DataContext = empty_data_context
+    context: FileDataContext = empty_data_context
 
     sqlite_engine: sa.engine.base.Engine = sa.create_engine(test_db_connection_string)
     # noinspection PyUnusedLocal
@@ -198,7 +200,7 @@ def test_instantiation_with_ConfiguredAssetSqlDataConnector_round_trip_to_config
     # This is a basic integration test demonstrating a Datasource containing a SQL data_connector.
     # It tests that splitter configurations can be saved and loaded to great_expectations.yml by performing a
     # round-trip to the configuration.
-    context: DataContext = empty_data_context
+    context: FileDataContext = empty_data_context
     db_file: Union[bytes, str] = file_relative_path(
         __file__,
         os.path.join(  # noqa: PTH118
@@ -361,7 +363,7 @@ def test_instantiation_with_InferredAssetSqlDataConnector_round_trip_to_config_s
     # This is a basic integration test demonstrating a Datasource containing a SQL data_connector.
     # It tests that splitter configurations can be saved and loaded to great_expectations.yml by performing a
     # round-trip to the configuration.
-    context: DataContext = empty_data_context
+    context: FileDataContext = empty_data_context
     db_file: Union[bytes, str] = file_relative_path(
         __file__,
         os.path.join(  # noqa: PTH118
@@ -854,11 +856,11 @@ introspection:
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_batch_request_sql_with_schema(
     data_context_with_sql_data_connectors_including_schema_for_testing_get_batch,
 ):
-    context: DataContext = (
+    context: FileDataContext = (
         data_context_with_sql_data_connectors_including_schema_for_testing_get_batch
     )
 

--- a/tests/execution_engine/split_and_sample/test_pandas_execution_engine_splitting.py
+++ b/tests/execution_engine/split_and_sample/test_pandas_execution_engine_splitting.py
@@ -98,7 +98,6 @@ def batch_with_split_on_whole_table_s3(test_s3_files) -> S3BatchSpec:
 
 
 @pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "splitter_kwargs_year,num_values_in_df",
     [
@@ -128,7 +127,6 @@ def test_get_batch_with_split_on_year(
 
 
 @pytest.mark.big
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "column_batch_identifier,num_values_in_df",
     [

--- a/tests/execution_engine/split_and_sample/test_sparkdf_execution_engine_splitting.py
+++ b/tests/execution_engine/split_and_sample/test_sparkdf_execution_engine_splitting.py
@@ -68,7 +68,6 @@ def simple_multi_year_spark_df(spark_session):
     return spark_df
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "splitter_kwargs_year,num_values_in_df",
     [
@@ -97,7 +96,6 @@ def test_get_batch_with_split_on_year(
     assert len(split_df.columns) == 2
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "column_batch_identifier,num_values_in_df",
     [
@@ -133,7 +131,6 @@ def test_get_batch_with_split_on_date_parts_day(
     assert len(split_df.columns) == 2
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "batch_identifiers_for_column",
     SINGLE_DATE_PART_BATCH_IDENTIFIERS,

--- a/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_sampling.py
+++ b/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_sampling.py
@@ -255,7 +255,6 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(
     assert query_str == expected
 
 
-@pytest.mark.integration
 def test_sqlite_sample_using_limit(sa):
     csv_path: str = file_relative_path(
         os.path.dirname(os.path.dirname(__file__)),  # noqa: PTH120

--- a/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_splitting.py
+++ b/tests/execution_engine/split_and_sample/test_sqlalchemy_execution_engine_splitting.py
@@ -308,7 +308,6 @@ def test_get_split_query_for_data_for_batch_identifiers_for_split_on_date_parts_
     )
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "date_parts",
     MULTIPLE_DATE_PART_DATE_PARTS,
@@ -419,7 +418,6 @@ def in_memory_sqlite_taxi_ten_trips_per_month_execution_engine(sa):
     return engine
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "taxi_test_cases",
     [
@@ -557,7 +555,6 @@ def test_sqlite_split(
         assert num_rows == test_case.num_expected_rows_in_first_batch_definition
 
 
-@pytest.mark.integration
 def test_sqlite_split_on_year(
     sa, in_memory_sqlite_taxi_ten_trips_per_month_execution_engine
 ):
@@ -601,7 +598,6 @@ def test_sqlite_split_on_year(
         assert row_date.year == 2018
 
 
-@pytest.mark.integration
 def test_sqlite_split_and_sample_using_limit(
     sa, in_memory_sqlite_taxi_ten_trips_per_month_execution_engine
 ):

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -37,7 +37,6 @@ def test_reader_fn(spark_session, basic_spark_df_execution_engine):
     assert "<bound method DataFrameReader.csv" in str(fn_new)
 
 
-@pytest.mark.integration
 def test_reader_fn_parameters(
     spark_session, basic_spark_df_execution_engine, tmp_path_factory
 ):
@@ -1177,7 +1176,6 @@ def test_dataframe_property_given_loaded_batch(spark_session):
     assert engine.dataframe == df
 
 
-@pytest.mark.integration
 def test_schema_properly_added(spark_session):
     schema: pyspark.types.StructType = pyspark.types.StructType(
         [

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -97,7 +97,6 @@ def test_instantiation_via_url(sa):
     )
 
 
-@pytest.mark.integration
 def test_instantiation_via_url_and_retrieve_data_with_other_dialect(sa):
     """Ensure that we can still retrieve data when the dialect is not recognized."""
 

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -321,7 +321,7 @@ def test_sa_unexpected_index_query_metric_without_id_pk(sa, animal_table_df):
         )
 
 
-@pytest.mark.integration
+@pytest.mark.spark
 def test_spark_unexpected_index_list_metric_with_id_pk(
     spark_session, animal_table_df, metric_value_kwargs_complete
 ):
@@ -355,7 +355,7 @@ def test_spark_unexpected_index_list_metric_with_id_pk(
         ]
 
 
-@pytest.mark.integration
+@pytest.mark.spark
 def test_spark_unexpected_index_list_metric_without_id_pk(
     spark_session, animal_table_df
 ):
@@ -393,7 +393,7 @@ def test_spark_unexpected_index_list_metric_without_id_pk(
     assert list(results.values())[0] is None
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_pd_unexpected_index_query_metric_with_id_pk(
     animal_table_df, metric_value_kwargs_complete
 ):
@@ -422,7 +422,7 @@ def test_pd_unexpected_index_query_metric_with_id_pk(
         assert val == "df.filter(items=[3, 4, 5], axis=0)"
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_pd_unexpected_index_query_metric_without_id_pk(
     animal_table_df,
 ):
@@ -459,7 +459,7 @@ def test_pd_unexpected_index_query_metric_without_id_pk(
         assert val == "df.filter(items=[3, 4, 5], axis=0)"
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_spark_unexpected_index_query_metric_with_id_pk(
     spark_session, animal_table_df, metric_value_kwargs_complete
 ):
@@ -492,7 +492,7 @@ def test_spark_unexpected_index_query_metric_with_id_pk(
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_spark_unexpected_index_query_metric_without_id_pk(
     spark_session, animal_table_df, metric_value_kwargs_complete
 ):

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -4436,7 +4436,7 @@ def test_column_median_metric_spark(spark_session):
     assert results == {desired_metric.id: 2}
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_value_counts_metric_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
 
@@ -4464,7 +4464,7 @@ def test_value_counts_metric_pd():
     assert pd.Series(index=[1, 2, 3], data=[2, 2, 2]).equals(metrics[desired_metric.id])
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_value_counts_metric_sa(sa):
     engine = build_sa_execution_engine(
         pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]}), sa
@@ -4494,7 +4494,7 @@ def test_value_counts_metric_sa(sa):
     ).equals(metrics[desired_metric_b.id])
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_value_counts_metric_spark(spark_session):
     engine: SparkDFExecutionEngine = build_spark_engine(
         spark=spark_session,
@@ -4534,7 +4534,7 @@ def test_value_counts_metric_spark(spark_session):
     assert pd.Series(index=[], data=[]).equals(metrics[desired_metric.id])
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.parametrize(
     "dataframe",
     [
@@ -4627,7 +4627,7 @@ def test_distinct_metric_spark(
     assert metrics[column_distinct_values_count_threshold_metric.id] is True
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_distinct_metric_sa(
     sa,
 ):
@@ -4715,7 +4715,7 @@ def test_distinct_metric_sa(
     assert metrics[column_distinct_values_count_threshold_metric.id] is True
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_distinct_metric_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
 

--- a/tests/integration/docusaurus/connecting_to_your_data/datasource_configuration/how_to_configure_a_spark_datasource.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/datasource_configuration/how_to_configure_a_spark_datasource.py
@@ -13,7 +13,7 @@ the snippets that are specified for use in documentation are maintained.  These 
 
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_configure_a_spark_datasource" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_configure_a_spark_datasource" tests/integration/test_script_runner.py
 ```
 
 To validate the snippets in this file, use the following console command:

--- a/tests/integration/docusaurus/connecting_to_your_data/datasource_configuration/how_to_configure_a_sql_datasource.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/datasource_configuration/how_to_configure_a_sql_datasource.py
@@ -13,7 +13,7 @@ the snippets that are specified for use in documentation are maintained.  These 
 
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_configure_a_sql_datasource" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_configure_a_sql_datasource" tests/integration/test_script_runner.py
 ```
 
 To validate the snippets in this file, use the following console command:

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_a_sql_table.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_a_sql_table.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_a_sql_table" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_a_sql_table" tests/integration/test_script_runner.py
 ```
 """
 import tests.test_utils as test_utils

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_azure_blob_storage_using_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_azure_blob_storage_using_pandas" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_azure_blob_storage_using_spark" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_azure_blob_storage_using_spark" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_gcs_using_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_gcs_using_pandas" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_gcs_using_spark.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_gcs_using_spark" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_gcs_using_spark" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_s3_using_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_s3_using_pandas" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_spark.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_data_on_s3_using_spark.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_data_on_s3_using_spark" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_data_on_s3_using_spark" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_in_memory_data_using_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_in_memory_data_using_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_in_memory_data_using_pandas" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_one_or_more_files_using_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_one_or_more_files_using_pandas" tests/integration/test_script_runner.py
 ```
 """
 import pathlib

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_spark.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_spark.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_one_or_more_files_using_spark" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_one_or_more_files_using_spark" tests/integration/test_script_runner.py
 ```
 """
 import pathlib

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_postgresql_data.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_postgresql_data.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_postgresql_data" tests/integration/test_script_runner.py --postgresql
+pytest -v --docs-tests -k "how_to_connect_to_postgresql_data" tests/integration/test_script_runner.py --postgresql
 ```
 """
 import tests.test_utils as test_utils

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_sql_data" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_sql_data" tests/integration/test_script_runner.py
 ```
 """
 import pathlib

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data_using_a_query.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data_using_a_query.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_sql_data_using_a_query" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_sql_data_using_a_query" tests/integration/test_script_runner.py
 ```
 """
 import tests.test_utils as test_utils

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sqlite_data.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sqlite_data.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_connect_to_sqlite_data" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_connect_to_sqlite_data" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_explicitly_instantiate_an_ephemeral_data_context.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_explicitly_instantiate_an_ephemeral_data_context.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_explicitly_instantiate_an_ephemeral_data_context" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_explicitly_instantiate_an_ephemeral_data_context" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_initialize_a_filesystem_data_context_in_python.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_initialize_a_filesystem_data_context_in_python.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_initialize_a_filesystem_data_context_in_python" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_initialize_a_filesystem_data_context_in_python" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_instantiate_a_specific_filesystem_data_context.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_instantiate_a_specific_filesystem_data_context.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_instantiate_a_specific_filesystem_data_context" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_instantiate_a_specific_filesystem_data_context" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_quickly_connect_to_a_single_file_with_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_quickly_connect_to_a_single_file_with_pandas.py
@@ -1,7 +1,7 @@
 """
 To run this code as a local test, use the following console command:
 ```
-pytest -v --docs-tests -m integration -k "how_to_quickly_connect_to_a_single_file_with_pandas" tests/integration/test_script_runner.py
+pytest -v --docs-tests -k "how_to_quickly_connect_to_a_single_file_with_pandas" tests/integration/test_script_runner.py
 ```
 """
 

--- a/tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
+++ b/tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
@@ -9,7 +9,7 @@ GE_TEST_BIGQUERY_DATASET
 
 Then run the following command from the great_expectations directory:
 ```
-GE_TEST_GCP_PROJECT=<YOUR GCP PROJECT> GE_TEST_BIGQUERY_DATASET=<YOUR BIGQUERY DATASET> pytest -v --docs-tests -m integration -k "how_to_host_and_share_data_docs_on_gcs" tests/integration/test_script_runner.py --bigquery
+GE_TEST_GCP_PROJECT=<YOUR GCP PROJECT> GE_TEST_BIGQUERY_DATASET=<YOUR BIGQUERY DATASET> pytest -v --docs-tests -k "how_to_host_and_share_data_docs_on_gcs" tests/integration/test_script_runner.py --bigquery
 ```
 """
 import os

--- a/tests/integration/integration_test_fixture.py
+++ b/tests/integration/integration_test_fixture.py
@@ -11,7 +11,7 @@ class IntegrationTestFixture:
     Configurations for integration tests are defined as IntegrationTestFixture dataclass objects.
 
     Individual tests can also be run by setting the '-k' flag and referencing the name of test, like the following example:
-    pytest -v --docs-tests -m integration -k "test_docs[migration_guide_spark_v2_api]" tests/integration/test_script_runner.py
+    pytest -v --docs-tests -k "test_docs[migration_guide_spark_v2_api]" tests/integration/test_script_runner.py
 
     Args:
         name: Name for integration test. Individual tests can be run by using the -k option and specifying the name of the test.

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -181,7 +181,6 @@ def quentin_validator(
 
 @pytest.mark.slow  # 1.15s
 @pytest.mark.big
-@pytest.mark.integration
 def test_alice_columnar_table_single_batch_batches_are_accessible(
     alice_columnar_table_single_batch_context,
     alice_columnar_table_single_batch,
@@ -238,7 +237,6 @@ def test_alice_columnar_table_single_batch_batches_are_accessible(
 )
 @pytest.mark.slow  # 2.31s
 @pytest.mark.big
-@pytest.mark.integration
 def test_alice_profiler_user_workflow_single_batch(
     mock_emit,
     caplog,
@@ -421,7 +419,6 @@ def test_alice_profiler_user_workflow_single_batch(
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 0.86s
 @pytest.mark.big
-@pytest.mark.integration
 def test_alice_expect_column_values_to_match_regex_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -497,7 +494,6 @@ def test_alice_expect_column_values_to_not_match_regex_auto_yes_default_profiler
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.38s
 @pytest.mark.big
-@pytest.mark.integration
 def test_alice_expect_column_values_to_match_stftime_format_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -529,7 +525,6 @@ def test_alice_expect_column_values_to_match_stftime_format_auto_yes_default_pro
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.26s
 @pytest.mark.big
-@pytest.mark.integration
 def test_alice_expect_column_value_lengths_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -564,7 +559,6 @@ def test_alice_expect_column_value_lengths_to_be_between_auto_yes_default_profil
 # noinspection PyUnusedLocal
 @pytest.mark.slow  # 1.16s
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobby_columnar_table_multi_batch_batches_are_accessible(
     monkeypatch,
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -642,7 +636,6 @@ def test_bobby_columnar_table_multi_batch_batches_are_accessible(
 )
 @pytest.mark.slow  # 13.08s
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_column_ranges_rule_quantiles_estimator(
     mock_emit,
     caplog,
@@ -918,7 +911,6 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
 )
 @freeze_time(TIMESTAMP)
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     bobby_validator: Validator,
     set_consistent_seed_within_numeric_metric_range_multi_batch_parameter_builder,
@@ -1067,7 +1059,6 @@ def restore_profiler_config(
 )
 @freeze_time(TIMESTAMP)
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_yes(
     bobby_columnar_table_multi_batch_deterministic_data_context,
     bobby_validator: Validator,
@@ -1295,7 +1286,6 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
 )
 @freeze_time(TIMESTAMP)
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_no_custom_profiler_config_yes(
     bobby_columnar_table_multi_batch_deterministic_data_context,
     bobby_validator: Validator,
@@ -1564,7 +1554,6 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
 )
 @pytest.mark.slow  # 4.83s
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstrap_estimator(
     mock_emit,
     caplog,
@@ -1694,7 +1683,6 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 4.24s
 @pytest.mark.big
-@pytest.mark.integration
 def test_bobster_expect_table_row_count_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     bobster_validator: Validator,
 ):
@@ -1715,7 +1703,6 @@ def test_bobster_expect_table_row_count_to_be_between_auto_yes_default_profiler_
     reason="requires numpy version 1.21.0 or newer",
 )
 @pytest.mark.slow  # 2.02s
-@pytest.mark.integration
 def test_quentin_expect_expect_table_columns_to_match_set_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):
@@ -1778,7 +1765,6 @@ def test_quentin_expect_expect_table_columns_to_match_set_auto_yes_default_profi
 )
 @pytest.mark.slow  # 15.07s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
     mock_emit,
     caplog,
@@ -1928,7 +1914,6 @@ def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.40s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_yes(
     quentin_validator: Validator,
 ):
@@ -2116,7 +2101,6 @@ def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_pr
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.15s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_values_to_be_in_set_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):
@@ -2160,7 +2144,6 @@ def test_quentin_expect_column_values_to_be_in_set_auto_yes_default_profiler_con
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 3.44s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_min_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):
@@ -2203,7 +2186,6 @@ def test_quentin_expect_column_min_to_be_between_auto_yes_default_profiler_confi
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.12s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):
@@ -2271,7 +2253,6 @@ def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_confi
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.24s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_unique_value_count_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ) -> None:
@@ -2327,7 +2308,6 @@ def test_quentin_expect_column_unique_value_count_to_be_between_auto_yes_default
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.67s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_proportion_of_unique_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ) -> None:
@@ -2386,7 +2366,6 @@ def test_quentin_expect_column_proportion_of_unique_values_to_be_between_auto_ye
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.26s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_sum_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ) -> None:
@@ -2445,7 +2424,6 @@ def test_quentin_expect_column_sum_to_be_between_auto_yes_default_profiler_confi
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.29s
 @pytest.mark.big
-@pytest.mark.integration
 def test_quentin_expect_column_stdev_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):

--- a/tests/integration/test_definitions/multiple_backend/integration_tests.py
+++ b/tests/integration/test_definitions/multiple_backend/integration_tests.py
@@ -29,7 +29,7 @@ deployment_patterns = [
 
 cross_table_comparisons = [
     IntegrationTestFixture(
-        # Run locally via `pytest -v --mysql --postgresql --docs-tests -m integration -k "test_docs[cross_table_comparisons]" tests/integration/test_script_runner.py`
+        # Run locally via `pytest -v --mysql --postgresql --docs-tests -k "test_docs[cross_table_comparisons]" tests/integration/test_script_runner.py`
         name="cross_table_comparisons",
         user_flow_script="tests/integration/docusaurus/expectations/advanced/data_assistant_cross_table_comparison.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -64,6 +64,8 @@ from tests.integration.test_definitions.trino.integration_tests import (
     trino_integration_tests,
 )
 
+pytestmark = pytest.mark.docs
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -486,8 +488,6 @@ def pytest_parsed_arguments(request):
     return request.config.option
 
 
-@pytest.mark.docs
-@pytest.mark.integration
 @pytest.mark.parametrize("integration_test_fixture", docs_test_matrix, ids=idfn)
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 def test_docs(integration_test_fixture, tmp_path, pytest_parsed_arguments):
@@ -495,7 +495,6 @@ def test_docs(integration_test_fixture, tmp_path, pytest_parsed_arguments):
     _execute_integration_test(integration_test_fixture, tmp_path)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("test_configuration", integration_test_matrix, ids=idfn)
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 @pytest.mark.slow  # 79.77s

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -1,7 +1,7 @@
 """Run integration and docs tests.
 
 Individual tests can be run by setting the '-k' flag and referencing the name of test, like the following example:
-    pytest -v --docs-tests -m integration -k "test_docs[quickstart]" tests/integration/test_script_runner.py
+    pytest -v --docs-tests -k "test_docs[quickstart]" tests/integration/test_script_runner.py
 """
 
 import importlib.machinery

--- a/tests/rule_based_profiler/data_assistant/test_column_value_missing_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_column_value_missing_data_assistant.py
@@ -36,7 +36,7 @@ def test_column_value_missing_data_assistant_result_plot_expectations_and_metric
     assert len(column_domain_charts) == 0
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow
 def test_single_batch_multiple_columns(ephemeral_context_with_defaults):
     context = ephemeral_context_with_defaults

--- a/tests/rule_based_profiler/data_assistant/test_data_assistant_runner.py
+++ b/tests/rule_based_profiler/data_assistant/test_data_assistant_runner.py
@@ -11,7 +11,7 @@ from great_expectations.rule_based_profiler.data_assistant_result import (
 )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_runner_top_level_kwargs_allowed(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
 ):
@@ -46,7 +46,7 @@ def test_onboarding_data_assistant_runner_top_level_kwargs_allowed(
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_runner_top_level_kwargs_override(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
 ):
@@ -70,7 +70,7 @@ def test_onboarding_data_assistant_runner_top_level_kwargs_override(
     assert not any([column_name.endswith("ID") for column_name in columns_used])
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_runner_top_level_kwargs_explicit_none(
     data_context_with_datasource_pandas_engine,
 ):

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -213,7 +213,7 @@ def run_onboarding_data_assistant_result_jupyter_notebook_with_new_cell(
     ep.preprocess(nb, {"metadata": {"path": root_dir}})
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 6.90s
 def test_onboarding_data_assistant_result_serialization(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -232,7 +232,7 @@ def test_onboarding_data_assistant_result_serialization(
     assert len(bobby_onboarding_data_assistant_result.profiler_config.rules) == 8
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
@@ -259,7 +259,7 @@ def test_onboarding_data_assistant_result_get_expectation_suite(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_metrics_count(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ) -> None:
@@ -291,7 +291,7 @@ def test_onboarding_data_assistant_metrics_count(
     assert num_metrics == 300
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_result_batch_id_to_batch_identifier_display_name_map_coverage(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ):
@@ -317,7 +317,7 @@ def test_onboarding_data_assistant_result_batch_id_to_batch_identifier_display_n
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 39.26s
 def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_invocation_with_variables_directives(
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -399,7 +399,7 @@ def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_i
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 38.26s
 def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_invocation_with_estimation_directive(
     quentin_columnar_table_multi_batch_data_context,
@@ -427,7 +427,7 @@ def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_i
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 25.61s
 def test_onboarding_data_assistant_plot_descriptive_notebook_execution_fails(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -453,7 +453,7 @@ def test_onboarding_data_assistant_plot_descriptive_notebook_execution_fails(
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 28.73s
 def test_onboarding_data_assistant_plot_descriptive_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -475,7 +475,7 @@ def test_onboarding_data_assistant_plot_descriptive_notebook_execution(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 36.23s
 def test_onboarding_data_assistant_plot_prescriptive_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -497,7 +497,7 @@ def test_onboarding_data_assistant_plot_prescriptive_notebook_execution(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 27.95s
 def test_onboarding_data_assistant_plot_descriptive_theme_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -521,7 +521,7 @@ def test_onboarding_data_assistant_plot_descriptive_theme_notebook_execution(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 35.34s
 def test_onboarding_data_assistant_plot_prescriptive_theme_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -547,7 +547,7 @@ def test_onboarding_data_assistant_plot_prescriptive_theme_notebook_execution(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 2.02s
 def test_onboarding_data_assistant_plot_returns_proper_dict_repr_of_table_domain_chart(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -558,7 +558,7 @@ def test_onboarding_data_assistant_plot_returns_proper_dict_repr_of_table_domain
     assert find_strings_in_nested_obj(table_domain_chart, ["Table Row Count per Batch"])
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 3.42s
 def test_onboarding_data_assistant_plot_returns_proper_dict_repr_of_column_domain_chart(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -583,7 +583,7 @@ def test_onboarding_data_assistant_plot_returns_proper_dict_repr_of_column_domai
     assert find_strings_in_nested_obj(column_domain_charts, columns)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_plot_metrics_include_column_names_filters_output(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ) -> None:
@@ -597,7 +597,7 @@ def test_onboarding_data_assistant_plot_metrics_include_column_names_filters_out
     assert find_strings_in_nested_obj(column_domain_charts, include_column_names)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 2.74s
 def test_onboarding_data_assistant_plot_metrics_exclude_column_names_filters_output(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -613,7 +613,7 @@ def test_onboarding_data_assistant_plot_metrics_exclude_column_names_filters_out
     assert not find_strings_in_nested_obj(column_domain_charts, exclude_column_names)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.67s
 def test_onboarding_data_assistant_plot_expectations_and_metrics_include_column_names_filters_output(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -630,7 +630,7 @@ def test_onboarding_data_assistant_plot_expectations_and_metrics_include_column_
     assert find_strings_in_nested_obj(column_domain_charts, include_column_names)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 8.26s
 def test_onboarding_data_assistant_plot_expectations_and_metrics_exclude_column_names_filters_output(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -647,7 +647,7 @@ def test_onboarding_data_assistant_plot_expectations_and_metrics_exclude_column_
     assert not find_strings_in_nested_obj(column_domain_charts, exclude_column_names)
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_plot_include_and_exclude_column_names_raises_error(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ) -> None:
@@ -677,7 +677,7 @@ def test_onboarding_data_assistant_result_plot_expectations_and_metrics_correctl
     assert len(column_domain_charts) == 0
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 5.63s
 def test_onboarding_data_assistant_plot_custom_theme_overrides(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -739,7 +739,7 @@ def test_onboarding_data_assistant_plot_custom_theme_overrides(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 5.61s
 def test_onboarding_data_assistant_plot_return_tooltip(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
@@ -826,7 +826,7 @@ def test_onboarding_data_assistant_plot_return_tooltip(
         assert tooltip in actual_tooltip
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 27.11s
 def test_onboarding_data_assistant_metrics_plot_descriptive_non_sequential_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -848,7 +848,7 @@ def test_onboarding_data_assistant_metrics_plot_descriptive_non_sequential_noteb
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 34.85s
 def test_onboarding_data_assistant_metrics_and_expectations_plot_descriptive_non_sequential_notebook_execution(
     bobby_columnar_table_multi_batch_probabilistic_data_context,
@@ -872,7 +872,7 @@ def test_onboarding_data_assistant_metrics_and_expectations_plot_descriptive_non
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectations(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ):
@@ -889,7 +889,7 @@ def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectati
         ), f"DataAssistantResult.plot_expectations_and_metrics raised an exception '{exc}'"
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_onboarding_data_assistant_plot_metrics_stdout(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ):

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
@@ -6,14 +8,13 @@ from typing import List
 import pandas as pd
 import pytest
 
-import great_expectations as gx
-from great_expectations import DataContext
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import BatchRequest
 from great_expectations.core.yaml_handler import YAMLHandler
+from great_expectations.data_context import FileDataContext
 from great_expectations.data_context.util import file_relative_path
 
 yaml: YAMLHandler = YAMLHandler()
@@ -26,7 +27,6 @@ CONNECTION_STRING: str = f"postgresql+psycopg2://postgres:@{pg_hostname}/test_ci
 
 
 @pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 19s
 def test_pandas_happy_path_onboarding_data_assistant(empty_data_context) -> None:
     """
@@ -46,7 +46,7 @@ def test_pandas_happy_path_onboarding_data_assistant(empty_data_context) -> None
     This test tests the code in `DataAssistants_Instantiation_And_Running-OnboardingAssistant-Pandas.ipynb`
 
     """
-    data_context: gx.DataContext = empty_data_context
+    data_context: FileDataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__, os.path.join("..", "..", "test_sets", "taxi_yellow_tripdata_samples")
     )
@@ -129,9 +129,7 @@ def test_pandas_happy_path_onboarding_data_assistant(empty_data_context) -> None
     assert results.success is False
 
 
-@pytest.mark.filesystem
 @pytest.mark.spark
-@pytest.mark.integration
 @pytest.mark.slow  # 149 seconds
 def test_spark_happy_path_onboarding_data_assistant(
     empty_data_context, spark_session, spark_df_taxi_data_schema
@@ -156,7 +154,7 @@ def test_spark_happy_path_onboarding_data_assistant(
     from great_expectations.compatibility import pyspark
 
     schema: pyspark.types.StructType = spark_df_taxi_data_schema
-    data_context: gx.DataContext = empty_data_context
+    data_context: FileDataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__, os.path.join("..", "..", "test_sets", "taxi_yellow_tripdata_samples")
     )
@@ -239,8 +237,6 @@ def test_spark_happy_path_onboarding_data_assistant(
 
 
 @pytest.mark.postgresql
-@pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 104 seconds
 def test_sql_happy_path_onboarding_data_assistant(
     empty_data_context, test_backends, sa
@@ -267,7 +263,7 @@ def test_sql_happy_path_onboarding_data_assistant(
     else:
         load_data_into_postgres_database(sa)
 
-    data_context: gx.DataContext = empty_data_context
+    data_context: FileDataContext = empty_data_context
 
     datasource_config = {
         "name": "taxi_multi_batch_sql_datasource",
@@ -346,14 +342,13 @@ def test_sql_happy_path_onboarding_data_assistant(
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python3.8")
-@pytest.mark.integration
 @pytest.mark.filesystem
 @pytest.mark.slow  # 6.54 seconds
 def test_sql_happy_path_onboarding_data_assistant_null_column_quantiles_metric_values(
     sa,
     empty_data_context,
 ) -> None:
-    context: DataContext = empty_data_context
+    context: FileDataContext = empty_data_context
 
     db_file = file_relative_path(
         __file__,
@@ -397,8 +392,6 @@ def test_sql_happy_path_onboarding_data_assistant_null_column_quantiles_metric_v
 
 
 @pytest.mark.postgresql
-@pytest.mark.filesystem
-@pytest.mark.integration
 @pytest.mark.slow  # 26.57 seconds
 def test_sql_happy_path_onboarding_data_assistant_mixed_decimal_float_and_boolean_column_unique_proportion_metric_values(
     empty_data_context,
@@ -408,7 +401,7 @@ def test_sql_happy_path_onboarding_data_assistant_mixed_decimal_float_and_boolea
     if "postgresql" not in test_backends:
         pytest.skip("testing data assistant in sql requires postgres backend")
 
-    context: DataContext = empty_data_context
+    context: FileDataContext = empty_data_context
     postgresql_engine: sa.engine.Engine = sa.create_engine(CONNECTION_STRING)
     # noinspection PyUnusedLocal
     conn: sa.engine.Connection = postgresql_engine.connect()

--- a/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
+++ b/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
@@ -37,7 +37,7 @@ RTOL: float = 1.0e-7
 ATOL: float = 1.0e-2
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 6.20s
 def test_bootstrap_point_estimate_efficacy(
     bootstrap_distribution_parameters_and_1000_samples_with_01_false_positive,

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -122,7 +122,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_override_defaults(
 
 
 @pytest.mark.slow  # 1.34s
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_pattern_string_parameter_builder_alice(
     alice_columnar_table_single_batch_context,
 ):
@@ -193,7 +193,7 @@ def test_regex_pattern_string_parameter_builder_alice(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
@@ -275,7 +275,7 @@ def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
     assert results["details"] == expected_parameter_node_as_dict["details"]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_pattern_string_parameter_builder_bobby_no_match(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
@@ -374,7 +374,7 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
 
 
 @mock.patch("great_expectations.data_context.data_context.DataContext")
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_wrong_domain(mock_data_context: mock.MagicMock, batch_fixture: Batch):
     batch: Batch = batch_fixture
     mock_data_context.get_batch_list.return_value = [batch]
@@ -422,7 +422,7 @@ def test_regex_wrong_domain(mock_data_context: mock.MagicMock, batch_fixture: Ba
 
 
 @mock.patch("great_expectations.data_context.data_context.DataContext")
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_single_candidate(
     mock_data_context: mock.MagicMock,
     batch_fixture: Batch,
@@ -496,7 +496,7 @@ def test_regex_single_candidate(
 
 
 @mock.patch("great_expectations.data_context.data_context.DataContext")
-@pytest.mark.integration
+@pytest.mark.big
 def test_regex_two_candidates(mock_data_context: mock.MagicMock, batch_fixture: Batch):
     batch: Batch = batch_fixture
 

--- a/tests/rule_based_profiler/parameter_builder/test_value_set_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_value_set_multi_batch_parameter_builder.py
@@ -19,7 +19,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.08s
 def test_instantiation_value_set_multi_batch_parameter_builder(
     alice_columnar_table_single_batch_context,
@@ -33,7 +33,7 @@ def test_instantiation_value_set_multi_batch_parameter_builder(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.07s
 def test_instantiation_value_set_multi_batch_parameter_builder_no_name(
     alice_columnar_table_single_batch_context,
@@ -50,7 +50,7 @@ def test_instantiation_value_set_multi_batch_parameter_builder_no_name(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.19s
 def test_value_set_multi_batch_parameter_builder_alice_single_batch_numeric(
     alice_columnar_table_single_batch_context,
@@ -125,7 +125,7 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_numeric(
     assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 1.20s
 def test_value_set_multi_batch_parameter_builder_alice_single_batch_string(
     alice_columnar_table_single_batch_context,
@@ -206,7 +206,7 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_string(
     assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_value_set_multi_batch_parameter_builder_bobby_numeric(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
@@ -285,7 +285,7 @@ def test_value_set_multi_batch_parameter_builder_bobby_numeric(
     assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_value_set_multi_batch_parameter_builder_bobby_string(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):

--- a/tests/rule_based_profiler/test_user_workflow_fixtures.py
+++ b/tests/rule_based_profiler/test_user_workflow_fixtures.py
@@ -3,7 +3,7 @@ import pytest
 from great_expectations.core import ExpectationSuite
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_alice_fixture_generation(
     alice_columnar_table_single_batch,
 ):
@@ -26,7 +26,7 @@ def test_alice_fixture_generation(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_bobby_fixture_generation(
     bobby_columnar_table_multi_batch,
 ):

--- a/tests/scripts/test_public_api_report.py
+++ b/tests/scripts/test_public_api_report.py
@@ -20,6 +20,8 @@ from docs.sphinx_api_docs_source.public_api_report import (
     parse_docs_contents_for_class_names,
 )
 
+pytestmark = pytest.mark.docs
+
 
 @pytest.fixture
 def sample_docs_example_python_file_string() -> str:
@@ -243,11 +245,9 @@ def empty_docs_example_parser(
 
 
 class TestDocExampleParser:
-    @pytest.mark.unit
     def test_instantiate(self, docs_example_parser: DocsExampleParser):
         assert isinstance(docs_example_parser, DocsExampleParser)
 
-    @pytest.mark.unit
     def test_retrieve_all_usages_in_files(self, docs_example_parser: DocsExampleParser):
         usages = docs_example_parser.get_names_from_usage_in_docs_examples()
         assert usages == {
@@ -275,11 +275,9 @@ def code_parser(sample_with_definitions_file_contents: FileContents) -> CodePars
 
 
 class TestCodeParser:
-    @pytest.mark.unit
     def test_instantiate(self, code_parser: CodeParser):
         assert isinstance(code_parser, CodeParser)
 
-    @pytest.mark.unit
     def test_get_all_class_method_and_function_names(self, code_parser: CodeParser):
         names = code_parser.get_all_class_method_and_function_names()
         assert names == {
@@ -301,7 +299,6 @@ class TestCodeParser:
             "example_staticmethod",
         }
 
-    @pytest.mark.unit
     def test_get_all_class_method_and_function_definitions(
         self, code_parser: CodeParser
     ):
@@ -381,7 +378,6 @@ from a.b.c import some_method as sm
 """
 
 
-@pytest.mark.unit
 def test__get_import_names(various_imports: str):
     """Make sure the actual class and module names are returned."""
     tree = ast.parse(various_imports)
@@ -411,11 +407,9 @@ def public_api_checker(
 
 
 class TestPublicAPIChecker:
-    @pytest.mark.unit
     def test_instantiate(self, public_api_checker: PublicAPIChecker):
         assert isinstance(public_api_checker, PublicAPIChecker)
 
-    @pytest.mark.integration
     def test_get_all_public_api_definitions(self, public_api_checker: PublicAPIChecker):
         observed = public_api_checker.get_all_public_api_definitions()
         assert len(observed) == 6
@@ -448,7 +442,6 @@ class TestPublicAPIChecker:
 
         return definitions
 
-    @pytest.mark.integration
     def test_is_definition_marked_public_api_yes(
         self, public_api_checker: PublicAPIChecker
     ):
@@ -496,7 +489,6 @@ class ExamplePublicAPIClass:
             for definition in definitions
         )
 
-    @pytest.mark.integration
     def test_is_definition_marked_public_api_no(
         self, public_api_checker: PublicAPIChecker
     ):
@@ -772,13 +764,11 @@ def code_reference_filter_with_include_by_file_and_name_not_used_in_docs_example
 
 
 class TestCodeReferenceFilter:
-    @pytest.mark.unit
     def test_instantiate(self, code_reference_filter: CodeReferenceFilter):
         assert isinstance(code_reference_filter, CodeReferenceFilter)
         assert code_reference_filter.excludes
         assert code_reference_filter.includes
 
-    @pytest.mark.integration
     def test_instantiate_with_non_default_include_exclude(
         self,
         code_reference_filter_with_non_default_include_exclude: CodeReferenceFilter,
@@ -790,7 +780,6 @@ class TestCodeReferenceFilter:
         assert len(code_reference_filter.excludes) == 1
         assert len(code_reference_filter.includes) == 1
 
-    @pytest.mark.integration
     def test_filter_definitions_no_include_exclude(
         self, code_reference_filter_with_no_include_exclude: CodeReferenceFilter
     ):
@@ -813,7 +802,6 @@ class TestCodeReferenceFilter:
             )
         }
 
-    @pytest.mark.integration
     def test_filter_definitions_with_references_from_docs_content(
         self,
         code_reference_filter_with_references_from_docs_content: CodeReferenceFilter,
@@ -829,7 +817,6 @@ class TestCodeReferenceFilter:
             )
         }
 
-    @pytest.mark.integration
     def test_filter_definitions_exclude_by_file(
         self, code_reference_filter_with_exclude_by_file: CodeReferenceFilter
     ):
@@ -838,7 +825,6 @@ class TestCodeReferenceFilter:
         assert {d.name for d in observed} == set()
         assert {d.filepath for d in observed} == set()
 
-    @pytest.mark.integration
     def test_filter_definitions_exclude_by_file_and_name(
         self, code_reference_filter_with_exclude_by_file_and_name: CodeReferenceFilter
     ):
@@ -858,7 +844,6 @@ class TestCodeReferenceFilter:
             )
         }
 
-    @pytest.mark.integration
     def test_filter_definitions_include_by_file_and_name_already_included(
         self,
         code_reference_filter_with_include_by_file_and_name_already_included: CodeReferenceFilter,
@@ -889,7 +874,6 @@ class TestCodeReferenceFilter:
             )
         }
 
-    @pytest.mark.integration
     def test_filter_definitions_include_by_file_and_name_already_excluded(
         self,
         code_reference_filter_with_include_by_file_and_name_already_excluded: CodeReferenceFilter,
@@ -914,7 +898,6 @@ class TestCodeReferenceFilter:
             )
         }
 
-    @pytest.mark.integration
     def test_filter_definitions_include_by_file_and_name_already_excluded_not_used_in_docs_example(
         self,
         code_reference_filter_with_include_by_file_and_name_not_used_in_docs_example_exclude_file: CodeReferenceFilter,
@@ -961,11 +944,9 @@ def public_api_report_filter_out_file(
 
 
 class TestPublicAPIReport:
-    @pytest.mark.unit
     def test_instantiate(self, public_api_report: PublicAPIReport):
         assert isinstance(public_api_report, PublicAPIReport)
 
-    @pytest.mark.integration
     def test_generate_printable_definitions(self, public_api_report: PublicAPIReport):
         expected: List[str] = [
             "File: great_expectations/sample_with_definitions_python_file_string.py Name: "
@@ -984,7 +965,6 @@ class TestPublicAPIReport:
         observed = public_api_report.generate_printable_definitions()
         assert observed == expected
 
-    @pytest.mark.integration
     def test_generate_printable_definitions_exclude_by_file(
         self, public_api_report_filter_out_file: PublicAPIReport
     ):
@@ -994,26 +974,22 @@ class TestPublicAPIReport:
 
 
 class TestIncludeExcludeDefinition:
-    @pytest.mark.unit
     def test_instantiate_name_and_filepath(self):
         definition = IncludeExcludeDefinition(
             reason="reason", name="name", filepath=pathlib.Path("filepath")
         )
         assert isinstance(definition, IncludeExcludeDefinition)
 
-    @pytest.mark.unit
     def test_instantiate_filepath_only(self):
         definition = IncludeExcludeDefinition(
             reason="reason", filepath=pathlib.Path("filepath")
         )
         assert isinstance(definition, IncludeExcludeDefinition)
 
-    @pytest.mark.unit
     def test_instantiate_name_and_filepath_no_reason(self):
         with pytest.raises(TypeError):
             IncludeExcludeDefinition(name="name", filepath=pathlib.Path("filepath"))
 
-    @pytest.mark.unit
     def test_instantiate_name_only(self):
         with pytest.raises(ValueError) as exc:
             IncludeExcludeDefinition(reason="reason", name="name")
@@ -1022,7 +998,6 @@ class TestIncludeExcludeDefinition:
             "You must provide a filepath if also providing a name" in exc.value.args[0]
         )
 
-    @pytest.mark.unit
     def test_instantiate_reason_only(self):
         with pytest.raises(ValueError) as exc:
             IncludeExcludeDefinition(reason="reason")

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -470,7 +470,7 @@ def pytest_generate_tests(metafunc):  # noqa C901 - 35
 
 
 @pytest.mark.order(index=0)
-@pytest.mark.integration
+@pytest.mark.big
 @pytest.mark.slow  # 12.68s
 def test_case_runner_v3_api(test_case):
     if test_case["skip"]:

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -127,7 +127,7 @@ def yellow_trip_pandas_data_context(
     return context
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_default_expectation_args__pandas(basic_datasource):
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
 
@@ -154,7 +154,7 @@ def test_validator_default_expectation_args__pandas(basic_datasource):
     print(my_validator.get_default_expectation_arguments())
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_default_expectation_args__sql(
     data_context_with_simple_sql_datasource_for_testing_get_batch,
 ):
@@ -193,7 +193,7 @@ def test_validator_default_expectation_args__sql(
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_columns(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
 ):
@@ -221,7 +221,7 @@ def test_columns(
     assert columns == expected
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_head(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
 ):
@@ -277,7 +277,7 @@ def multi_batch_taxi_validator(
     return validator_multi_batch
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_convert_to_checkpoint_validations_list(multi_batch_taxi_validator):
     validator = multi_batch_taxi_validator
 
@@ -352,7 +352,6 @@ def multi_batch_taxi_validator_ge_cloud_mode(
 @mock.patch("great_expectations.data_context.store.ExpectationsStore.update")
 @mock.patch("great_expectations.validator.validator.Validator.cloud_mode")
 @pytest.mark.cloud
-@pytest.mark.integration
 def test_ge_cloud_validator_updates_self_suite_with_ge_cloud_ids_on_save(
     mock_cloud_mode,
     mock_expectation_store_update,
@@ -408,7 +407,7 @@ def test_ge_cloud_validator_updates_self_suite_with_ge_cloud_ids_on_save(
     assert mock_emit.call_count == 0
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_can_instantiate_with_a_multi_batch_request(
     multi_batch_taxi_validator,
 ):
@@ -430,7 +429,7 @@ def test_validator_can_instantiate_with_a_multi_batch_request(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_with_bad_batchrequest(
     yellow_trip_pandas_data_context,
 ):
@@ -451,7 +450,7 @@ def test_validator_with_bad_batchrequest(
         )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_batch_filter(
     multi_batch_taxi_validator,
 ):
@@ -541,7 +540,7 @@ def test_validator_batch_filter(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_custom_filter_function(
     multi_batch_taxi_validator,
 ):
@@ -574,7 +573,7 @@ def test_custom_filter_function(
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-@pytest.mark.integration
+@pytest.mark.big
 def test_adding_expectation_to_validator_not_send_usage_message(
     mock_emit, multi_batch_taxi_validator
 ):
@@ -593,7 +592,7 @@ def test_adding_expectation_to_validator_not_send_usage_message(
     assert mock_emit.call_args_list == []
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_load_additional_batch_to_validator(
     yellow_trip_pandas_data_context,
 ):
@@ -642,7 +641,7 @@ def test_validator_load_additional_batch_to_validator(
     assert first_batch_markers != updated_batch_markers
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_instantiate_validator_with_a_list_of_batch_requests(
     yellow_trip_pandas_data_context,
 ):
@@ -702,7 +701,7 @@ def test_instantiate_validator_with_a_list_of_batch_requests(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate(in_memory_runtime_context, basic_datasource):
     in_memory_runtime_context.datasources["my_datasource"] = basic_datasource
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
@@ -759,7 +758,7 @@ def test_graph_validate(in_memory_runtime_context, basic_datasource):
 
 
 # Tests that runtime configuration actually works during graph validation
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate_with_runtime_config(
     in_memory_runtime_context, basic_datasource
 ):
@@ -836,7 +835,7 @@ def test_graph_validate_with_runtime_config(
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate_with_exception(basic_datasource):
     # noinspection PyUnusedLocal
     def mock_error(*args, **kwargs):
@@ -883,7 +882,7 @@ def test_graph_validate_with_exception(basic_datasource):
     assert result[0].expectation_config is not None
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate_with_bad_config_catch_exceptions_false(
     in_memory_runtime_context, basic_datasource
 ):
@@ -935,7 +934,7 @@ def test_graph_validate_with_bad_config_catch_exceptions_false(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validate_expectation(multi_batch_taxi_validator):
     validator: Validator = multi_batch_taxi_validator
     expect_column_values_to_be_between_config = validator.validate_expectation(
@@ -959,7 +958,7 @@ def test_validate_expectation(multi_batch_taxi_validator):
     }
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_docstrings(multi_batch_taxi_validator):
     expectation_impl = getattr(
         multi_batch_taxi_validator, "expect_column_values_to_be_in_set", None
@@ -969,7 +968,7 @@ def test_validator_docstrings(multi_batch_taxi_validator):
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_include_rendered_content_diagnostic(
     yellow_trip_pandas_data_context,
 ):
@@ -1269,7 +1268,7 @@ def _context_to_validator_and_expectation_sql(
     return validator, expectation
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_result_format_config_from_validator(
     data_context_with_connection_to_metrics_db,
 ):
@@ -1294,7 +1293,7 @@ def test_validator_result_format_config_from_validator(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_validator_result_format_config_from_expectation(
     data_context_with_connection_to_metrics_db,
 ):
@@ -1318,7 +1317,7 @@ def test_validator_result_format_config_from_expectation(
     )
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate_with_two_expectations_and_first_expectation_without_additional_configuration(
     in_memory_runtime_context, basic_datasource
 ):
@@ -1485,7 +1484,7 @@ def test_graph_validate_with_two_expectations_and_first_expectation_without_addi
     ]
 
 
-@pytest.mark.integration
+@pytest.mark.big
 def test_graph_validate_with_two_expectations_and_first_expectation_with_result_format_complete(
     in_memory_runtime_context, basic_datasource
 ):


### PR DESCRIPTION
Remove all `pytest` `integration` markers.
Add `docs` to the marker matrix.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
