### PR TITLE
[BUGFIX] PR title checker's code should handle apostrophes

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name : Check PR title validity
       run: |
-        echo ${{ github.event.pull_request.title }} | grep -E "^\\[(FEATURE|BUGFIX|DOCS|MAINTENANCE|CONTRIB|RELEASE)\\]"
+        echo "${{ github.event.pull_request.title }}" | grep -E "^\\[(FEATURE|BUGFIX|DOCS|MAINTENANCE|CONTRIB|RELEASE)\\]"
         if [ $? -ne 0 ]; then
         echo "Invalid PR title - please prefix with one of: [FEATURE] | [BUGFIX] | [DOCS] | [MAINTENANCE] | [CONTRIB] | [RELEASE]"
           exit 1


### PR DESCRIPTION
Error:
<img width="1413" alt="Screenshot 2023-08-08 at 11 36 41 AM" src="https://github.com/great-expectations/great_expectations/assets/2117313/78197f10-92a4-492b-a93b-2d19df709b18">

Test:
- PR title checker should pass for this PR

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
