### PR TITLE
[BUGFIX] `ensure_json_serializable` accounts for `pydantic.BaseModel`

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -451,7 +451,7 @@ def ensure_json_serializable(data) -> None:  # noqa: C901, PLR0911, PLR0912
         # test_obj[key] = test_obj[key].tolist()
         # If we have an array or index, convert it first to a list--causing coercion to float--and then round
         # to the number of digits for which the string representation will equal the float representation
-        _ = [ensure_json_serializable(x) for x in data.tolist()]
+        _ = [ensure_json_serializable(x) for x in data.tolist()]  # type: ignore[func-returns-value]
         return
 
     if isinstance(data, (datetime.datetime, datetime.date)):
@@ -502,7 +502,7 @@ def ensure_json_serializable(data) -> None:  # noqa: C901, PLR0911, PLR0912
         ]
         return
 
-    if pyspark.DataFrame and isinstance(data, pyspark.DataFrame):  # type: ignore[truthy-function]
+    if pyspark.DataFrame and isinstance(data, pyspark.DataFrame):
         # using StackOverflow suggestion for converting pyspark df into dictionary
         # https://stackoverflow.com/questions/43679880/pyspark-dataframe-to-dictionary-columns-as-keys-and-list-of-column-values-ad-di
         return ensure_json_serializable(

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -417,16 +417,16 @@ def convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912
     )
 
 
-def ensure_json_serializable(data):  # noqa: C901, PLR0911, PLR0912
+def ensure_json_serializable(data) -> None:  # noqa: C901, PLR0911, PLR0912
     """
     Helper function to convert an object to one that is json serializable
     Args:
         data: an object to attempt to convert a corresponding json-serializable object
-    Returns:
-        (dict) A converted test_object
     Warning:
         test_obj may also be converted in place.
     """
+    if isinstance(data, pydantic.BaseModel):
+        return
 
     if isinstance(data, (SerializableDictDot, SerializableDotDict)):
         return

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -417,7 +417,7 @@ def convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912
     )
 
 
-def ensure_json_serializable(data) -> None:  # noqa: C901, PLR0911, PLR0912
+def ensure_json_serializable(data: Any) -> None:  # noqa: C901, PLR0911, PLR0912
     """
     Helper function to convert an object to one that is json serializable
     Args:


### PR DESCRIPTION
`convert_to_json_serializable` already knows how to serialize a `pydantic.BaseModel`, but `ensure_json_serializable` was never updated leading to `TypeErrors` incorrectly being raised.

https://github.com/great-expectations/great_expectations/blob/a0b95a206feaaf12a0618f50f6c45caef7fecc1d/great_expectations/core/util.py#L272-L276


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
