### PR TITLE
[MAINTENANCE] Update the CTA in the Data Docs footer

### DIFF
--- a/great_expectations/render/view/templates/cloud-footer.j2
+++ b/great_expectations/render/view/templates/cloud-footer.j2
@@ -1,4 +1,4 @@
 
 <footer>
-  <p>Explore how Great Expectations Cloud visualizes and creates shareable links for anyone on your team. <a href="https://greatexpectations.io/blog/why-gx-cloud?utm_source=os-data-docs&utm_medium=internal-display&utm_campaign=eid6a&utm_content=footer-text">Check out GX Cloud.</a></p>
+  <p>Stay current on everything GX with our newsletter <a href="https://greatexpectations.io/newsletter?utm_source=datadocs&utm_medium=product&utm_campaign=newsletter&utm_content=form">Subscribe</a></p>
 </footer>


### PR DESCRIPTION
Updates the CTA in the Data Docs footer

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

