### PR TITLE
[BUGFIX] Query Template not always String

### DIFF
--- a/great_expectations/expectations/metrics/query_metrics/query_template_values.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_template_values.py
@@ -28,7 +28,7 @@ class QueryTemplateValues(QueryMetricProvider):
     @classmethod
     def get_query(cls, query, template_dict, selectable):
         template_dict_reformatted = {
-            k: str(v).format(active_batch=selectable)
+            k: sa.text(v).format(active_batch=selectable)
             if isinstance(v, int)
             else v.format(active_batch=selectable)
             for k, v in template_dict.items()

--- a/great_expectations/expectations/metrics/query_metrics/query_template_values.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_template_values.py
@@ -28,7 +28,10 @@ class QueryTemplateValues(QueryMetricProvider):
     @classmethod
     def get_query(cls, query, template_dict, selectable):
         template_dict_reformatted = {
-            k: str(v).format(active_batch=selectable) for k, v in template_dict.items()
+            k: str(v).format(active_batch=selectable)
+            if isinstance(v, int)
+            else v.format(active_batch=selectable)
+            for k, v in template_dict.items()
         }
         query_reformatted = query.format(
             **template_dict_reformatted, active_batch=selectable


### PR DESCRIPTION
Follow up to #8562 where we need to consider both `int` and `sa.text()` values to be a query template. Adds conversion in cases where the input is `int`

@itaise could you check if this works for your Expectations? 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated