### PR TITLE
[MAINTENANCE] Run `marker-tests` after `unit-tests` and `static-analysis`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
         run: invoke ci-tests 'cloud' --up-services --verbose
 
   marker-tests:
+    needs: [unit-tests, static-analysis]
     if: github.event.pull_request.draft == false
     env:
       # aws

--- a/tasks.py
+++ b/tasks.py
@@ -989,6 +989,7 @@ def docs_snippet_tests(
 
 
 @invoke.task(
+    help={"pty": _PTY_HELP_DESC},
     iterable=["service_names", "up_services", "verbose"],
 )
 def ci_tests(  # noqa: PLR0913
@@ -1048,6 +1049,8 @@ def ci_tests(  # noqa: PLR0913
 
 
 @invoke.task(
+    aliases=("services",),
+    help={"pty": _PTY_HELP_DESC},
     iterable=["names", "markers"],
 )
 def service(


### PR DESCRIPTION
To prevent using up so many workers, wait until the `unit-tests` and `static-analysis` steps have passed before fanning out withe all the marker tests.

![image](https://github.com/great-expectations/great_expectations/assets/13108583/23be9c4d-7afa-4ab5-b20c-8d713bb050f0)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
