### PR TITLE
[MAINTENANCE] AWS Glue script using Context Manager to catch `FutureWarning`

### DIFF
--- a/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
@@ -14,14 +14,14 @@ from great_expectations.util import get_context
 
 import warnings
 
-# needed because GlueContext(sc) function emits the following FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.
-warnings.filterwarnings("ignore", category=FutureWarning)
-
 yaml = YAMLHandler()
 
-sc = SparkContext.getOrCreate()
-glueContext = GlueContext(sc)
-spark = glueContext.spark_session
+# needed because GlueContext(sc) function emits the following FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.
+with warnings.catch_warnings():
+    sc = SparkContext.getOrCreate()
+    glueContext = GlueContext(sc)
+    spark = glueContext.spark_session
+
 s3_client = boto3.client("s3")
 response = s3_client.get_object(
     Bucket="bucket", Key="bucket/great_expectations/great_expectations.yml"

--- a/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
@@ -18,6 +18,7 @@ yaml = YAMLHandler()
 
 # needed because GlueContext(sc) function emits the following FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.
 with warnings.catch_warnings():
+    warnings.simplefilter(action="ignore", category=FutureWarning)
     sc = SparkContext.getOrCreate()
     glueContext = GlueContext(sc)
     spark = glueContext.spark_session


### PR DESCRIPTION
Follow up to #8437 
* Adding `FilterWarnings` to context manager
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated