### PR TITLE
[DOCS] Add redirects for module API docs

### DIFF
--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -236,6 +236,15 @@
 /docs/api_docs/methods/great_expectations-data_context-data_context-data_context-datacontext-test_yaml_config /docs/reference/api/abstract_data_context
 /docs/api_docs/methods/great_expectations-data_context-data_context-data_context-datacontext-create /docs/reference/api/great_expectations.util
 
+# Redirects for module API docs with .py suffix
+
+/docs/reference/api/core/util.py /docs/reference/api/core/util
+/docs/reference/api/data_context/data_context/context_factory.py /docs/reference/api/data_context/data_context/context_factory
+/docs/reference/api/expectations/expectation.py /docs/reference/api/expectations/expectation
+/docs/reference/api/expectations/registry.py /docs/reference/api/expectations/registry
+/docs/reference/api/expectations/util.py /docs/reference/api/expectations/util
+/docs/reference/api/render/util.py /docs/reference/api/render/util
+
 # Redirects for renamed reference docs
 
 /docs/reference/anonymous_usage_statistics /docs/reference/usage_statistics


### PR DESCRIPTION
Add redirects for the module level API docs ending in `.py` to the URLs without the `.py` suffix.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
