### PR TITLE
[MAINTENANCE] Clean-up: Renaming "self-initializing" to "auto-initializing"

### DIFF
--- a/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
+++ b/docs/docusaurus/docs/guides/expectations/how_to_use_auto_initializing_expectations.md
@@ -35,7 +35,7 @@ To check whether the Expectation you are interested in works under the auto-init
 
 For example:
 
-```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_self_initializing False"
+```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_auto_initializing False"
 ```
 
 will return `False` and print the message:
@@ -46,7 +46,7 @@ The Expectation expect_column_to_exist is not able to be auto-initialized.
 
 However, the command:
 
-```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_self_initializing True"
+```python name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_auto_initializing True"
 ```
 
 will return `True` and print the message:

--- a/docs/sphinx_api_docs_source/public_api_missing_threshold.py
+++ b/docs/sphinx_api_docs_source/public_api_missing_threshold.py
@@ -62,7 +62,7 @@ ITEMS_IGNORED_FROM_PUBLIC_API = [
     "File: great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py Name: validate_configuration",
     "File: great_expectations/expectations/core/expect_compound_columns_to_be_unique.py Name: validate_configuration",
     "File: great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py Name: validate_configuration",
-    "File: great_expectations/expectations/expectation.py Name: is_expectation_self_initializing",
+    "File: great_expectations/expectations/expectation.py Name: is_expectation_auto_initializing",
     "File: great_expectations/expectations/expectation.py Name: validate_configuration",
     "File: great_expectations/expectations/metrics/map_metric_provider/column_pair_condition_partial.py Name: column_pair_condition_partial",
     "File: great_expectations/expectations/metrics/map_metric_provider/multicolumn_condition_partial.py Name: multicolumn_condition_partial",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1716,11 +1716,11 @@ class Expectation(metaclass=MetaExpectation):
             )
         if "auto" in expectation_impl.default_kwarg_values:
             print(
-                f"The Expectation {name} is able to be self-initialized. Please run by using the auto=True parameter."
+                f"The Expectation {name} is able to be auto-initialized. Please run by using the auto=True parameter."
             )
             return True
         else:
-            print(f"The Expectation {name} is not able to be self-initialized.")
+            print(f"The Expectation {name} is not able to be auto-initialized.")
             return False
 
     @staticmethod

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -35,7 +35,10 @@ from dateutil.parser import parse
 
 from great_expectations import __version__ as ge_version
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core._docs_decorators import public_api
+from great_expectations.core._docs_decorators import (
+    deprecated_method_or_class,
+    public_api,
+)
 from great_expectations.core.expectation_configuration import (
     ExpectationConfiguration,
     parse_result_format,
@@ -1678,7 +1681,23 @@ class Expectation(metaclass=MetaExpectation):
         return None
 
     @staticmethod
+    @deprecated_method_or_class(
+        version="0.17.11", message="Please use is_expectation_auto_initializing instead"
+    )
     def is_expectation_self_initializing(name: str) -> bool:
+        """
+        Given the name of an Expectation, returns a boolean that represents whether an Expectation can be auto-intialized.
+
+        Args:
+            name (str): name of Expectation
+
+        Returns:
+            boolean that represents whether an Expectation can be auto-initialized. Information also outputted to logger.
+        """
+        return Expectation.is_expectation_auto_initializing(name=name)
+
+    @staticmethod
+    def is_expectation_auto_initializing(name: str) -> bool:
         """
         Given the name of an Expectation, returns a boolean that represents whether an Expectation can be auto-intialized.
 

--- a/tests/expectations/test_expectation_auto_initializing.py
+++ b/tests/expectations/test_expectation_auto_initializing.py
@@ -7,12 +7,12 @@ from great_expectations.expectations.expectation import Expectation
 pytestmark = pytest.mark.unit
 
 
-def test_expectation_is_expectation_self_initializing(capsys):
+def test_expectation_is_expectation_auto_initializing(capsys):
     with pytest.raises(gx_exceptions.ExpectationNotFoundError):
-        Expectation.is_expectation_self_initializing(name="I_dont_exist")
+        Expectation.is_expectation_auto_initializing(name="I_dont_exist")
 
     assert (
-        Expectation.is_expectation_self_initializing(
+        Expectation.is_expectation_auto_initializing(
             name="expect_column_distinct_values_to_be_in_set"
         )
         is False
@@ -24,7 +24,7 @@ def test_expectation_is_expectation_self_initializing(capsys):
     )
 
     assert (
-        Expectation.is_expectation_self_initializing(
+        Expectation.is_expectation_auto_initializing(
             name="expect_column_mean_to_be_between"
         )
         is True

--- a/tests/expectations/test_expectation_auto_initializing.py
+++ b/tests/expectations/test_expectation_auto_initializing.py
@@ -19,7 +19,7 @@ def test_expectation_is_expectation_auto_initializing(capsys):
     )
     captured = capsys.readouterr()
     assert (
-        "The Expectation expect_column_distinct_values_to_be_in_set is not able to be self-initialized."
+        "The Expectation expect_column_distinct_values_to_be_in_set is not able to be auto-initialized."
         in captured.out
     )
 
@@ -31,6 +31,6 @@ def test_expectation_is_expectation_auto_initializing(capsys):
     )
     captured = capsys.readouterr()
     assert (
-        "The Expectation expect_column_mean_to_be_between is able to be self-initialized. Please run by using the auto=True parameter."
+        "The Expectation expect_column_mean_to_be_between is able to be auto-initialized. Please run by using the auto=True parameter."
         in captured.out
     )

--- a/tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py
+++ b/tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py
@@ -12,22 +12,22 @@ the snippets that are specified for use in documentation are maintained.  These 
 --documentation--
     https://docs.greatexpectations.io/docs/
 """
-# <snippet name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_self_initializing False">
+# <snippet name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_auto_initializing False">
 from great_expectations.expectations.expectation import Expectation
 
-Expectation.is_expectation_self_initializing(name="expect_column_to_exist")
+Expectation.is_expectation_auto_initializing(name="expect_column_to_exist")
 # </snippet>
 
-# <snippet name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_self_initializing True">
-Expectation.is_expectation_self_initializing(name="expect_column_mean_to_be_between")
+# <snippet name="tests/integration/docusaurus/expectations/auto_initializing_expectations/is_expectation_auto_initializing.py is_expectation_auto_initializing True">
+Expectation.is_expectation_auto_initializing(name="expect_column_mean_to_be_between")
 # </snippet>
 
 # NOTE: The following assertions are only for testing and can be ignored by users.
 assert (
-    Expectation.is_expectation_self_initializing(name="expect_column_to_exist") is False
+    Expectation.is_expectation_auto_initializing(name="expect_column_to_exist") is False
 )
 assert (
-    Expectation.is_expectation_self_initializing(
+    Expectation.is_expectation_auto_initializing(
         name="expect_column_mean_to_be_between"
     )
     is True

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample_Pandas.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample_Pandas.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample_Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample_Spark.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -8,7 +8,7 @@
     "# How to write multi-batch `BatchRequest` - Configured `Sql` Example\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample_Pandas.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample_Pandas.ipynb
@@ -8,7 +8,7 @@
     "# How to write multi-batch `BatchRequest` - `InferredAsset` Example for Pandas\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample_Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample_Spark.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetSQLExample.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetSQLExample.ipynb
@@ -8,7 +8,7 @@
     "# How to write multi-batch `BatchRequest` - Inferred `Sql` Example\n",
     "* A `BatchRequest` facilitates the return of one or more `batch(es)` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_one_or_more_batches_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
     "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   1. Auto-Initializing Expectations to estimate parameters\n",
     "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
     "   \n",
     "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
@@ -19,12 +19,12 @@
    "id": "a25cb0ae-94d9-4584-ac3a-6d5685ca2201",
    "metadata": {},
    "source": [
-    "# Self-Initializing Expectations\n",
-    "- Self-initializing `Expectations` utilize `RuleBasedProfilers` to automate parameter estimation for Expectations using a Batch or Batches that have been loaded into a `Validator`. \n",
+    "# Auto-Initializing Expectations\n",
+    "- Auto-initializing `Expectations` utilize `RuleBasedProfilers` to automate parameter estimation for Expectations using a Batch or Batches that have been loaded into a `Validator`. \n",
     "\n",
     "### Do they work for all `Expectations`?\n",
-    "- No, not all `Expectations` have parameters that can be estimated. As an example, `ExpectColumnToExist` only takes in a `Domain` (which is the column name) and checks whether the column name is in the list of names in the table's metadata. It would be an example of an `Expectation` that would not work under the self-initializing framework. \n",
-    "- An example of an `Expectation` that would work under the self-initializing framework would be ones that have numeric ranges, like `ExpectColumnMeanToBeBetween`, `ExpectColumnMaxToBeBetween`, and `ExpectColumnSumToBeBetween`\n",
+    "- No, not all `Expectations` have parameters that can be estimated. As an example, `ExpectColumnToExist` only takes in a `Domain` (which is the column name) and checks whether the column name is in the list of names in the table's metadata. It would be an example of an `Expectation` that would not work under the auto-initializing framework. \n",
+    "- An example of an `Expectation` that would work under the auto-initializing framework would be ones that have numeric ranges, like `ExpectColumnMeanToBeBetween`, `ExpectColumnMaxToBeBetween`, and `ExpectColumnSumToBeBetween`\n",
     "- To check whether the `Expectation` you are interested in by running the `is_expectation_self_initializing()` method on `Expectations`. "
    ]
   },
@@ -38,7 +38,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Expectation expect_column_to_exist is not able to be self-initialized.\n"
+      "The Expectation expect_column_to_exist is not able to be auto-initialized.\n"
      ]
     },
     {
@@ -66,7 +66,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Expectation expect_column_mean_to_be_between is able to be self-initialized. Please run by using the auto=True parameter.\n"
+      "The Expectation expect_column_mean_to_be_between is able to be auto-initialized. Please run by using the auto=True parameter.\n"
      ]
     },
     {
@@ -97,7 +97,7 @@
    "id": "492f223a",
    "metadata": {},
    "source": [
-    "* To setup an example usecase for self-initializing `Expectations`, we will start from a new Great Expectations Data Context (ie `great_expectations` folder after running `great_expectations init`), and begin by adding the `Datasource`, and configuring a `BatchRequest`"
+    "* To setup an example usecase for auto-initializing `Expectations`, we will start from a new Great Expectations Data Context (ie `great_expectations` folder after running `great_expectations init`), and begin by adding the `Datasource`, and configuring a `BatchRequest`"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "id": "31bf7beb",
    "metadata": {},
    "source": [
-    "# Running Self-Initializing Expectation"
+    "# Running Auto-Initializing Expectation"
    ]
   },
   {
@@ -533,7 +533,7 @@
    "id": "da1b2a9b-3b72-453b-9d7f-e4774e15dc73",
    "metadata": {},
    "source": [
-    "Self-initializing `Expectations` automate this sort of calculation across batches. To do perform the same calculation described above (the mean ranges across the 12 `Batches` in the 2018 data), the only thing you need to do is run the `Expectation` with `auto=True`."
+    "Auto-initializing `Expectations` automate this sort of calculation across batches. To do perform the same calculation described above (the mean ranges across the 12 `Batches` in the 2018 data), the only thing you need to do is run the `Expectation` with `auto=True`."
    ]
   },
   {
@@ -648,7 +648,7 @@
    "id": "d09a8920",
    "metadata": {},
    "source": [
-    "# How to write your own self-initializing Expectation"
+    "# How to write your own auto-initializing Expectation"
    ]
   },
   {
@@ -656,7 +656,7 @@
    "id": "1edb05aa",
    "metadata": {},
    "source": [
-    "Inside each of the `Expectatations` is a `RuleBasedProfiler` configuration that is run by the `Validator` when building the `ExpectationConfiguration`. Writing your own self-initializing `Expectation` involved writing your own `RuleBasedProfiler` configuration (or adapting an existing configuration) to automatically estimate the parameters that the `Expectation` requires. For more information on `RuleBasedProfiler` components, and their requirements, please refer to the [RBP Jupyter Notebook](https://github.com/great-expectations/great_expectations/blob/d91fe2e801879f8c407082dd4330dbe9a11d2d78/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb)\n"
+    "Inside each of the `Expectatations` is a `RuleBasedProfiler` configuration that is run by the `Validator` when building the `ExpectationConfiguration`. Writing your own auto-initializing `Expectation` involved writing your own `RuleBasedProfiler` configuration (or adapting an existing configuration) to automatically estimate the parameters that the `Expectation` requires. For more information on `RuleBasedProfiler` components, and their requirements, please refer to the [RBP Jupyter Notebook](https://github.com/great-expectations/great_expectations/blob/d91fe2e801879f8c407082dd4330dbe9a11d2d78/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb)\n"
    ]
   },
   {

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
@@ -53,7 +53,7 @@
     }
    ],
    "source": [
-    "Expectation.is_expectation_self_initializing(name=\"expect_column_to_exist\")"
+    "Expectation.is_expectation_auto_initializing(name=\"expect_column_to_exist\")"
    ]
   },
   {
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "Expectation.is_expectation_self_initializing(name=\"expect_column_mean_to_be_between\")"
+    "Expectation.is_expectation_auto_initializing(name=\"expect_column_mean_to_be_between\")"
    ]
   },
   {


### PR DESCRIPTION
We had both terms used interchangeably, this PR consolidates to "auto-initializing"

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated