### PR TITLE
[MAINTENANCE] only build-docs on doc-changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   docs-snippets:
     name: docs-snippets
-    needs: [docs-changes, ci-is-on-main-repo]
+    needs: [unit-tests, docs-changes, ci-is-on-main-repo]
     # run on non-draft PRs with docs changes
     if: |
       (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,11 +232,26 @@ jobs:
         run: invoke public-api
       - name: link_checker
         run: python docs/checks/docs_link_checker.py -p docs/docusaurus/docs -r docs/docusaurus/docs -s docs --skip-external
-      - name: docs_build
+
+  docs-build:
+    needs: [doc-checks, docs-changes]
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: reqs/requirements-dev-test.txt
+      - name: Install dependencies
+        run: pip install -r reqs/requirements-dev-test.txt
+      - name: Build docs
         env:
           NODE_OPTIONS: --max_old_space_size=4096
         run: cd docs/docusaurus && yarn install && bash ../build_docs
-
 
   cloud-tests:
     needs: [unit-tests, static-analysis, ci-is-on-main-repo]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   docs-snippets:
     name: docs-snippets
-    needs: [unit-tests, docs-changes, ci-is-on-main-repo]
+    needs: [unit-tests, docs-changes, doc-checks, ci-is-on-main-repo]
     # run on non-draft PRs with docs changes
     if: |
       (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         run: invoke ci-tests -m "unit" --xdist --slowest=10 --timeout=1.5
 
   doc-checks:
-    needs: [unit-tests, static-analysis]
+    needs: [static-analysis]
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,10 @@ jobs:
 
   docs-build:
     needs: [doc-checks, docs-changes]
-    if: github.event.pull_request.draft == false
+    # run on non-draft PRs with docs changes
+    if: |
+      (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,1 +1,0 @@
-# force docs-changes TODO: remove before merge

--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,0 +1,1 @@
+# force docs-changes TODO: remove before merge


### PR DESCRIPTION
Moves the `build-docs` step of `doc-checks` to a separate job that only runs on `docs-changes`.

This step was by far our longest-running task and moving it to a separate job that only runs on `docs-changes` preserves our ci workers for other tasks.

### Updated Action Topology

![image](https://github.com/great-expectations/great_expectations/assets/13108583/9b4a183a-b852-4077-9b3b-37722ded662e)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
