### PR TITLE
[MAINTENANCE] Default snippet-check to non verbose mode

### DIFF
--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -13,7 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint": "standard --fix",
-    "snippet-check": "node scripts/remark-named-snippets/snippet.js verbose"
+    "snippet-check": "node scripts/remark-named-snippets/snippet.js"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.11.0",


### PR DESCRIPTION
Verbose mode can be invoked by adding the verbose flag, we don't need to default to verbose for every invocation.