### PR TITLE
[MAINTENANCE] conditional `snowflake-connector-python` version bump

### DIFF
--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,3 +1,3 @@
 snowflake-connector-python>=2.5.0; python_version < "3.11"
-snowflake-connector-python>2.9.0; python_version <= "3.11" # earlier versions fail to build on 3.11
+snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
 snowflake-sqlalchemy>=1.2.3

--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,2 +1,3 @@
-snowflake-connector-python>=2.5.0
+snowflake-connector-python>=2.5.0; python_version < "3.11"
+snowflake-connector-python>2.9.0; python_version <= "3.11" # earlier versions fail to build on 3.11
 snowflake-sqlalchemy>=1.2.3


### PR DESCRIPTION
Earlier version of `snowflake-connector-python` fail to install on python 3.11.
Conditional require a later version for python 3.11.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
