### PR TITLE
[MAINTENANCE] Column Descriptive Metrics: Add Null Count

### DIFF
--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, List, Sequence
+from typing import TYPE_CHECKING, Any, List, Sequence
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.interfaces import Batch
@@ -94,8 +94,9 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
         metric_name = "table.column_types"
         metric_lookup_key = (metric_name, tuple(), "include_nested=True")
 
-        raw_column_types = computed_metrics[metric_lookup_key]
-        column_types_converted_to_str = [
+        raw_column_types: list[dict[str, Any]] = computed_metrics[metric_lookup_key]  # type: ignore[assignment] # Metric results from computed_metrics are not typed
+
+        column_types_converted_to_str: list[dict[str, str]] = [
             {"name": raw_column_type["name"], "type": str(raw_column_type["type"])}
             for raw_column_type in raw_column_types
         ]

--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -92,10 +92,7 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
         )
 
         metric_name = "table.column_types"
-        if (metric_name, tuple(), "include_nested=True") in computed_metrics.keys():
-            metric_lookup_key = (metric_name, tuple(), "include_nested=True")
-        else:
-            metric_lookup_key = (metric_name, tuple(), tuple())
+        metric_lookup_key = (metric_name, tuple(), "include_nested=True")
 
         raw_column_types = computed_metrics[metric_lookup_key]
         column_types_converted_to_str = [

--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -41,10 +41,7 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
         return column_list
 
     def _get_table_metrics(self, batch_request: BatchRequest) -> Sequence[Metric]:
-        table_metric_names = [
-            "table.row_count",
-            "table.columns",
-        ]  # , "table.column_types"]
+        table_metric_names = ["table.row_count", "table.columns", "table.column_types"]
         table_metric_configs = [
             MetricConfiguration(
                 metric_name=metric_name, metric_domain_kwargs={}, metric_value_kwargs={}
@@ -90,6 +87,26 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
                 batch_id=validator.active_batch.id,
                 metric_name=metric_name,
                 value=computed_metrics[metric_lookup_key],
+                exception=None,  # TODO: Pass through a MetricException() if an exception is thrown
+            )
+        )
+
+        metric_name = "table.column_types"
+        if (metric_name, tuple(), "include_nested=True") in computed_metrics.keys():
+            metric_lookup_key = (metric_name, tuple(), "include_nested=True")
+        else:
+            metric_lookup_key = (metric_name, tuple(), tuple())
+
+        raw_column_types = computed_metrics[metric_lookup_key]
+        column_types_converted_to_str = [
+            {"name": raw_column_type["name"], "type": str(raw_column_type["type"])}
+            for raw_column_type in raw_column_types
+        ]
+        metrics.append(
+            TableMetric[List[str]](
+                batch_id=validator.active_batch.id,
+                metric_name=metric_name,
+                value=column_types_converted_to_str,
                 exception=None,  # TODO: Pass through a MetricException() if an exception is thrown
             )
         )

--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Any, List, Sequence
+from typing import TYPE_CHECKING, Any, List, Sequence, Type
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.interfaces import Batch
@@ -150,14 +150,14 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
         metric_lookup_key: _MetricKey
 
         # TODO: nested for-loop can be better
-        value_type = float
+        value_type: Type[int] | Type[float] = float
         for metric_name in column_metric_names:
             if metric_name == "column_values.null.count":
                 value_type = int
             for column in column_list:
                 metric_lookup_key = (metric_name, f"column={column}", tuple())
                 metrics.append(
-                    ColumnMetric[value_type](
+                    ColumnMetric[value_type](  # type: ignore[valid-type]  # Will be refactored in upcoming PR
                         batch_id=validator.active_batch.id,
                         metric_name=metric_name,
                         column=column,

--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -118,6 +118,7 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
             "column.max",
             "column.mean",
             "column.median",
+            "column_values.null.count",
         ]
 
         column_metric_configs: List[MetricConfiguration] = list()
@@ -149,11 +150,14 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
         metric_lookup_key: _MetricKey
 
         # TODO: nested for-loop can be better
+        value_type = float
         for metric_name in column_metric_names:
+            if metric_name == "column_values.null.count":
+                value_type = int
             for column in column_list:
                 metric_lookup_key = (metric_name, f"column={column}", tuple())
                 metrics.append(
-                    ColumnMetric[float](
+                    ColumnMetric[value_type](
                         batch_id=validator.active_batch.id,
                         metric_name=metric_name,
                         column=column,

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -37,6 +37,8 @@ def test_get_metrics():
         ("column.mean", "column=col2", ()): 2.7,
         ("column.median", "column=col1", ()): 2.5,
         ("column.median", "column=col2", ()): 2.7,
+        ("column_values.null.count", "column=col1", ()): 3,
+        ("column_values.null.count", "column=col2", ()): 5,
     }
     mock_batch = Mock(spec=Batch)
     mock_batch.id = "batch_id"
@@ -122,6 +124,20 @@ def test_get_metrics():
             batch_id="batch_id",
             metric_name="column.median",
             value=2.7,
+            exception=None,
+            column="col2",
+        ),
+        ColumnMetric[int](
+            batch_id="batch_id",
+            metric_name="column_values.null.count",
+            value=3,
+            exception=None,
+            column="col1",
+        ),
+        ColumnMetric[int](
+            batch_id="batch_id",
+            metric_name="column_values.null.count",
+            value=5,
             exception=None,
             column="col2",
         ),

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -25,6 +25,10 @@ def test_get_metrics():
     mock_validator.compute_metrics.return_value = {
         ("table.row_count", (), ()): 2,
         ("table.columns", (), ()): ["col1", "col2"],
+        ("table.column_types", (), "include_nested=True"): [
+            {"name": "col1", "type": "float"},
+            {"name": "col2", "type": "float"},
+        ],
         ("column.min", "column=col1", ()): 2.5,
         ("column.min", "column=col2", ()): 2.7,
         ("column.max", "column=col1", ()): 5.5,
@@ -54,6 +58,15 @@ def test_get_metrics():
             batch_id="batch_id",
             metric_name="table.columns",
             value=["col1", "col2"],
+            exception=None,
+        ),
+        TableMetric[List[str]](
+            batch_id="batch_id",
+            metric_name="table.column_types",
+            value=[
+                {"name": "col1", "type": "float"},
+                {"name": "col2", "type": "float"},
+            ],
             exception=None,
         ),
         ColumnMetric[float](
@@ -113,8 +126,3 @@ def test_get_metrics():
             column="col2",
         ),
     ]
-
-
-def test_get_metrics_with_exception():
-    # TODO: Implement this test in DX-749
-    pass

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -37,8 +37,8 @@ def test_get_metrics():
         ("column.mean", "column=col2", ()): 2.7,
         ("column.median", "column=col1", ()): 2.5,
         ("column.median", "column=col2", ()): 2.7,
-        ("column_values.null.count", "column=col1", ()): 3,
-        ("column_values.null.count", "column=col2", ()): 5,
+        ("column_values.null.count", "column=col1", ()): 1,
+        ("column_values.null.count", "column=col2", ()): 1,
     }
     mock_batch = Mock(spec=Batch)
     mock_batch.id = "batch_id"
@@ -130,14 +130,14 @@ def test_get_metrics():
         ColumnMetric[int](
             batch_id="batch_id",
             metric_name="column_values.null.count",
-            value=3,
+            value=1,
             exception=None,
             column="col1",
         ),
         ColumnMetric[int](
             batch_id="batch_id",
             metric_name="column_values.null.count",
-            value=5,
+            value=1,
             exception=None,
             column="col2",
         ),

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever_integration.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever_integration.py
@@ -31,7 +31,7 @@ def cloud_context_and_batch_request_with_simple_dataframe(
     context = empty_cloud_context_fluent
     datasource = context.sources.add_pandas(name="my_pandas_datasource")
 
-    d = {"col1": [1, 2], "col2": [3, 4]}
+    d = {"col1": [1, 2, None], "col2": [3, 4, None]}
     df = pd.DataFrame(data=d)
 
     name = "dataframe"
@@ -58,7 +58,7 @@ def test_get_metrics(
         TableMetric[int](
             batch_id=batch_id,
             metric_name="table.row_count",
-            value=2,
+            value=3,
             exception=None,
         ),
         TableMetric[List[str]](
@@ -127,9 +127,23 @@ def test_get_metrics(
             batch_id=batch_id,
             metric_name="table.column_types",
             value=[
-                {"name": "col1", "type": "int64"},
-                {"name": "col2", "type": "int64"},
+                {"name": "col1", "type": "float64"},
+                {"name": "col2", "type": "float64"},
             ],
+            exception=None,
+        ),
+        ColumnMetric[int](
+            batch_id=batch_id,
+            metric_name="column_values.null.count",
+            column="col1",
+            value=1,
+            exception=None,
+        ),
+        ColumnMetric[int](
+            batch_id=batch_id,
+            metric_name="column_values.null.count",
+            column="col2",
+            value=1,
             exception=None,
         ),
     ]

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever_integration.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever_integration.py
@@ -123,9 +123,20 @@ def test_get_metrics(
             value=3.5,
             exception=None,
         ),
+        TableMetric[List[str]](
+            batch_id=batch_id,
+            metric_name="table.column_types",
+            value=[
+                {"name": "col1", "type": "int64"},
+                {"name": "col2", "type": "int64"},
+            ],
+            exception=None,
+        ),
     ]
 
     # Assert each metric so it is easier to see which one fails (instead of assert metrics == expected_metrics):
     assert len(metrics) == len(expected_metrics)
-    for metric, expected_metric in zip(metrics, expected_metrics):
-        assert metric.dict() == expected_metric.dict()
+    for metric in metrics:
+        assert metric.dict() in [
+            expected_metric.dict() for expected_metric in expected_metrics
+        ]


### PR DESCRIPTION
Add the null count metric. This will later be used with row count to compute the null %.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
