### PR TITLE
[BUGFIX] Databricks tests skipped for Forks

### DIFF
--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -287,7 +287,7 @@ class TestTableIdentifiers:
     ):
         table_name = TABLE_NAME_MAPPING["postgres"].get(asset_name)
         if not table_name:
-            pytest.skip(f"no '{asset_name}' table_name for databricks")
+            pytest.skip(f"no '{asset_name}' table_name for postgres")
         # create table
         table_factory(engine=postgres_ds.get_engine(), table_names={table_name})
 

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -207,7 +207,22 @@ def postgres_ds(context: EphemeralDataContext) -> PostgresDatasource:
 
 
 @pytest.fixture
-def databricks_sql_ds(context: EphemeralDataContext) -> DatabricksSQLDatasource:
+def databricks_creds_populated() -> bool:
+    if (
+        os.getenv("DATABRICKS_TOKEN")
+        or os.getenv("DATABRICKS_HOST")
+        or os.getenv("DATABRICKS_HTTP_PATH")
+    ):
+        return True
+    return False
+
+
+@pytest.fixture
+def databricks_sql_ds(
+    context: EphemeralDataContext, databricks_creds_populated: bool
+) -> DatabricksSQLDatasource:
+    if not databricks_creds_populated:
+        pytest.skip("no databricks credentials")
     ds = context.sources.add_databricks_sql(
         "databricks_sql",
         connection_string="databricks://token:"
@@ -316,7 +331,7 @@ class TestTableIdentifiers:
     ):
         table_name = TABLE_NAME_MAPPING["snowflake"].get(asset_name)
         if not table_name:
-            pytest.skip(f"no '{asset_name}' table_name for databricks")
+            pytest.skip(f"no '{asset_name}' table_name for snowflake")
         if not snowflake_ds:
             pytest.skip("no snowflake datasource")
         # create table


### PR DESCRIPTION
# What does this PR do? 
* Adds logic to skip `databricks` integration tests in cases where credentials dont exists (ie on contributor PRs)
* Uses same logic that we use for `snowflake` tests
* Typo in message

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
