### PR TITLE
[MAINTENANCE] Run all_backend tests along with specific service tests.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -860,7 +860,7 @@ MARKER_DEPENDENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
 
 
 def _add_all_backends_marker(marker_string: str) -> bool:
-    # We should generalize this, possibly leveraging MARKER_DEPENDENDENCY_MA, but for now
+    # We should generalize this, possibly leveraging MARKER_DEPENDENDENCY_MAP, but for now
     # right I've hardcoded all the containerized backend services we support in testing.
     return marker_string in ["postgresql", "mssql", "mysql", "trino"]
 

--- a/tasks.py
+++ b/tasks.py
@@ -859,6 +859,12 @@ MARKER_DEPENDENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
 }
 
 
+def _add_all_backends_marker(marker_string: str) -> bool:
+    # We should generalize this, possibly leveraging MARKER_DEPENDENDENCY_MA, but for now
+    # right I've hardcoded all the containerized backend services we support in testing.
+    return marker_string in ["postgresql", "mssql", "mysql", "trino"]
+
+
 def _tokenize_marker_string(marker_string: str) -> Generator[str, None, None]:
     """_summary_
 
@@ -1014,37 +1020,35 @@ def ci_tests(  # noqa: PLR0913
 
     Defined this as a new invoke task to avoid some of the baggage of our old test setup.
     """
-    pytest_cmds = [
-        "pytest",
-        f"--durations={slowest}",
-        "-m",
-        f"'{marker}'",
-        "-rEf",
-    ]
+    pytest_options = [f"--durations={slowest}", "-rEf"]
 
     if xdist:
-        pytest_cmds.append("-n auto")
+        pytest_options.append("-n auto")
 
     if timeout != 0:
-        pytest_cmds.append(f"--timeout={timeout}")
+        pytest_options.append(f"--timeout={timeout}")
 
     if reports:
-        pytest_cmds.extend(["--cov=great_expectations", "--cov-report=xml"])
+        pytest_options.extend(["--cov=great_expectations", "--cov-report=xml"])
 
     if verbose:
-        pytest_cmds.append("-vv")
+        pytest_options.append("-vv")
 
     for test_deps in _get_marker_dependencies(marker):
         if up_services:
             service(ctx, names=test_deps.services, markers=test_deps.services, pty=pty)
 
         for extra_pytest_arg in test_deps.extra_pytest_args:
-            pytest_cmds.append(extra_pytest_arg)
+            pytest_options.append(extra_pytest_arg)
 
-    if marker in ["postgresql", "mssql", "mysql", "trino"]:
-        pytest_cmds[3] = "all_backends"
+    marker_statement = (
+        f"'all_backends or {marker}'"
+        if _add_all_backends_marker(marker)
+        else f"'{marker}'"
+    )
 
-    ctx.run(" ".join(pytest_cmds), echo=True, pty=pty)
+    pytest_cmd = ["pytest", "-m", marker_statement] + pytest_options
+    ctx.run(" ".join(pytest_cmd), echo=True, pty=pty)
 
 
 @invoke.task(


### PR DESCRIPTION
When I run `invoke ci-tests postgresql --up-services --verbose` I see both the postgresql marked tests and the all_backends marked tests running. I do see this test fail: `tests/profile/test_user_configurable_profiler_v3_batch_request.py::test_profiler_all_expectation_types_sqlalchemy`.
It looks like it's timing out trying to connect when I run it locally based on the error message but I haven't dug in. It does pass in CI.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
