### PR TITLE
[MAINTENANCE] Pytest Mark - Rendering and UserConfigurable Profiler

### DIFF
--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -1703,6 +1703,7 @@ def test_bobster_expect_table_row_count_to_be_between_auto_yes_default_profiler_
     reason="requires numpy version 1.21.0 or newer",
 )
 @pytest.mark.slow  # 2.02s
+@pytest.mark.big
 def test_quentin_expect_expect_table_columns_to_match_set_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):

--- a/tests/jupyter_ux/test_jupyter_ux.py
+++ b/tests/jupyter_ux/test_jupyter_ux.py
@@ -5,6 +5,8 @@ import pytest
 import great_expectations as gx
 import great_expectations.jupyter_ux as jux
 
+pytestmark = pytest.mark.unit
+
 
 def test_styling_elements_exist():
     assert "<link" in jux.bootstrap_link_element

--- a/tests/profile/test_basic_suite_builder_profiler.py
+++ b/tests/profile/test_basic_suite_builder_profiler.py
@@ -175,6 +175,7 @@ def test_BasicSuiteBuilderProfiler_raises_error_on_both_included_and_excluded_co
     "ignore:DataAsset.remove_expectations*:DeprecationWarning:great_expectations.data_asset"
 )
 @pytest.mark.skipif(os.getenv("PANDAS") == "0.22.0", reason="0.22.0 pandas")
+@pytest.mark.unit
 def test_BasicSuiteBuilderProfiler_raises_error_on_non_existent_column_on_pandas(
     pandas_dataset,
 ):

--- a/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
+++ b/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
@@ -367,6 +367,7 @@ def test_build_suite_with_semantic_types_dict(
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
+@pytest.mark.unit
 def test_build_suite_when_suite_already_exists(mock_emit, cardinality_dataset):
     """
     What does this test do and why?

--- a/tests/profile/test_user_configurable_profiler_v3_batch_request.py
+++ b/tests/profile/test_user_configurable_profiler_v3_batch_request.py
@@ -308,6 +308,7 @@ def taxi_data_semantic_types():
     }
 
 
+@pytest.mark.big
 def test_profiler_init_no_config(
     cardinality_validator,
 ):
@@ -323,6 +324,7 @@ def test_profiler_init_no_config(
     assert profiler.excluded_expectations == []
 
 
+@pytest.mark.big
 def test_profiler_init_full_config_no_semantic_types(cardinality_validator):
     """
     What does this test do and why?
@@ -348,6 +350,7 @@ def test_profiler_init_full_config_no_semantic_types(cardinality_validator):
     assert "col_one" not in profiler.column_info
 
 
+@pytest.mark.big
 def test_init_with_semantic_types(cardinality_validator):
     """
     What does this test do and why?
@@ -402,6 +405,7 @@ def test_init_with_semantic_types(cardinality_validator):
     }
 
 
+@pytest.mark.big
 def test__validate_config(cardinality_validator):
     """
     What does this test do and why?
@@ -420,6 +424,7 @@ def test__validate_config(cardinality_validator):
 
 
 @pytest.mark.slow  # 1.18s
+@pytest.mark.big
 def test__validate_semantic_types_dict(cardinality_validator):
     """
     What does this test do and why?

--- a/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
+++ b/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
@@ -69,6 +69,7 @@ def assetless_dataconnector_context(
     return context
 
 
+@pytest.mark.filesystem
 def test_find_datasource_with_asset_on_context_with_no_datasources(
     empty_data_context,
 ):
@@ -80,6 +81,7 @@ def test_find_datasource_with_asset_on_context_with_no_datasources(
     assert obs is None
 
 
+@pytest.mark.filesystem
 def test_find_datasource_with_asset_on_context_with_a_datasource_with_no_dataconnectors(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
 ):
@@ -103,6 +105,7 @@ def test_find_datasource_with_asset_on_context_with_a_datasource_with_no_datacon
 
 
 @pytest.mark.slow  # 2.27s
+@pytest.mark.filesystem
 def test_find_datasource_with_asset_on_context_with_a_datasource_with_a_dataconnector_that_has_no_assets(
     assetless_dataconnector_context,
 ):
@@ -122,6 +125,7 @@ def test_find_datasource_with_asset_on_context_with_a_datasource_with_a_dataconn
     assert obs is None
 
 
+@pytest.mark.filesystem
 def test_find_datasource_with_asset_on_happy_path_context(
     deterministic_asset_data_connector_context,
 ):
@@ -138,6 +142,7 @@ def test_find_datasource_with_asset_on_happy_path_context(
     }
 
 
+@pytest.mark.filesystem
 def test_find_datasource_with_asset_on_context_with_a_full_datasource_and_one_with_no_dataconnectors(
     deterministic_asset_data_connector_context,
 ):
@@ -318,6 +323,7 @@ validations:
     }
 
 
+@pytest.mark.filesystem
 @pytest.mark.slow  # 1.10s
 def test_render_checkpoint_new_notebook_with_available_data_asset(
     deterministic_asset_data_connector_context,
@@ -372,6 +378,7 @@ def test_render_checkpoint_new_notebook_with_available_data_asset(
     assert obs == expected
 
 
+@pytest.mark.filesystem
 def test_render_checkpoint_new_notebook_with_unavailable_data_asset(
     assetless_dataconnector_context,
     checkpoint_new_notebook_assets,

--- a/tests/render/renderer/test_datasource_new_notebook_renderer.py
+++ b/tests/render/renderer/test_datasource_new_notebook_renderer.py
@@ -11,6 +11,8 @@ from great_expectations.render.renderer.datasource_new_notebook_renderer import 
 if TYPE_CHECKING:
     import nbformat
 
+pytestmark = pytest.mark.filesystem
+
 
 @pytest.fixture
 def construct_datasource_new_notebook_assets():

--- a/tests/render/renderer/test_other_section_renderer.py
+++ b/tests/render/renderer/test_other_section_renderer.py
@@ -19,6 +19,7 @@ def datetime_column_evrs():
         )
 
 
+@pytest.mark.filesystem
 def test_ProfilingResultsOverviewSectionRenderer_render_variable_types(
     datetime_column_evrs,
 ):

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -18,6 +18,8 @@ from great_expectations.render.renderer.suite_edit_notebook_renderer import (
 from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.util import get_context
 
+pytestmark = pytest.mark.filesystem
+
 
 @pytest.fixture
 def data_context_with_bad_notebooks(tmp_path_factory):

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -73,6 +73,7 @@ def titanic_validation_results():
 
 @pytest.mark.smoketest
 @pytest.mark.rendered_output
+@pytest.mark.unit
 def test_render_profiling_results_column_section_renderer(titanic_validation_results):
     # Group EVRs by column
     evrs = {}
@@ -107,6 +108,7 @@ def test_render_profiling_results_column_section_renderer(titanic_validation_res
 
 @pytest.mark.smoketest
 @pytest.mark.rendered_output
+@pytest.mark.unit
 def test_render_expectation_suite_column_section_renderer(titanic_expectations):
     # Group expectations by column
     exp_groups = {}
@@ -297,6 +299,7 @@ def test_ProfilingResultsColumnSectionRenderer_render_bar_chart_table(
         assert json.loads(content_block["graph"])
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_render_header(
     titanic_profiled_name_column_expectations,
 ):
@@ -370,6 +373,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_header(
     assert content_blocks.to_json_dict() == expected
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_expectation_with_markdown_meta_notes():
     expectation_with_markdown_meta_notes = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_type_list",
@@ -532,6 +536,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_markdown_meta_no
     assert result_json == expected_result_json
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta_notes_in_dict():
     expectation_with_string_notes_list_in_dict = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_type_list",
@@ -697,6 +702,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta
     assert result_json == expected_result_json
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_meta_note_in_dict():
     expectation_with_single_string_note_in_dict = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_type_list",
@@ -852,6 +858,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_me
     assert result_json == expected_result_json
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta_notes():
     expectation_with_string_list_note = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_type_list",
@@ -1007,6 +1014,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta
     assert result_json == expected_result_json
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_meta_note():
     expectation_with_single_string_note = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_type_list",
@@ -1159,6 +1167,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_me
     assert result_json == expected_result_json
 
 
+@pytest.mark.unit
 def test_ExpectationSuiteColumnSectionRenderer_render_bullet_list(
     titanic_profiled_name_column_expectations,
 ):
@@ -1182,6 +1191,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_bullet_list(
     )
 
 
+@pytest.mark.unit
 def test_ValidationResultsColumnSectionRenderer_render_header(
     titanic_profiled_name_column_evrs,
 ):
@@ -1209,6 +1219,7 @@ def test_ValidationResultsColumnSectionRenderer_render_header(
     }
 
 
+@pytest.mark.unit
 def test_ValidationResultsColumnSectionRenderer_render_header_evr_with_unescaped_dollar_sign(
     titanic_profiled_name_column_evrs,
 ):
@@ -1266,6 +1277,7 @@ def test_ValidationResultsColumnSectionRenderer_render_header_evr_with_unescaped
 
 
 # noinspection PyPep8Naming
+@pytest.mark.unit
 def test_ValidationResultsColumnSectionRenderer_render_table(
     titanic_profiled_name_column_evrs,
 ):
@@ -1307,6 +1319,7 @@ def test_ValidationResultsColumnSectionRenderer_render_table(
 
 
 # noinspection PyPep8Naming
+@pytest.mark.unit
 def test_ValidationResultsTableContentBlockRenderer_generate_expectation_row_happy_path():
     evr = ExpectationValidationResult(
         success=True,

--- a/tests/render/test_renderer.py
+++ b/tests/render/test_renderer.py
@@ -37,6 +37,7 @@ def test_render():
 #     Renderer()._find_ge_object_type(ge_object)
 
 
+@pytest.mark.unit
 def test__find_evr_by_type(titanic_profiled_evrs_1):
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
     found_evr = Renderer()._find_evr_by_type(
@@ -78,6 +79,7 @@ def test__find_evr_by_type(titanic_profiled_evrs_1):
     )
 
 
+@pytest.mark.unit
 def test__find_all_evrs_by_type(titanic_profiled_evrs_1):
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
     found_evrs = Renderer()._find_all_evrs_by_type(
@@ -112,6 +114,7 @@ def test__find_all_evrs_by_type(titanic_profiled_evrs_1):
     assert len(found_evrs) == 1
 
 
+@pytest.mark.unit
 def test__get_column_list_from_evrs(titanic_profiled_evrs_1):
     column_list = Renderer()._get_column_list_from_evrs(titanic_profiled_evrs_1)
     print(column_list)

--- a/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
+++ b/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
@@ -59,6 +59,7 @@ def test_get_chart_titles():
     assert e.value.message == "All DataAssistantResult charts must have a title."
 
 
+@pytest.mark.unit
 def test_get_expectation_suite_should_use_default_name_if_none():
     data_assistant_result: DataAssistantResult = DataAssistantResult()
 

--- a/tests/rule_based_profiler/parameter_builder/test_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_parameter_builder.py
@@ -87,6 +87,7 @@ class DummyParameterBuilder(ParameterBuilder):
         )
 
 
+@pytest.mark.unit
 def test_resolve_evaluation_dependencies_no_parameter_builder_dependencies_specified(
     empty_rule_state: Dict[str, Union[Domain, Dict[str, ParameterContainer]]],
 ):
@@ -120,6 +121,7 @@ def test_resolve_evaluation_dependencies_no_parameter_builder_dependencies_speci
     assert not all_fully_qualified_parameter_names
 
 
+@pytest.mark.unit
 def test_resolve_evaluation_dependencies_two_parameter_builder_dependencies_specified(
     empty_rule_state: Dict[str, Union[Domain, Dict[str, ParameterContainer]]],
 ):

--- a/tests/rule_based_profiler/parameter_builder/test_value_counts_single_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_value_counts_single_batch_parameter_builder.py
@@ -21,6 +21,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 pytestmark = pytest.mark.big
 
 
+@pytest.mark.big
 def test_instantiation_value_counts_single_batch_parameter_builder(
     alice_columnar_table_single_batch_context,
 ):
@@ -33,6 +34,7 @@ def test_instantiation_value_counts_single_batch_parameter_builder(
     )
 
 
+@pytest.mark.big
 def test_value_counts_single_batch_parameter_builder_alice(
     alice_columnar_table_single_batch_context,
 ):

--- a/tests/scripts/test_public_api_report.py
+++ b/tests/scripts/test_public_api_report.py
@@ -330,6 +330,7 @@ class TestCodeParser:
         }
 
 
+@pytest.mark.unit
 def test_parse_docs_contents_for_class_names(
     sample_markdown_doc_with_yaml_file_contents: FileContents,
 ):
@@ -338,6 +339,7 @@ def test_parse_docs_contents_for_class_names(
     ) == {"Datasource", "SqlAlchemyExecutionEngine"}
 
 
+@pytest.mark.filesystem
 def test_get_shortest_dotted_path(monkeypatch):
     """Test path traversal using an example file.
 

--- a/tests/validator/test_metrics_calculator.py
+++ b/tests/validator/test_metrics_calculator.py
@@ -45,12 +45,8 @@ def integer_and_datetime_sample_dataset() -> dict:
 @pytest.mark.parametrize(
     "backend,",
     [
-        pytest.param(
-            "pandas",
-        ),
-        pytest.param(
-            "sqlite",
-        ),
+        pytest.param("pandas", marks=pytest.mark.unit),
+        pytest.param("sqlite", marks=pytest.mark.sqlite),
         pytest.param("spark", marks=pytest.mark.spark),
     ],
 )


### PR DESCRIPTION
## Pytest Marks
- Rendering and RuleBasedProfiler

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated