### PR TITLE
[BUGFIX] Fix faulty logic around writing to .gitignore in context root dir

### DIFF
--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -46,6 +46,7 @@ class SerializableDataContext(AbstractDataContext):
 
     UNCOMMITTED_DIRECTORIES = ["data_docs", "validations"]
     GX_UNCOMMITTED_DIR = "uncommitted"
+    GITIGNORE = ".gitignore"
     BASE_DIRECTORIES = [
         DataContextConfigDefaults.CHECKPOINTS_BASE_DIRECTORY.value,
         DataContextConfigDefaults.EXPECTATIONS_BASE_DIRECTORY.value,
@@ -321,15 +322,16 @@ class SerializableDataContext(AbstractDataContext):
     @classmethod
     def _scaffold_gitignore(cls, base_dir: PathStr) -> None:
         """Make sure .gitignore exists and contains uncommitted/"""
-        gitignore = pathlib.Path(base_dir) / ".gitignore"
+        gitignore = pathlib.Path(base_dir) / cls.GITIGNORE
 
+        uncommitted_dir = f"{cls.GX_UNCOMMITTED_DIR}/"
         if gitignore.is_file():
-            lines = gitignore.read_text().splitlines()
-            if "uncommited/" in lines:
+            contents = gitignore.read_text()
+            if uncommitted_dir in contents:
                 return
 
-        with open(gitignore, "a") as f:
-            f.write("\nuncommitted/")
+        with gitignore.open("a") as f:
+            f.write(f"\n{uncommitted_dir}")
 
     @classmethod
     def _scaffold_custom_data_docs(cls, plugins_dir: PathStr) -> None:

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -3027,9 +3027,6 @@ def test_file_backed_context_updates_existing_gitignore(tmp_path: pathlib.Path):
     uncommitted = context_path / FileDataContext.GX_UNCOMMITTED_DIR
     gitignore = context_path / FileDataContext.GITIGNORE
 
-    assert not uncommitted.exists()
-    assert not gitignore.exists()
-
     # Scaffold necessary files so `get_context` updates rather than creates
     uncommitted.mkdir(parents=True)
     existing_value = "__pycache__/"


### PR DESCRIPTION
Typo caused us to write to disk when we shouldn't

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
