### PR TITLE
[MAINTENANCE] Deprecate misc method around batch kwargs and validation operators on DataContext

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3773,6 +3773,9 @@ class AbstractDataContext(ConfigPeer, ABC):
             id=id,
         )
 
+    @deprecated_method_or_class(
+        version="0.17.10", message="Part of the deprecated v2 API"
+    )
     def add_validation_operator(
         self, validation_operator_name: str, validation_operator_config: dict
     ) -> ValidationOperator:
@@ -3908,8 +3911,19 @@ class AbstractDataContext(ConfigPeer, ABC):
                 **kwargs,
             )
 
+    @deprecated_method_or_class(
+        version="0.17.10", message="Part of the deprecated v2 API"
+    )
     def list_validation_operators(self):
         """List currently-configured Validation Operators on this context"""
+
+        # deprecated-v0.17.10
+        warnings.warn(
+            "list_validation_operator is deprecated as of v0.17.10 and will be removed in v0.20. "
+            "Validation operators and their related methods are from our legacy V2 API and will not be supported moving forward; "
+            "please pin your version of GX or reference our documentation to migrate your project to the current API.",
+            DeprecationWarning,
+        )
 
         validation_operators = []
         for (
@@ -3920,8 +3934,19 @@ class AbstractDataContext(ConfigPeer, ABC):
             validation_operators.append(value)
         return validation_operators
 
+    @deprecated_method_or_class(
+        version="0.17.10", message="Part of the deprecated v2 API"
+    )
     def list_validation_operator_names(self):
         """List the names of currently-configured Validation Operators on this context"""
+        # deprecated-v0.17.10
+        warnings.warn(
+            "list_validation_operator_names is deprecated as of v0.17.10 and will be removed in v0.20. "
+            "Validation operators and their related methods are from our legacy V2 API and will not be supported moving forward; "
+            "please pin your version of GX or reference our documentation to migrate your project to the current API.",
+            DeprecationWarning,
+        )
+
         if not self.validation_operators:
             return []
 
@@ -4225,6 +4250,9 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         }
         return fluent_and_config_data_asset_names
 
+    @deprecated_method_or_class(
+        version="0.17.10", message="Part of the deprecated v2 API"
+    )
     def build_batch_kwargs(
         self,
         datasource,
@@ -4245,6 +4273,14 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             BatchKwargs
 
         """
+        # deprecated-v0.17.10
+        warnings.warn(
+            "build_batch_kwargs is deprecated as of v0.17.10 and will be removed in v0.20. "
+            "Batch kwargs and their related methods are from our legacy V2 API and will not be supported moving forward; "
+            "please pin your version of GX or reference our documentation to migrate your project to the current API.",
+            DeprecationWarning,
+        )
+
         datasource_obj = self.get_datasource(datasource)
         batch_kwargs = datasource_obj.build_batch_kwargs(
             batch_kwargs_generator=batch_kwargs_generator,

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1234,31 +1234,35 @@ def test_scaffold_directories(tmp_path_factory):
 
 @pytest.mark.filesystem
 def test_build_batch_kwargs(titanic_multibatch_data_context):
-    batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
-        "mydatasource",
-        "mygenerator",
-        data_asset_name="titanic",
-        partition_id="Titanic_1912",
-    )
+    with pytest.deprecated_call():
+        batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
+            "mydatasource",
+            "mygenerator",
+            data_asset_name="titanic",
+            partition_id="Titanic_1912",
+        )
     assert os.path.relpath("./data/titanic/Titanic_1912.csv") in batch_kwargs["path"]
 
-    batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
-        "mydatasource",
-        "mygenerator",
-        data_asset_name="titanic",
-        partition_id="Titanic_1911",
-    )
+    with pytest.deprecated_call():
+        batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
+            "mydatasource",
+            "mygenerator",
+            data_asset_name="titanic",
+            partition_id="Titanic_1911",
+        )
     assert os.path.relpath("./data/titanic/Titanic_1911.csv") in batch_kwargs["path"]
 
     paths = []
-    batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
-        "mydatasource", "mygenerator", data_asset_name="titanic"
-    )
+    with pytest.deprecated_call():
+        batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
+            "mydatasource", "mygenerator", data_asset_name="titanic"
+        )
     paths.append(os.path.basename(batch_kwargs["path"]))  # noqa: PTH119
 
-    batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
-        "mydatasource", "mygenerator", data_asset_name="titanic"
-    )
+    with pytest.deprecated_call():
+        batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(
+            "mydatasource", "mygenerator", data_asset_name="titanic"
+        )
     paths.append(os.path.basename(batch_kwargs["path"]))  # noqa: PTH119
 
     assert {"Titanic_1912.csv", "Titanic_1911.csv"} == set(paths)
@@ -1383,14 +1387,16 @@ def test_list_validation_operators_data_context_with_none_returns_empty_list(
     titanic_data_context,
 ):
     titanic_data_context.validation_operators = {}
-    assert titanic_data_context.list_validation_operator_names() == []
+    with pytest.deprecated_call():
+        assert titanic_data_context.list_validation_operator_names() == []
 
 
 @pytest.mark.unit
 def test_list_validation_operators_data_context_with_one(titanic_data_context):
-    assert titanic_data_context.list_validation_operator_names() == [
-        "action_list_operator"
-    ]
+    with pytest.deprecated_call():
+        assert titanic_data_context.list_validation_operator_names() == [
+            "action_list_operator"
+        ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Add deprecation tags and warnings to V2 methods

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
