### PR TITLE
[MAINTENANCE] Run additional matrix steps on any non-`pull_request` event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,9 @@ jobs:
           # TODO: would like to adopt `actionlint` pre-commit hook
           # but false positive here and inability to do an inline ignore
           # prevents this https://github.com/rhysd/actionlint/issues/237
-          - python-version: ${{ github.event_name != 'schedule' && '3.9' }}
-          - python-version: ${{ github.event_name != 'schedule' && '3.10' }}
-          - python-version: ${{ github.event_name != 'schedule' && '3.11' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.9' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
 
     steps:
       - name: Checkout
@@ -310,8 +310,8 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
-          - python-version: ${{ github.event_name != 'schedule' && '3.9' }}
-          - python-version: ${{ github.event_name != 'schedule' && '3.10' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.9' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Changes here should enable the full CI pipeline to run for every event type except for `pull_request`.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
