### PR TITLE
[BUGFIX] Raise warning if data_connector cannot be built on config load

### DIFF
--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -601,8 +601,6 @@ class Datasource(
             warnings.warn(
                 f"data_connector build failure for {self.name} assets - {', '.join(names_and_error)}",
                 category=RuntimeWarning,
-                # TODO: how does `source` work with warnings?
-                source=names_and_error,
             )
 
     @staticmethod

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -570,9 +570,10 @@ class Datasource(
     def _rebuild_asset_data_connectors(self) -> None:
         """
         If Datasource required a data_connector we need to build the data_connector for each asset.
-        If data_connector cannot be built for an asset, a warning is raised.
-        This is needed because not all users may have access to the needed credentials and dependencies
-        needed for all assets.
+
+        A warning is raised if a data_connector cannot be built for an asset.
+        Not all users will have access to the needed dependencies (packages or credentials) for every asset.
+        Missing dependencies will stop them from using the asset but should not stop them from loading it from config.
         """
         if self.data_connector_type:
             for data_asset in self.assets:

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -588,7 +588,7 @@ class Datasource(
                         f"Unable to build data_connector for {self.type} {data_asset.type} {data_asset.name}",
                         exc_info=True,
                     )
-                    # direct cause will be useful to users than a generic error
+                    # reveal direct cause instead of generic, unhelpful MyDatasourceError
                     asset_build_failure_direct_cause[data_asset.name] = (
                         dc_build_err.__cause__ or dc_build_err
                     )
@@ -601,6 +601,7 @@ class Datasource(
             warnings.warn(
                 f"data_connector build failure for {self.name} assets - {', '.join(names_and_error)}",
                 category=RuntimeWarning,
+                # TODO: how does `source` work with warnings?
                 source=names_and_error,
             )
 

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -418,8 +418,8 @@ def seeded_cloud_context(
 
 @pytest.fixture(
     params=[
-        pytest.param("seeded_file_context", marks=pytest.mark.filesystem),
-        pytest.param("seeded_cloud_context", marks=pytest.mark.cloud),
+        pytest.param("seeded_file_context", marks=[pytest.mark.filesystem]),
+        pytest.param("seeded_cloud_context", marks=[pytest.mark.cloud]),
     ]
 )
 def seeded_contexts(

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 import pathlib
+import warnings
 from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
@@ -331,6 +332,13 @@ def cloud_storage_get_client_doubles(
 
 
 @pytest.fixture
+def filter_data_connector_build_warning():
+    with warnings.catch_warnings() as w:
+        warnings.simplefilter("ignore", RuntimeWarning)
+        yield w
+
+
+@pytest.fixture
 def fluent_only_config(
     fluent_gx_config_yml_str: str, seed_ds_env_vars: tuple
 ) -> GxConfig:
@@ -365,7 +373,7 @@ def fluent_yaml_config_file(
 @pytest.fixture
 @functools.lru_cache(maxsize=1)
 def seeded_file_context(
-    cloud_storage_get_client_doubles,
+    filter_data_connector_build_warning,
     fluent_yaml_config_file: pathlib.Path,
     seed_ds_env_vars: tuple,
 ) -> FileDataContext:
@@ -378,7 +386,7 @@ def seeded_file_context(
 
 @pytest.fixture
 def seed_cloud(
-    cloud_storage_get_client_doubles,
+    filter_data_connector_build_warning,
     cloud_api_fake: responses.RequestsMock,
     fluent_only_config: GxConfig,
 ):

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -368,7 +368,7 @@ class TestPandasDefaultWithCloud:
         )
 
 
-# Test markers come from seeded_contexts fixture
+@pytest.mark.filesystem
 def test_data_connectors_are_built_on_config_load(
     cloud_storage_get_client_doubles,
     seeded_file_context: FileDataContext,

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -370,6 +370,7 @@ class TestPandasDefaultWithCloud:
 
 # Test markers come from seeded_contexts fixture
 def test_data_connectors_are_built_on_config_load(
+    cloud_storage_get_client_doubles,
     seeded_contexts: CloudDataContext | FileDataContext,
 ):
     """

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import re
 import urllib.parse
+from collections import defaultdict
 from pprint import pformat as pf
 from typing import TYPE_CHECKING
 
@@ -365,6 +366,35 @@ class TestPandasDefaultWithCloud:
             f"{cloud_details.base_url}/organizations/{cloud_details.org_id}/datasources/{pandas_default_id}",
             1,
         )
+
+
+# Test markers come from seeded_contexts fixture
+def test_data_connectors_are_built_on_config_load(
+    seeded_contexts: CloudDataContext | FileDataContext,
+):
+    """
+    Ensure that all Datasources that require data_connectors have their data_connectors
+    created when loaded from config.
+    """
+    context = seeded_contexts
+    dc_datasources: dict[str, list[str]] = defaultdict(list)
+
+    assert context.fluent_datasources
+    for datasource in context.fluent_datasources.values():
+        if datasource.data_connector_type:
+            print(f"class: {datasource.__class__.__name__}")
+            print(f"type: {datasource.type}")
+            print(f"data_connector: {datasource.data_connector_type.__name__}")
+            print(f"name: {datasource.name}", end="\n\n")
+
+            dc_datasources[datasource.type].append(datasource.name)
+
+            for asset in datasource.assets:
+                assert isinstance(asset._data_connector, datasource.data_connector_type)
+            print()
+
+    print(f"Datasources with DataConnectors\n{pf(dict(dc_datasources))}")
+    assert dc_datasources
 
 
 if __name__ == "__main__":

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -371,13 +371,13 @@ class TestPandasDefaultWithCloud:
 # Test markers come from seeded_contexts fixture
 def test_data_connectors_are_built_on_config_load(
     cloud_storage_get_client_doubles,
-    seeded_contexts: CloudDataContext | FileDataContext,
+    seeded_file_context: FileDataContext,
 ):
     """
     Ensure that all Datasources that require data_connectors have their data_connectors
     created when loaded from config.
     """
-    context = seeded_contexts
+    context = seeded_file_context
     dc_datasources: dict[str, list[str]] = defaultdict(list)
 
     assert context.fluent_datasources


### PR DESCRIPTION
  A warning is raised if a data_connector cannot be built for an asset.
  Not all users will have access to the needed dependencies (packages or credentials) for every asset.
  Missing dependencies will stop them from using the asset but should not stop them from loading it from config.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
