### PR TITLE
[DOCS] Correct Typo

### DIFF
--- a/docs/docusaurus/docs/conceptual_guides/learn_lp.md
+++ b/docs/docusaurus/docs/conceptual_guides/learn_lp.md
@@ -8,7 +8,7 @@ description: Longer format conceptual information about Great Expectations featu
 import LinkCardGrid from '/docs/components/LinkCardGrid';
 import LinkCard from '/docs/components/LinkCard';
 
-<p class="DocItem__header-description">Use longer format conceptual information to learn more about Great Expectations (GX) features and functionbality.</p>
+<p class="DocItem__header-description">Use longer format conceptual information to learn more about Great Expectations (GX) features and functionality.</p>
 
 <LinkCardGrid>
   <LinkCard topIcon label="Expectation classes" description="An overview of the available Expectation classes, why they are helpful, and when they should be used" href="/docs/conceptual_guides/expectation_classes" icon="/img/overview_icon.svg" />


### PR DESCRIPTION
Corrected typo identified [here](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1690579271026759).

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated
