### PR TITLE
[MAINTENANCE]Add ci test for test marker coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
           invoke type-check --ci --pretty
           invoke type-check --ci --pretty  --check-stub-sources
 
+      - name: Marker-coverage-check
+        run: |
+          invoke marker-coverage
+
   unit-tests:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,13 @@ jobs:
 
       - run: invoke lint --no-fmt
       - run: invoke fmt --check
+      - name: Marker-coverage-check
+        run: |
+          invoke marker-coverage
       - name: Type-check
         run: |
           invoke type-check --ci --pretty
           invoke type-check --ci --pretty  --check-stub-sources
-
-      - name: Marker-coverage-check
-        run: |
-          invoke marker-coverage
 
   unit-tests:
     strategy:

--- a/tasks.py
+++ b/tasks.py
@@ -211,6 +211,14 @@ def docstrings(ctx: Context, paths: list[str] | None = None):
         )
 
 
+@invoke.task()
+def marker_coverage(
+    ctx: Context,
+):
+    pytest_cmds = ["pytest", "--verify-marker-coverage-and-exit"]
+    ctx.run(" ".join(pytest_cmds), echo=True, pty=True)
+
+
 @invoke.task(
     aliases=["types"],
     iterable=["packages"],


### PR DESCRIPTION
This adds a ci step that ensures all tests are covered by a marker.

This depends on https://github.com/great-expectations/great_expectations/pull/8394

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
