### PR TITLE
[BUGFIX] Fix FDS auto-complete for Conda installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE
 include great_expectations/data_context/checkpoint_template.yml
 include great_expectations/init_notebooks/*/*.ipynb
 recursive-include great_expectations/render *.j2 *.md *.py
+recursive-include great_expectations *.pyi
 graft great_expectations/render/view/static
 graft tests
 global-exclude *.py[co]


### PR DESCRIPTION
Conda packages currently are missing auto-complete for most of our FDS API.
This is because the conda package does not seem to be shipping with our `.pyi` stub files.

Example `context.sources`

![image](https://github.com/great-expectations/great_expectations/assets/13108583/8307283c-d4f8-4d4a-a1f8-e05012388550)
 
This PR updates the `MANIFEST.ini` to include all `.pyi` files.
Updating `MANFIEST.ini` [is not required as part of normal](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data) setuptools uploads, but this seems to be required for `conda`. 

>The `package_data` argument is a dictionary that maps from package names to lists of glob patterns. Note that the data files specified using the `package_data` option neither require to be included within a [MANIFEST.in](https://packaging.python.org/en/latest/guides/using-manifest-in/) file, nor require to be added by a revision control system plugin.

- See a similar fix applied by @xhochy (our [conda feedstock maintainer](https://github.com/conda-forge/great-expectations-feedstock)) https://github.com/great-expectations/great_expectations/pull/6292
