### PR TITLE
[MAINTENANCE] Column Descriptive Metrics: Return id from Data Store

### DIFF
--- a/great_expectations/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations/agent/actions/run_column_descriptive_metrics_action.py
@@ -38,6 +38,6 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
             id=id,
             type=event.type,
             created_resources=[
-                CreatedResource(resource_id=metric_run_id, type="MetricRun"),
+                CreatedResource(resource_id=str(metric_run_id), type="MetricRun"),
             ],
         )

--- a/great_expectations/agent/actions/run_column_descriptive_metrics_action.py
+++ b/great_expectations/agent/actions/run_column_descriptive_metrics_action.py
@@ -32,13 +32,12 @@ class ColumnDescriptiveMetricsAction(AgentAction[RunColumnDescriptiveMetricsEven
 
         metric_run = self._batch_inspector.compute_metric_run(batch_request)
 
-        self._metric_repository.add_metric_run(metric_run)
+        metric_run_id = self._metric_repository.add_metric_run(metric_run)
 
-        # TODO: What should resource_id be? Likely the returned id for the metric run from the rest API call.
         return ActionResult(
             id=id,
             type=event.type,
             created_resources=[
-                CreatedResource(resource_id="resource_id", type="MetricRun"),
+                CreatedResource(resource_id=metric_run_id, type="MetricRun"),
             ],
         )

--- a/great_expectations/experimental/metric_repository/data_store.py
+++ b/great_expectations/experimental/metric_repository/data_store.py
@@ -1,4 +1,5 @@
 import abc
+import uuid
 from typing import Generic, TypeVar
 
 from great_expectations.data_context import CloudDataContext
@@ -13,13 +14,13 @@ class DataStore(abc.ABC, Generic[T]):
         self._context = context
 
     @abc.abstractmethod
-    def add(self, value: T) -> T:
+    def add(self, value: T) -> uuid.UUID:
         """Add a value to the DataStore.
 
         Args:
             value: Value to add to the DataStore.
 
         Returns:
-            `value` passed in.
+            id of the created resource.
         """
         raise NotImplementedError

--- a/great_expectations/experimental/metric_repository/metric_repository.py
+++ b/great_expectations/experimental/metric_repository/metric_repository.py
@@ -1,3 +1,5 @@
+import uuid
+
 from great_expectations.experimental.metric_repository.data_store import DataStore
 from great_expectations.experimental.metric_repository.metrics import MetricRun
 
@@ -12,5 +14,5 @@ class MetricRepository:
     def __init__(self, data_store: DataStore):
         self._data_store = data_store
 
-    def add_metric_run(self, metric_run: MetricRun) -> MetricRun:
+    def add_metric_run(self, metric_run: MetricRun) -> uuid.UUID:
         return self._data_store.add(value=metric_run)

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -124,7 +124,36 @@ class TestCloudDataStoreMetricRun:
             ],
         )
         cloud_data_store._session = Mock()
-        cloud_data_store.add(metric_run)
+        cloud_data_store._session.post = Mock()
+        response_mock = Mock()
+        cloud_data_store._session.post.return_value = response_mock
+
+        response_metric_run_id = uuid.uuid4()
+        response_metric_id = uuid.uuid4()
+        response_mock.json.return_value = {
+            "data": {
+                "type": "metric-run",
+                "attributes": {
+                    "id": str(response_metric_run_id),
+                    "data_asset_id": str(data_asset_id),
+                    "metrics": [
+                        {
+                            "id": str(response_metric_id),
+                            "metric_type": "ColumnMetric",
+                            "value_type": "int",
+                            "batch_id": "batch_id",
+                            "column": "column",
+                            "exception": None,
+                            "metric_name": "metric_name",
+                            "value": 1,
+                        }
+                    ],
+                },
+            }
+        }
+
+        uuid_from_add = cloud_data_store.add(metric_run)
+
         cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data={
@@ -147,6 +176,7 @@ class TestCloudDataStoreMetricRun:
                 }
             },
         )
+        assert uuid_from_add == response_metric_run_id
 
     @pytest.mark.unit
     def test_add_metric_run_generic_metric_type_with_exception(

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import Mock
 from uuid import UUID
 
@@ -45,7 +46,38 @@ class TestCloudDataStoreMetricRun:
             ],
         )
         cloud_data_store._session = Mock()
-        cloud_data_store.add(metric_run)
+        cloud_data_store._session.post = Mock()
+        response_mock = Mock()
+        cloud_data_store._session.post.return_value = response_mock
+
+        response_metric_run_id = uuid.uuid4()
+        response_metric_id = uuid.uuid4()
+        response_mock.json.return_value = {
+            "data": {
+                "type": "metric-run",
+                "attributes": {
+                    "id": str(response_metric_run_id),
+                    "data_asset_id": str(data_asset_id),
+                    "metrics": [
+                        {
+                            "id": str(response_metric_id),
+                            "metric_type": "ColumnQuantileValuesMetric",
+                            "value_type": "list[float]",
+                            "allow_relative_error": 0.001,
+                            "batch_id": "batch_id",
+                            "column": "column",
+                            "exception": None,
+                            "metric_name": "metric_name",
+                            "quantiles": [0.25, 0.5, 0.75],
+                            "value": [0.25, 0.5, 0.75],
+                        }
+                    ],
+                },
+            }
+        }
+
+        uuid_from_add = cloud_data_store.add(metric_run)
+
         cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data={
@@ -70,6 +102,7 @@ class TestCloudDataStoreMetricRun:
                 }
             },
         )
+        assert uuid_from_add == response_metric_run_id
 
     @pytest.mark.unit
     def test_add_metric_run_generic_metric_type(

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -200,7 +200,39 @@ class TestCloudDataStoreMetricRun:
             ],
         )
         cloud_data_store._session = Mock()
-        cloud_data_store.add(metric_run)
+        cloud_data_store._session.post = Mock()
+        response_mock = Mock()
+        cloud_data_store._session.post.return_value = response_mock
+
+        response_metric_run_id = uuid.uuid4()
+        response_metric_id = uuid.uuid4()
+        response_mock.json.return_value = {
+            "data": {
+                "type": "metric-run",
+                "attributes": {
+                    "id": str(response_metric_run_id),
+                    "data_asset_id": str(data_asset_id),
+                    "metrics": [
+                        {
+                            "id": str(response_metric_id),
+                            "metric_type": "ColumnMetric",
+                            "value_type": "int",
+                            "batch_id": "batch_id",
+                            "column": "column",
+                            "exception": {
+                                "message": "exception message",
+                                "type": "exception type",
+                            },
+                            "metric_name": "metric_name",
+                            "value": 1,
+                        }
+                    ],
+                },
+            }
+        }
+
+        uuid_from_add = cloud_data_store.add(metric_run)
+
         cloud_data_store._session.post.assert_called_once_with(
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data={
@@ -226,3 +258,4 @@ class TestCloudDataStoreMetricRun:
                 }
             },
         )
+        assert uuid_from_add == response_metric_run_id


### PR DESCRIPTION
The ID is needed of the metric_run to populate the CreatedResource of the ActionResult. The rest of the changes will first be implemented in the cloud repo https://github.com/great-expectations/cloud

Eventually we will likely want to rehydrate the `MetricRun` & `Metrics` within OSS (e.g. if used as a metric store) however for the Column Descriptive Metrics project we don't have a use currently for the rehydrated objects. In the spirit of YAGNI / not overbuilding yet this PR only returns the id of the created `MetricRun` instead of using the response payload to build a `MetricRun` object with corresponding `Metrics`. The returned ID is used in the agent to populate the `CreatedResource`. Note: if/when we implement creating the `MetricRun` & `Metric` objects in OSS, we will also need to build deserialization logic to use the appropriate metric type for validation.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
