### PR TITLE
[BUGFIX] Patch `add_or_update_expectation_suite` with Cloud-backed contexts

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -631,6 +631,9 @@ class CloudDataContext(SerializableDataContext):
 
         Returns:
             An existing ExpectationSuite
+
+        Raises:
+            DataContextError: There is no expectation suite with the name provided
         """
         if ge_cloud_id is None and expectation_suite_name is None:
             raise ValueError(
@@ -648,7 +651,7 @@ class CloudDataContext(SerializableDataContext):
                 dict, self.expectations_store.get(key)
             )
         except StoreBackendError:
-            raise ValueError(
+            raise DataContextError(
                 f"Unable to load Expectation Suite {key.resource_name or key.id}"
             )
 

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -447,7 +447,7 @@ def test_get_expectation_suite_nonexistent_suite_raises_error(
 
     suite_id = "abc123"
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(DataContextError) as e:
         with mock.patch(
             "requests.Session.get", autospec=True, side_effect=mocked_404_response
         ):
@@ -590,7 +590,8 @@ def test_add_or_update_expectation_suite_adds_new_obj(
         f"{GXCloudStoreBackend.__module__}.{GXCloudStoreBackend.__name__}.has_key",
         return_value=False,
     ), mock.patch(
-        "requests.Session.get", autospec=True, side_effect=DataContextError("not found")
+        "great_expectations.data_context.data_context.cloud_data_context.CloudDataContext.get_expectation_suite",
+        side_effect=DataContextError("not found"),
     ) as mock_get, mock.patch(
         "requests.Session.post",
         autospec=True,


### PR DESCRIPTION
`get_expectation_suite` should raise `DataContextError` if the retrieval misses but the Cloud context override used `ValueError` - this resulted in both `get_expectation_suite` and any users of that method (namely `add_or_update_expectation_suite`) being broken with `CloudDataContext`.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
