### PR TITLE
[MAINTENANCE] Ignore `pandas` warning emitted through `altair` codepath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,6 +452,7 @@ filterwarnings = [
     'ignore: The default dtype for empty Series will be:FutureWarning',
     # Example Actual Warning: Found by running tests/render/test_column_section_renderer.py::test_ProfilingResultsColumnSectionRenderer_render_bar_chart_table with Pandas 2.0. The warning is emitted through an Altair v5 codepath.
     # FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
+    # GH Issue: https://github.com/altair-viz/altair/issues/3181
     'ignore: the convert_dtype parameter is deprecated and will be removed in a future version:FutureWarning',
 
     # numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,6 +450,9 @@ filterwarnings = [
     # Example Actual Warning: Found by running tests/expectations/metrics/test_core.py::test_value_counts_metric_spark
     # FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
     'ignore: The default dtype for empty Series will be:FutureWarning',
+    # Example Actual Warning: Found by running tests/render/test_column_section_renderer.py::test_ProfilingResultsColumnSectionRenderer_render_bar_chart_table with Pandas 2.0. The warning is emitted through an Altair v5 codepath.
+    # FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
+    'ignore: the convert_dtype parameter is deprecated and will be removed in a future version:FutureWarning'
 
     # numpy
     # Example Actual Warning: RuntimeWarning: Mean of empty slice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,7 +452,7 @@ filterwarnings = [
     'ignore: The default dtype for empty Series will be:FutureWarning',
     # Example Actual Warning: Found by running tests/render/test_column_section_renderer.py::test_ProfilingResultsColumnSectionRenderer_render_bar_chart_table with Pandas 2.0. The warning is emitted through an Altair v5 codepath.
     # FutureWarning: the convert_dtype parameter is deprecated and will be removed in a future version.  Do ``ser.astype(object).apply()`` instead if you want ``convert_dtype=False``.
-    'ignore: the convert_dtype parameter is deprecated and will be removed in a future version:FutureWarning'
+    'ignore: the convert_dtype parameter is deprecated and will be removed in a future version:FutureWarning',
 
     # numpy
     # Example Actual Warning: RuntimeWarning: Mean of empty slice.


### PR DESCRIPTION
Altair v5 with Pandas v2 emits this deprecation warning - we need Altair to change their method call to fix this so ignoring for the time being. Note that this only shows up in 3.11 in our CI due to our version-based pins.

Issue: https://github.com/altair-viz/altair/issues/3181

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
