### PR TITLE
[MAINTENANCE] Fix Azure CI packaging step

### DIFF
--- a/ci/dev-install-matrix.yml
+++ b/ci/dev-install-matrix.yml
@@ -31,7 +31,7 @@ jobs:
 
         - script: |
             pip install pytest pytest-cov pytest-azurepipelines
-            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "unit or big or filesystem"
           displayName: 'pytest'
 
         - task: PublishTestResults@2
@@ -74,7 +74,7 @@ jobs:
         - script: |
             pip install -I pytest
             pip install pytest-cov pytest-azurepipelines
-            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "not external_sqldialect"
+            pytest --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics -m "unit or big or filesystem"
           displayName: 'pytest'
 
         - task: PublishTestResults@2

--- a/ci/dev-install-matrix.yml
+++ b/ci/dev-install-matrix.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
   - ${{ each pythonVersion in parameters.pythonVersion }}:
     - job:
-      timeoutInMinutes: 120
+      timeoutInMinutes: 60
       displayName: full${{ pythonVersion }}
       steps:
         - task: UsePythonVersion@0
@@ -47,7 +47,7 @@ jobs:
             reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
     - job:
-      timeoutInMinutes: 120
+      timeoutInMinutes: 60
       displayName: lightweight${{ pythonVersion }}
       steps:
         - task: UsePythonVersion@0


### PR DESCRIPTION
Old packaging steps were failing because it was trying to run tests that it isn't setup for (snowflake, databricks etc.)
