### PR TITLE
[MAINTENANCE] Remove public usage stats method from context

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -40,6 +40,7 @@ from great_expectations.core.expectation_configuration import (
 )
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
+from great_expectations.core.usage_statistics.usage_statistics import send_usage_message
 from great_expectations.core.util import (
     convert_to_json_serializable,
     ensure_json_serializable,
@@ -622,7 +623,7 @@ class ExpectationSuite(SerializableDictDot):
 
         if len(found_expectation_indexes) > 1:
             if send_usage_event:
-                self.send_usage_event(success=False)
+                self._send_usage_event(success=False)
             raise ValueError(
                 "More than one matching expectation was found. Please be more specific with your search "
                 "criteria"
@@ -648,7 +649,7 @@ class ExpectationSuite(SerializableDictDot):
                 ] = expectation_configuration
             else:
                 if send_usage_event:
-                    self.send_usage_event(success=False)
+                    self._send_usage_event(success=False)
 
                 raise gx_exceptions.DataContextError(
                     "A matching ExpectationConfiguration already exists. If you would like to overwrite this "
@@ -658,16 +659,16 @@ class ExpectationSuite(SerializableDictDot):
             self.append_expectation(expectation_configuration)
 
         if send_usage_event:
-            self.send_usage_event(success=True)
+            self._send_usage_event(success=True)
 
         return expectation_configuration
 
-    def send_usage_event(self, success: bool) -> None:
-        usage_stats_event_payload: dict = {}
+    def _send_usage_event(self, success: bool) -> None:
         if self._data_context is not None:
-            self._data_context.send_usage_message(
+            send_usage_message(
+                data_context=self._data_context,
                 event=UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION,
-                event_payload=usage_stats_event_payload,
+                event_payload={},
                 success=success,
             )
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -131,7 +131,6 @@ from great_expectations.core.usage_statistics.usage_statistics import (  # isort
     get_batch_list_usage_statistics,
     run_validation_operator_usage_statistics,
     save_expectation_suite_usage_statistics,
-    send_usage_message,
     usage_statistics_enabled_method,
 )
 from great_expectations.checkpoint import Checkpoint
@@ -5064,21 +5063,6 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
                             "metric {} was requested by another expectation suite but is not available in "
                             "this validation result.".format(metric_name)
                         )
-
-    def send_usage_message(
-        self, event: str, event_payload: Optional[dict], success: Optional[bool] = None
-    ) -> None:
-        """helper method to send a usage method using DataContext. Used when sending usage events from
-            classes like ExpectationSuite.
-            event
-        Args:
-            event (str): str representation of event
-            event_payload (dict): optional event payload
-            success (bool): optional success param
-        Returns:
-            None
-        """
-        send_usage_message(self, event, event_payload, success)
 
     def _determine_if_expectation_suite_include_rendered_content(
         self, include_rendered_content: Optional[bool] = None

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -1031,7 +1031,7 @@ def test_expectation_suite_send_usage_message(success: bool):
         data_context=dc_message_spy,  # type: ignore[arg-type]
     )
 
-    suite.send_usage_event(success=success)
+    suite._send_usage_event(success=success)
 
     assert dc_message_spy.messages
     assert len(dc_message_spy.messages) == 1


### PR DESCRIPTION
In an effort to streamline the context API, let's remove extraneous methods like this one

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
