### PR TITLE
[BUGFIX] Missing CloudDataContext when loading from config

### DIFF
--- a/great_expectations/core/datasource_dict.py
+++ b/great_expectations/core/datasource_dict.py
@@ -112,6 +112,7 @@ class DatasourceDict(UserDict):
         return self._init_block_style_datasource(name=name, config=ds)
 
     def _init_fluent_datasource(self, ds: FluentDatasource) -> FluentDatasource:
+        ds._data_context = self._context
         ds._rebuild_asset_data_connectors()
         return ds
 

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -343,16 +343,6 @@ def verify_asset_names_mock(
     return cloud_api_fake
 
 
-def test_data_context_is_available(
-    seeded_contexts: FileDataContext | CloudDataContext,
-):
-    # FIXME: this test does not catch the regression
-    context = seeded_contexts
-    for datasource in context.datasources.values():
-        assert datasource._data_context
-        assert isinstance(datasource._data_context, type(seeded_contexts))
-
-
 class TestPandasDefaultWithCloud:
     @pytest.mark.cloud
     def test_payload_sent_to_cloud(

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -343,6 +343,16 @@ def verify_asset_names_mock(
     return cloud_api_fake
 
 
+def test_data_context_is_available(
+    seeded_contexts: FileDataContext | CloudDataContext,
+):
+    # FIXME: this test does not catch the regression
+    context = seeded_contexts
+    for datasource in context.datasources.values():
+        assert datasource._data_context
+        assert isinstance(datasource._data_context, type(seeded_contexts))
+
+
 class TestPandasDefaultWithCloud:
     @pytest.mark.cloud
     def test_payload_sent_to_cloud(


### PR DESCRIPTION
Always attach a DataContext when retrieving datasource
- Caused by #8608 

TODO: followup this up and simplify the config retrevial and hydration logic.

-----

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
