### PR TITLE
[MAINTENANCE] Update ListTableNamesAction to use GxAgentEnvVars

### DIFF
--- a/great_expectations/agent/actions/list_table_names.py
+++ b/great_expectations/agent/actions/list_table_names.py
@@ -60,7 +60,7 @@ class ListTableNamesAction(AgentAction[ListTableNamesEvent]):
         if response.status_code != 204:  # noqa: PLR2004
             raise GXCloudError(
                 message=f"ListTableNamesAction encountered an error while connecting to GX Cloud. Unable to update "
-                f"table_names for Datasource with id"
+                f"table_names for Datasource with id "
                 f"={datasource_id}.",
                 response=response,
             )

--- a/great_expectations/agent/actions/list_table_names.py
+++ b/great_expectations/agent/actions/list_table_names.py
@@ -60,7 +60,7 @@ class ListTableNamesAction(AgentAction[ListTableNamesEvent]):
         if response.status_code != 204:  # noqa: PLR2004
             raise GXCloudError(
                 message=f"ListTableNamesAction encountered an error while connecting to GX Cloud. Unable to update "
-                f"table_names for Datasource with id "
+                f"table_names for Datasource with id"
                 f"={datasource_id}.",
                 response=response,
             )


### PR DESCRIPTION
- Update ListTableNamesAction to use GxAgentEnvVars instead of accessing private attr on context (`._cloud_config`)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
