### PR TITLE
[MAINTENANCE] List required markers when verify marker test fails.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,7 +361,6 @@ def _verify_marker_coverage(
     session,
 ) -> list[tuple[str, str, list[str]]]:
     uncovered: list[tuple[str, str, set[str]]] = []
-    markers_on_uncovered: set[str] = set()
     for test in session.items:
         markers = {m.name for m in test.iter_markers()}
         if not REQUIRED_MARKERS.intersection(markers):


### PR DESCRIPTION
When `pytest --verify-marker-coverage-and-exit` fails, we now print the failing tests, their markers and the list of required markers so the user can remedy without looking through code. Some types were also cleaned up.

This is also in preparation for updating the contributor docs.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
