### PR TITLE
[MAINTENANCE] Github Actions DocsChange Step with Checkout Stage added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     # check whether docs were changed
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: read
     outputs:
       docs: ${{ steps.filter.outputs.docs }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2
       id: filter
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     # check whether docs were changed
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       docs: ${{ steps.filter.outputs.docs }}


### PR DESCRIPTION
 # Why was this PR needed? 
* [Relevant discussion in the `paths-filter` repo is here](https://github.com/dorny/paths-filter/issues/24)
* Github action job for checking code changes needed to check out code for Non-pull requests. Otherwise it was failing with a `fatal: not a git repository (or any of the parent directories): .git` error. 

![Screenshot 2023-08-10 at 5 04 19 PM](https://github.com/great-expectations/great_expectations/assets/25670697/c5f1c10a-f63e-4fb6-a7b0-f78e55dd57ac)
![Screenshot 2023-08-10 at 5 03 17 PM](https://github.com/great-expectations/great_expectations/assets/25670697/7587d35d-b864-4c34-8cf2-bb9c195e3753)
* This PR adds a checkout step, so the step is able to pass: 
![Screenshot 2023-08-10 at 5 01 11 PM](https://github.com/great-expectations/great_expectations/assets/25670697/45d2ce63-c489-4388-9dbd-6209dadbdea0)
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
