### PR TITLE
[BUGFIX] Use consistent name between compose and cli command

### DIFF
--- a/examples/reference_environments/aws_postgres/compose.yaml
+++ b/examples/reference_environments/aws_postgres/compose.yaml
@@ -1,7 +1,7 @@
 services:
   jupyter:
-    image: gx/aws_rds_example_jupyter
-    container_name: gx_aws_rds_example_jupyter
+    image: gx/aws_postgres_example_jupyter
+    container_name: aws_postgres_example_jupyter
     build:
       context: .
       dockerfile: jupyter.Dockerfile


### PR DESCRIPTION
Use consistent name between compose and cli command in the aws postgres reference environment. This was leading to an error when trying to find the url of the jupyter server running in the container.