### PR TITLE
[MAINTENANCE] Change default testing level from WARNING to INFO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -538,5 +538,4 @@ testpaths = "tests"
 # https://pytest-mock.readthedocs.io/en/latest/configuration.html#use-standalone-mock-package
 mock_use_standalone_module = false
 # https://docs.pytest.org/en/7.1.x/how-to/logging.html#how-to-manage-logging
-# WARNING some cli v012 tests may fail if this is "info" or lower
 log_level = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -540,4 +540,4 @@ mock_use_standalone_module = false
 # https://docs.pytest.org/en/7.1.x/how-to/logging.html#how-to-manage-logging
 # uncomment to adjust captured log levels
 # WARNING some cli v012 tests may fail if this is altered
-# log_level = "info"
+log_level = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -538,6 +538,5 @@ testpaths = "tests"
 # https://pytest-mock.readthedocs.io/en/latest/configuration.html#use-standalone-mock-package
 mock_use_standalone_module = false
 # https://docs.pytest.org/en/7.1.x/how-to/logging.html#how-to-manage-logging
-# uncomment to adjust captured log levels
-# WARNING some cli v012 tests may fail if this is altered
+# WARNING some cli v012 tests may fail if this is "info" or lower
 log_level = "info"


### PR DESCRIPTION
This change was previously not possible because some of our v12 CLI tests were checking for emitted logs as part of their failure condition. These have since been removed.

This should make debugging failing tests much easier.

Note: pytest captures any logs emitted during test execution and only displays them as part of the test failure output.
https://docs.pytest.org/en/7.1.x/how-to/logging.html#how-to-manage-logging

---------

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more details, see our [Contribution Checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist), [Coding style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style), and [Documentation style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/docs_style).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
