### PR TITLE
[DOCS] Relocate Use Great Expectations with Google Cloud Platform and BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Great Expectations works with the tools and systems that you're already using wi
 				<img height="40" src="./docs/readme_assets/bigquery.jpg" />
 			</td>
 			<td style="width: 200px;">
-				<a href="https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery/">
+				<a href="https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data">
 					BigQuery
 				</a>
 			</td>
@@ -226,7 +226,7 @@ Great Expectations works with the tools and systems that you're already using wi
 				<img height="40" src="./docs/readme_assets/Google_Cloud_logo.jpg" />
 			</td>
 			<td style="width: 200px;">
-				<a href="https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery/">
+				<a href="https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data">
 					Google Cloud Platform &#40;GCP&#41;
 				</a>
 			</td>

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -797,7 +797,7 @@ If you are accessing data in BigQuery, the following privileges are required for
 
 See [Create Cloud Composer environments](https://cloud.google.com/composer/docs/composer-2/create-environments).
 
-### Install Great Expectations in Cloud Composer
+#### Install Great Expectations in Cloud Composer
 
 You can use the Composer web Console (recommended), `gcloud`, or a REST query to install Python dependencies in Cloud Composer. To install `great-expectations` in Cloud Composer, see [Installing Python dependencies in Google Cloud](https://cloud.google.com/composer/docs/how-to/using/installing-python-dependencies#install-package). If you are connecting to data in BigQuery, make sure `sqlalchemy-bigquery` is also installed in your Cloud Composer environment.
 

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -456,6 +456,8 @@ Repeat the previous steps to add additional Data Assets.
 </TabItem>
 <TabItem value="bigquery">
 
+## BigQuery SQL
+
 Integrate GX with [Google Cloud Platform](https://cloud.google.com/gcp) (GCP).
 
 The following scripts and configuration files are used in the examples:
@@ -466,7 +468,7 @@ The following scripts and configuration files are used in the examples:
 
 - The script to test the GCS configuration is located in [gcp_deployment_patterns_file_gcs.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py).
 
-## Prerequisites
+### Prerequisites
 
 <Prerequisites>
 
@@ -503,7 +505,7 @@ The following diagram shows the recommended components for a GX deployment in GC
 
 ![Screenshot of Data Docs](../../../../deployment_patterns/images/ge_and_gcp_diagram.png)
 
-## Upgrade your GX version (Optional)
+### Upgrade your GX version (Optional)
 
 Run the following code to upgrade your GX version:
 
@@ -511,7 +513,7 @@ Run the following code to upgrade your GX version:
 pip install great-expectations --upgrade
 ```
 
-## Get DataContext
+### Get DataContext
 
 Run the following code to create a new <TechnicalTag relative="../../../" tag="data_context" text="Data Context" />: 
 
@@ -520,7 +522,7 @@ Run the following code to create a new <TechnicalTag relative="../../../" tag="d
 
 The `full_path_to_project_directory` parameter can be an empty directory where you intend to build your GX configuration.
 
-## Connect to GCP Metadata Stores 
+### Connect to GCP Metadata Stores 
 
 The code examples are located in the [`great-expectations` repository](https://github.com/great-expectations/great_expectations/tree/develop/tests/integration/fixtures/gcp_deployment/).
 
@@ -571,7 +573,7 @@ gcloud app browse
 
 The URL to your app appears and opens in a new browser window. You can view the index page of your Data Docs site.
 
-## Connect to source data
+### Connect to source data
 
 Connect to source data stored on a GCS or .
 
@@ -614,7 +616,7 @@ To configure the BigQuery Data Source, see [How to connect to a BigQuery databas
 </TabItem>
 </Tabs>
 
-## Create Assets
+### Create Assets
 <Tabs
   groupId="connect-to-data-gcs-bigquery"
   defaultValue='gcs'
@@ -663,7 +665,7 @@ In the following example, a query `Asset` named `my_query_asset` is built by sub
 </TabItem>
 </Tabs>
 
-## Get a Batch and Create Expectation Suite
+### Get a Batch and Create Expectation Suite
 
 <Tabs
   groupId="connect-to-data-gcs-bigquery"
@@ -722,7 +724,7 @@ To configure the BatchRequest and learn how you can load data by specifying a ta
 </TabItem>
 </Tabs>
 
-## Build and run a Checkpoint
+### Build and run a Checkpoint
 
 <Tabs
   groupId="connect-to-data-gcs-bigquery"
@@ -761,7 +763,7 @@ To configure the BatchRequest and learn how you can load data by specifying a ta
 </TabItem>
 </Tabs>
 
-## Migrate your local configuration to Cloud Composer
+### Migrate your local configuration to Cloud Composer
 
 Migrate your local GX configuration to a Cloud Composer environment to automate the workflow. You can use one of the following methods to run GX in Cloud Composer or Airflow:
 
@@ -773,7 +775,7 @@ Migrate your local GX configuration to a Cloud Composer environment to automate 
 
 In this example, you'll use the `bash operator` to run the Checkpoint. A video overview of this process is also available in this [video](https://drive.google.com/file/d/1YhEMqSRkp5JDIQA_7fleiKTTlEmYx2K8/view?usp=sharing).
 
-### Create and Configure a GCP Service Account
+#### Create and Configure a GCP Service Account
 
 To create a GCP Service Account, see [Service accounts overview](https://cloud.google.com/iam/docs/service-accounts).
 
@@ -791,7 +793,7 @@ If you are accessing data in BigQuery, the following privileges are required for
 - `BigQuery Job User`
 - `BigQuery Read Session User`
 
-### Create a Cloud Composer environment
+#### Create a Cloud Composer environment
 
 See [Create Cloud Composer environments](https://cloud.google.com/composer/docs/composer-2/create-environments).
 
@@ -803,7 +805,7 @@ You can use the Composer web Console (recommended), `gcloud`, or a REST query to
 If you run into trouble when you install GX in Cloud Composer, see [Troubleshooting PyPI package installation](https://cloud.google.com/composer/docs/troubleshooting-package-installation).
 :::
 
-### Move your local configuration to Cloud Composer
+#### Move your local configuration to Cloud Composer
 
 Cloud Composer uses Cloud Storage to store Apache Airflow DAGs (also known as workflows), with each Environment having an associated Cloud Storage bucket. Typically, the bucket name uses this pattern: `[region]-[composer environment name]-[UUID]-bucket`.
 
@@ -817,7 +819,7 @@ To migrate your local configuration, you can move the local `great_expectations/
 
     After the `great_expectations/` folder is uploaded to the Cloud Storage bucket, it is mapped to the Airflow instances in your Cloud Composer and is accessible from the Airflow Worker nodes at: `/home/airflow/gcsfuse/great_expectations`.
 
-### Write the DAG and add it to Cloud Composer
+#### Write the DAG and add it to Cloud Composer
 <Tabs
   groupId="connect-to-data-gcs-bigquery"
   defaultValue='gcs'
@@ -878,7 +880,7 @@ To add the DAG to Cloud Composer, you move `ge_checkpoint_bigquery.py` to the en
 </Tabs>
 
 
-### Run the DAG and the Checkpoint
+#### Run the DAG and the Checkpoint
 
 Use one of the following methods to [trigger the DAG](https://cloud.google.com/composer/docs/triggering-dags):
 

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -502,7 +502,7 @@ GX recommends that you use the following services to integrate GX with GCP:
 
 The following diagram shows the recommended components for a GX deployment in GCP:
 
-![Screenshot of Data Docs](../deployment_patterns/images/ge_and_gcp_diagram.png)
+![Screenshot of Data Docs](../../../../deployment_patterns/images/ge_and_gcp_diagram.png)
 
 ## Upgrade your GX version (Optional)
 
@@ -557,7 +557,7 @@ To configure GX to use the new `validations_GCS_store` Validations Store, set th
 
 ### Add a Data Docs Store
 
-To host and share Data Docs on GCS, see [Host and share Data Docs](../guides/setup/configuring_data_docs/host_and_share_data_docs.md).
+To host and share Data Docs on GCS, see [Host and share Data Docs](../../../setup/configuring_data_docs/host_and_share_data_docs.md).
 
 After you have hosted and shared Data Docs, your `great-expectations.yml` contains the following configuration below `data_docs_sites`:
 
@@ -766,9 +766,9 @@ To configure the BatchRequest and learn how you can load data by specifying a ta
 
 Migrate your local GX configuration to a Cloud Composer environment to automate the workflow. You can use one of the following methods to run GX in Cloud Composer or Airflow:
 
-- [Using a `bash operator`](./how_to_use_great_expectations_with_airflow.md#option-1-running-a-checkpoint-with-a-bashoperator)
+- [Using a `bash operator`](../../../../deployment_patterns/how_to_use_great_expectations_with_airflow.md)
 
-- [Using a `python operator`](./how_to_use_great_expectations_with_airflow.md#option-2-running-the-checkpoint-script-output-with-a-pythonoperator)
+- [Using a `python operator`](../../../../deployment_patterns/how_to_use_great_expectations_with_airflow.md#option-2-running-the-checkpoint-script-output-with-a-pythonoperator)
 
 - [Using a `Airflow operator`](https://github.com/great-expectations/airflow-provider-great-expectations)
 
@@ -912,10 +912,10 @@ To trigger the DAG manually:
 
 - [Use the Onboarding Data Assistant to evaluate one or more Batches of data and create Expectations](/docs/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant)
 
-- [Configure Expectation Stores](../guides/setup/configuring_metadata_stores/configure_expectation_stores.md)
+- [Configure Expectation Stores](../../../setup/configuring_metadata_stores/configure_expectation_stores.md)
 
-- [Configure Validation Result Stores](../guides/setup/configuring_metadata_stores/configure_result_stores.md)
+- [Configure Validation Result Stores](../../../setup/configuring_metadata_stores/configure_result_stores.md)
 
-- [Host and share Data Docs](../guides/setup/configuring_data_docs/host_and_share_data_docs.md)
+- [Host and share Data Docs](../../../setup/configuring_data_docs/host_and_share_data_docs.md)
 
-- [Configure credentials](../guides/setup/configuring_data_contexts/how_to_configure_credentials.md)
+- [Configure credentials](../../../setup/configuring_data_contexts/how_to_configure_credentials.md)

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -11,7 +11,6 @@ import Prerequisites from '/docs/components/_prerequisites.jsx'
 import ImportGxAndInstantiateADataContext from '/docs/components/setup/data_context/_import_gx_and_instantiate_a_data_context.md'
 import AfterCreateSqlDatasource from '/docs/components/connect_to_data/next_steps/_after_create_sql_datasource.md'
 import PostgreSqlConfigureCredentialsInConfigVariablesYml from '/docs/components/setup/dependencies/_postgresql_configure_credentials_in_config_variables_yml.md'
-import Prerequisites from 'docs/deployment patterns/components/deployment_pattern_prerequisites.jsx'
 import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
 
 

--- a/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -11,6 +11,9 @@ import Prerequisites from '/docs/components/_prerequisites.jsx'
 import ImportGxAndInstantiateADataContext from '/docs/components/setup/data_context/_import_gx_and_instantiate_a_data_context.md'
 import AfterCreateSqlDatasource from '/docs/components/connect_to_data/next_steps/_after_create_sql_datasource.md'
 import PostgreSqlConfigureCredentialsInConfigVariablesYml from '/docs/components/setup/dependencies/_postgresql_configure_credentials_in_config_variables_yml.md'
+import Prerequisites from 'docs/deployment patterns/components/deployment_pattern_prerequisites.jsx'
+import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
+
 
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
@@ -26,6 +29,7 @@ Use the information provided here to connect to source data stored in SQL databa
   {label: 'SQLite', value:'sqlite'},
   {label: 'Snowflake', value:'snowflake'},
   {label: 'Databricks SQL', value:'databricks'},
+  {label: 'BigQuery SQL', value:'bigquery'},
   ]}>
 <TabItem value="sql">
 
@@ -451,6 +455,451 @@ my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?htt
 Repeat the previous steps to add additional Data Assets.
 
 </TabItem>
+<TabItem value="bigquery">
+
+Integrate GX with [Google Cloud Platform](https://cloud.google.com/gcp) (GCP).
+
+The following scripts and configuration files are used in the examples:
+
+- The local GX configuration is located in the [`great-expectations` GIT repository](https://github.com/great-expectations/great_expectations/tree/develop/tests/integration/fixtures/gcp_deployment/).
+
+- The script to test the BigQuery configuration is located in [gcp_deployment_patterns_file_bigquery.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py).
+
+- The script to test the GCS configuration is located in [gcp_deployment_patterns_file_gcs.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py).
+
+## Prerequisites
+
+<Prerequisites>
+
+- [An installation of GX set up to work with SQL](/docs/guides/setup/installation/install_gx).
+- Familiarity with Google Cloud Platform features and functionality.
+- A GCP project with a running Google Cloud Storage container that is accessible from your region.
+- Read/write access to a BigQuery database.
+- Access to a GCP [Service Account](https://cloud.google.com/iam/docs/service-accounts) with permission to access and read objects in Google Cloud Storage.
+
+</Prerequisites>
+
+
+:::caution Installing Great Expectations in Google Cloud Composer
+
+  When installing GX in Composer 1 and Composer 2 environments the following packages must be pinned:
+
+  `[tornado]==6.2`
+  `[nbconvert]==6.4.5`
+  `[mistune]==0.8.4`
+
+:::
+
+GX recommends that you use the following services to integrate GX with GCP:
+
+  - [Google Cloud Composer](https://cloud.google.com/composer) (GCC) for managing workflow orchestration including validating your data. GCC is built on [Apache Airflow](https://airflow.apache.org/).
+
+  - [BigQuery](https://cloud.google.com/bigquery) or files in [Google Cloud Storage](https://cloud.google.com/storage) (GCS) as your <TechnicalTag tag="datasource" text="Data Source"/>.
+
+  - [GCS](https://cloud.google.com/storage) for storing metadata (<TechnicalTag tag="expectation_suite" text="Expectation Suites"/>, <TechnicalTag tag="validation_result" text="Validation Results"/>, <TechnicalTag tag="data_docs" text="Data Docs"/>).
+
+  - [Google App Engine](https://cloud.google.com/appengine) (GAE) for hosting and controlling access to <TechnicalTag tag="data_docs" text="Data Docs"/>.
+
+The following diagram shows the recommended components for a GX deployment in GCP:
+
+![Screenshot of Data Docs](../deployment_patterns/images/ge_and_gcp_diagram.png)
+
+## Upgrade your GX version (Optional)
+
+Run the following code to upgrade your GX version:
+
+```bash
+pip install great-expectations --upgrade
+```
+
+## Get DataContext
+
+Run the following code to create a new <TechnicalTag relative="../../../" tag="data_context" text="Data Context" />: 
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py get_context"
+```
+
+The `full_path_to_project_directory` parameter can be an empty directory where you intend to build your GX configuration.
+
+## Connect to GCP Metadata Stores 
+
+The code examples are located in the [`great-expectations` repository](https://github.com/great-expectations/great_expectations/tree/develop/tests/integration/fixtures/gcp_deployment/).
+
+:::note Trailing Slashes in Metadata Store prefixes
+
+  When specifying `prefix` values for Metadata Stores in GCS, don't add a trailing slash `/`. For example, `prefix: my_prefix/`. When you add a trailing slash, an additional folder with the name `/` is created and metadata is stored in the `/` folder instead of `my_prefix`.
+
+:::
+
+### Add an Expectations Store
+
+By default, newly profiled Expectations are stored in JSON format in the `expectations/` subdirectory of your `great_expectations/` folder. A new Expectations Store can be configured by adding the following lines to your `great_expectations.yml` file. Replace the `project`, `bucket` and `prefix` with your values.
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py expected_expectation_store"
+```
+
+To configure GX to use this new Expectations Store, `expectations_GCS_store`, set the `expectations_store_name` value in the `great_expectations.yml` file.
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py new_expectation_store"
+```
+
+### Add a Validations Store
+
+By default, Validations are stored in JSON format in the `uncommitted/validations/` subdirectory of your `great_expectations/` folder. You can connfigure a new Validations Store by adding the following lines to your `great_expectations.yml` file. Replace the `project`, `bucket` and `prefix` with your values.
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py expected_validations_store"
+```
+
+To configure GX to use the new `validations_GCS_store` Validations Store, set the `validations_store_name` value in the `great_expectations.yml` file.
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py new_validations_store"
+```
+
+### Add a Data Docs Store
+
+To host and share Data Docs on GCS, see [Host and share Data Docs](../guides/setup/configuring_data_docs/host_and_share_data_docs.md).
+
+After you have hosted and shared Data Docs, your `great-expectations.yml` contains the following configuration below `data_docs_sites`:
+
+```YAML name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py new_data_docs_store"
+```
+
+Run the following command in the gcloud CLI to view the deployed DataDocs site:
+
+```bash
+gcloud app browse
+```
+
+The URL to your app appears and opens in a new browser window. You can view the index page of your Data Docs site.
+
+## Connect to source data
+
+Connect to source data stored on a GCS or .
+
+<Tabs
+  groupId="connect-to-data-gcs-bigquery"
+  defaultValue='gcs'
+  values={[
+  {label: 'Data in GCS', value:'gcs'},
+  {label: 'Data in BigQuery', value:'bigquery'},
+  ]}>
+<TabItem value="gcs">
+
+Run the following code to add the name of your GCS bucket to the `add_pandas_gcs` function:
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py datasource"
+```
+
+In the example, you've added a Data Source that connects to data in GCS using a Pandas dataframe. The name of the new datasource is `gcs_datasource` and it refers to a GCS bucket named `test_docs_data`.
+
+For more information about configuring a Data Source, see [How to connect to data on GCS using Pandas](/docs/0.15.50/guides/connecting_to_your_data/cloud/gcs/pandas).
+
+</TabItem>
+<TabItem value="bigquery">
+
+:::note
+
+Tables that are created by BigQuery queries are automatically set to expire after one day.
+
+:::
+
+Run the following code to create a Data Source that connects to data in BigQuery:
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py add_bigquery_datasource"
+```
+
+In the example, you created a Data Source named `my_bigquery_datasource`, using the `add_or_update_sql` method and passed it in a connection string.
+
+To configure the BigQuery Data Source, see [How to connect to a BigQuery database](/docs/0.15.50/guides/connecting_to_your_data/database/bigquery).
+
+</TabItem>
+</Tabs>
+
+## Create Assets
+<Tabs
+  groupId="connect-to-data-gcs-bigquery"
+  defaultValue='gcs'
+  values={[
+  {label: 'Data in GCS', value:'gcs'},
+  {label: 'Data in BigQuery', value:'bigquery'},
+  ]}>
+<TabItem value="gcs">
+
+Use the `add_csv_asset` function to add a CSV `Asset` to your `Datasource`.
+
+Configure the `prefix` and `batching_regex`. The `prefix` is the path to the GCS bucket where the files are located. `batching_regex` is a regular expression that indicates which files should be treated as Batches in the Asset, and how to identify them. For example:
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py prefix_and_batching_regex"
+```
+
+In the example, the pattern `r"data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"` builds a Batch for the following files in the GCS bucket:
+
+```bash
+test_docs_data/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv
+test_docs_data/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-02.csv
+test_docs_data/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-03.csv
+```
+The `batching_regex` pattern matches the four digits of the year portion and assigns it to the `year` domain, and then matches the two digits of the month portion and assigns it to the `month` domain.
+
+Run the following code to use the `add_csv_asset` function to add an `Asset` named `csv_taxi_gcs_asset` to your Data Source: 
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py asset"
+```
+
+</TabItem>
+<TabItem value="bigquery">
+
+You can add a BigQuery `Asset` into your `Datasource` as a table asset or query asset.
+
+In the following example, a table `Asset` named `my_table_asset` is built by naming the table in your BigQuery Database. 
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py add_bigquery_table_asset"
+```
+
+In the following example, a query `Asset` named `my_query_asset` is built by submitting a query to the `taxi_data` table.
+
+```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py add_bigquery_query_asset"
+```
+
+</TabItem>
+</Tabs>
+
+## Get a Batch and Create Expectation Suite
+
+<Tabs
+  groupId="connect-to-data-gcs-bigquery"
+  defaultValue='gcs'
+  values={[
+  {label: 'Data in GCS', value:'gcs'},
+  {label: 'Data in BigQuery', value:'bigquery'},
+  ]}>
+<TabItem value="gcs">
+
+1. Use the `add_or_update_expectation_suite` method on your Data Context to create an Expectation Suite:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py add_expectation_suite"
+    ```
+
+2. Use the `Validator` method to run Expectations on the Batch and automatically add them to the Expectation Suite. 
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py validator_calls"
+    ```
+    In this example, you're adding `expect_column_values_to_not_be_null` and `expect_column_values_to_be_between`. You can replace the `passenger_count` and `congestion_surcharge` test data columns with your own data columns.
+
+3. Run the following code to save the Expectation Suite:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py save_expectation_suite"
+    ```
+
+To configure the RuntimeBatchRequest and learn how you can load data by specifying a GCS path to a single CSV, see [How to connect to data on GCS using Pandas](/docs/0.15.50/guides/connecting_to_your_data/cloud/gcs/pandas).
+
+</TabItem>
+<TabItem value="bigquery">
+
+1. Use the `table_asset` you created previously to build a `BatchRequest`: 
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py batch_request"
+    ```
+
+2. Use the `add_or_update_expectation_suite` method on your Data Context to create an Expectation Suite and get a `Validator`: 
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py add_or_update_expectation_suite"
+    ```
+
+3. Use the `Validator` to run expectations on the batch and automatically add them to the Expectation Suite: 
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py validator_calls"
+    ```
+    In this example, you're adding `expect_column_values_to_not_be_null` and `expect_column_values_to_be_between`. You can replace the `passenger_count` and `congestion_surcharge` test data columns with your own data columns.
+    
+    
+4. Run the following code to save the Expectation Suite containing the two Expectations:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py save_expectation_suite"
+    ```
+
+To configure the BatchRequest and learn how you can load data by specifying a table name, see [How to connect to a BigQuery database](/docs/0.15.50/guides/connecting_to_your_data/database/bigquery).
+
+</TabItem>
+</Tabs>
+
+## Build and run a Checkpoint
+
+<Tabs
+  groupId="connect-to-data-gcs-bigquery"
+  defaultValue='gcs'
+  values={[
+  {label: 'Data in GCS', value:'gcs'},
+  {label: 'Data in BigQuery', value:'bigquery'},
+  ]}>
+<TabItem value="gcs">
+
+1. Run the following code to add the `gcs_checkpoint` Checkpoint to the Data Context:  
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py checkpoint"
+    ```
+    In this example, you're using the `BatchRequest` and `ExpectationSuite` names that you used when you created your Validator.
+
+2. Run the Checkpoint by calling `checkpoint.run()`:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_gcs.py run_checkpoint"
+    ```
+
+</TabItem>
+<TabItem value="bigquery">
+
+1. Run the following code to add the `bigquery_checkpoint` Checkpoint to the Data Context:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py checkpoint"
+    ```
+    In this example, you're using the `BatchRequest` and `ExpectationSuite` names that you used when you created your Validator.
+
+2. Run the Checkpoint by calling `checkpoint.run()`:
+
+    ```python name="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py run_checkpoint"
+    ```
+
+</TabItem>
+</Tabs>
+
+## Migrate your local configuration to Cloud Composer
+
+Migrate your local GX configuration to a Cloud Composer environment to automate the workflow. You can use one of the following methods to run GX in Cloud Composer or Airflow:
+
+- [Using a `bash operator`](./how_to_use_great_expectations_with_airflow.md#option-1-running-a-checkpoint-with-a-bashoperator)
+
+- [Using a `python operator`](./how_to_use_great_expectations_with_airflow.md#option-2-running-the-checkpoint-script-output-with-a-pythonoperator)
+
+- [Using a `Airflow operator`](https://github.com/great-expectations/airflow-provider-great-expectations)
+
+In this example, you'll use the `bash operator` to run the Checkpoint. A video overview of this process is also available in this [video](https://drive.google.com/file/d/1YhEMqSRkp5JDIQA_7fleiKTTlEmYx2K8/view?usp=sharing).
+
+### Create and Configure a GCP Service Account
+
+To create a GCP Service Account, see [Service accounts overview](https://cloud.google.com/iam/docs/service-accounts).
+
+To run GX in a Cloud Composer environment, the following privileges are required for your Service Account:
+
+- `Composer Worker`
+- `Logs Viewer`
+- `Logs Writer`
+- `Storage Object Creator`
+- `Storage Object Viewer`
+
+If you are accessing data in BigQuery, the following privileges are required for your Service Account:
+
+- `BigQuery Data Editor`
+- `BigQuery Job User`
+- `BigQuery Read Session User`
+
+### Create a Cloud Composer environment
+
+See [Create Cloud Composer environments](https://cloud.google.com/composer/docs/composer-2/create-environments).
+
+### Install Great Expectations in Cloud Composer
+
+You can use the Composer web Console (recommended), `gcloud`, or a REST query to install Python dependencies in Cloud Composer. To install `great-expectations` in Cloud Composer, see [Installing Python dependencies in Google Cloud](https://cloud.google.com/composer/docs/how-to/using/installing-python-dependencies#install-package). If you are connecting to data in BigQuery, make sure `sqlalchemy-bigquery` is also installed in your Cloud Composer environment.
+
+:::info Troubleshooting your installation
+If you run into trouble when you install GX in Cloud Composer, see [Troubleshooting PyPI package installation](https://cloud.google.com/composer/docs/troubleshooting-package-installation).
+:::
+
+### Move your local configuration to Cloud Composer
+
+Cloud Composer uses Cloud Storage to store Apache Airflow DAGs (also known as workflows), with each Environment having an associated Cloud Storage bucket. Typically, the bucket name uses this pattern: `[region]-[composer environment name]-[UUID]-bucket`.
+
+To migrate your local configuration, you can move the local `great_expectations/` folder to the Cloud Storage bucket where Composer can access the configuration.
+
+1. Open the **Environments** page in the Cloud Console and then click the environment name to open the **Environment details** page. The name of the Cloud Storage bucket is located to the right of the DAGs folder on the **Configuration** tab.
+
+    This is the folder where DAGs are stored. You can access it from the Airflow worker nodes at: `/home/airflow/gcsfuse/dags`. The location where you'll upload `great_expectations/` is **one level above the `/dags` folder**.
+
+2. Upload the local `great_expectations/` folder by dragging and dropping it into the window, using [`gsutil cp`](https://cloud.google.com/storage/docs/gsutil/commands/cp), or by clicking the `Upload Folder` button.
+
+    After the `great_expectations/` folder is uploaded to the Cloud Storage bucket, it is mapped to the Airflow instances in your Cloud Composer and is accessible from the Airflow Worker nodes at: `/home/airflow/gcsfuse/great_expectations`.
+
+### Write the DAG and add it to Cloud Composer
+<Tabs
+  groupId="connect-to-data-gcs-bigquery"
+  defaultValue='gcs'
+  values={[
+  {label: 'Data in GCS', value:'gcs'},
+  {label: 'Data in BigQuery', value:'bigquery'},
+  ]}>
+<TabItem value="gcs">
+
+1. Run the following code to create a DAG with a single node (`t1`) that runs a `BashOperator`:
+
+    ```python name="tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py full"
+    ```
+    The DAG is stored in a file named: [`ge_checkpoint_gcs.py`](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py)
+
+    The `BashOperator` changes the directory to `/home/airflow/gcsfuse/great_expectations`, where you uploaded your local configuration.
+
+2. Run the following command in the gcloud CLI to run the Checkpoint locally:
+
+    ```bash
+    great_expectations checkpoint run gcs_checkpoint
+    ````
+
+To add the DAG to Cloud Composer, you move `ge_checkpoint_gcs.py` to the environment's DAGs folder in Cloud Storage. For more information about adding or updating DAGs, see [Add or update a DAG](https://cloud.google.com/composer/docs/how-to/using/managing-dags#adding).
+
+1. Open the **Environments** page in the Cloud Console and then click the environment name to open the **Environment details** page.
+
+2. On the **Configuration** tab, click the Cloud Storage bucket name located to the right of the DAGs folder. 
+
+3. Upload the local copy of the DAG.
+
+</TabItem>
+<TabItem value="bigquery">
+
+1. Run the following code to create a DAG with a single node (`t1`) that runs a `BashOperator`
+
+    ```python name="tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py full"
+    ```
+    The DAG is stored in a file named: [`ge_checkpoint_bigquery.py`](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py)
+
+    The `BashOperator` changes the directory to `/home/airflow/gcsfuse/great_expectations`, where you uploaded your local configuration.
+
+2. Run the following command in the gcloud CLI to run the Checkpoint locally::
+
+    ```bash
+    great_expectations checkpoint run bigquery_checkpoint
+    ```
+
+To add the DAG to Cloud Composer, you move `ge_checkpoint_bigquery.py` to the environment's DAGs folder in Cloud Storage. For more information about adding or updating DAGs, see [Add or update a DAG](https://cloud.google.com/composer/docs/how-to/using/managing-dags#adding).
+
+1. Open the **Environments** page in the Cloud Console and then click the environment name to open the **Environment details** page.
+
+2. On the **Configuration** tab, click the Cloud Storage bucket name located to the right of the DAGs folder. 
+
+3. Upload the local copy of the DAG.
+
+</TabItem>
+</Tabs>
+
+
+### Run the DAG and the Checkpoint
+
+Use one of the following methods to [trigger the DAG](https://cloud.google.com/composer/docs/triggering-dags):
+
+- [Manually](https://cloud.google.com/composer/docs/triggering-dags#manually)
+
+- [On a schedule](https://cloud.google.com/composer/docs/triggering-dags#schedule)
+
+- [In response to events](http://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html)
+
+To trigger the DAG manually:
+
+1. Open the **Environments** page in the Cloud Console and then click the environment name to open the **Environment details** page. 
+
+2. In the **Airflow webserver** column, click the Airflow link for your environment to open the Airflow web interface for your Cloud Composer environment. 
+
+3. Click **Trigger Dag** to run your DAG configuration.
+
+    When the DAG run is successful, the `Success` status appears on the DAGs page of the Airflow Web UI. You can also check that new Data Docs have been generated by accessing the URL to your `gcloud` app.
+
+</TabItem>
 </Tabs>
 
 ## Related documentation
@@ -462,3 +911,11 @@ Repeat the previous steps to add additional Data Assets.
 - [Use a Data Asset to create Expectations while interactively evaluating a set of data](/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data)
 
 - [Use the Onboarding Data Assistant to evaluate one or more Batches of data and create Expectations](/docs/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_onboarding_data_assistant)
+
+- [Configure Expectation Stores](../guides/setup/configuring_metadata_stores/configure_expectation_stores.md)
+
+- [Configure Validation Result Stores](../guides/setup/configuring_metadata_stores/configure_result_stores.md)
+
+- [Host and share Data Docs](../guides/setup/configuring_data_docs/host_and_share_data_docs.md)
+
+- [Configure credentials](../guides/setup/configuring_data_contexts/how_to_configure_credentials.md)

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -187,7 +187,6 @@ module.exports = {
         'integrations/integration_datahub',
         'deployment_patterns/how_to_use_great_expectations_in_deepnote',
         'deployment_patterns/how_to_use_great_expectations_in_flyte',
-        'deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery',
         'deployment_patterns/how_to_use_great_expectations_with_meltano',
         'deployment_patterns/how_to_use_great_expectations_with_prefect',
         'deployment_patterns/how_to_use_great_expectations_with_ydata_synthetic',

--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -392,6 +392,7 @@ docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure
 /docs/guides/expectations/creating_custom_expectations/overview /docs/guides/expectations/custom_expectations_lp
 /docs/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas /docs/guides/connecting_to_your_data/fluent/in_memory/connect_in_memory_data
 /docs/guides/validation/how_to_validate_data_by_running_a_checkpoint /docs/guides/validation/checkpoints/how_to_create_a_new_checkpoint
+/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery /docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data
 
 # Redirects for pages removed as no longer applicable
 

--- a/tests/integration/fixtures/gcp_deployment/README.md
+++ b/tests/integration/fixtures/gcp_deployment/README.md
@@ -1,6 +1,6 @@
 # Example Configuration for GCP Deployment Guide
 
-This directory contains an example configuration for the guide: [How to Use Great Expectations with Google Cloud Platform and BigQuery](https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery)
+This directory contains an example configuration for [Using Great Expectations with Google Cloud Platform and BigQuery](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data)
 
 It contains a `great_expectations.yml` with a configuration for Metadata stores in GCS, and a Datadocs store in GCS, both with placeholder values. 
 


### PR DESCRIPTION
In this [Slack conversation](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1694188146803399), @jcampbell requested that we move the content in [Use Great Expectations with Google Cloud Platform and BigQuery](https://docs.greatexpectations.io/docs/deployment_patterns/how_to_use_great_expectations_with_google_cloud_platform_and_bigquery/) to [Connect to SQL database source data](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data). This PR implements this change. 

[DOC-595](https://greatexpectations.atlassian.net/browse/DOC-595)

[DOC-595]: https://greatexpectations.atlassian.net/browse/DOC-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ