### PR TITLE
[MAINTENANCE] `min-versions` wait for `unit-tests`, `static-analysis`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
         run: invoke ci-tests '${{ matrix.markers }}' --up-services --verbose
 
   py38-min-versions:
+    needs: [unit-tests, static-analysis]
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -262,6 +263,7 @@ jobs:
         run: invoke tests --unit
 
   py39-min-versions:
+    needs: [unit-tests, static-analysis]
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -280,6 +282,7 @@ jobs:
         run: invoke tests --unit
 
   py310-min-versions:
+    needs: [unit-tests, static-analysis]
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To prevent the early fanout of our Github Action workers, wait for the  `unit-tests`, `static-analysis` to pass before running the `min-versions` tests.

This should not increase the total time of the CI.

![image](https://github.com/great-expectations/great_expectations/assets/13108583/c494bffd-adb2-45c9-9735-71d41e8e540e)



- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
