### PR TITLE
[MAINTENANCE] Add `get_all` method to Store and StoreBackend APIs

### DIFF
--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import urllib
 import uuid
@@ -121,6 +123,9 @@ class StoreBackend(metaclass=ABCMeta):
         value = self._get(key, **kwargs)
         return value
 
+    def get_all(self):
+        return self._get_all()
+
     def set(self, key, value, **kwargs):
         self._validate_key(key)
         self._validate_value(value)
@@ -214,6 +219,10 @@ class StoreBackend(metaclass=ABCMeta):
 
     @abstractmethod
     def _get(self, key) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_all(self) -> list[Any]:
         raise NotImplementedError
 
     @abstractmethod

--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -255,6 +255,7 @@ class DatabaseStoreBackend(StoreBackend):
             logger.debug(f"Error fetching value: {e!s}")
             raise gx_exceptions.StoreError(f"Unable to fetch value for key: {key!s}")
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 

--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import sqlalchemy
@@ -254,6 +254,9 @@ class DatabaseStoreBackend(StoreBackend):
         except (IndexError, SQLAlchemyError) as e:
             logger.debug(f"Error fetching value: {e!s}")
             raise gx_exceptions.StoreError(f"Unable to fetch value for key: {key!s}")
+
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
 
     @override
     def _set(self, key, value, allow_update=True, **kwargs) -> None:

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -237,6 +237,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
         return self._send_get_request_to_api(url=url, params=params)
 
+    @override
     def _get_all(self) -> ResponsePayload:  # type: ignore[override]
         url = construct_url(
             base_url=self.ge_cloud_base_url,
@@ -246,7 +247,9 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
         return self._send_get_request_to_api(url=url)
 
-    def _send_get_request_to_api(self, url: str, params: dict | None = None) -> dict:
+    def _send_get_request_to_api(
+        self, url: str, params: dict | None = None
+    ) -> ResponsePayload:
         try:
             response = self._session.get(
                 url=url,

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -235,7 +235,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         else:
             params = None
 
-        return self._send_get_request_to_api(url=url, params=params)
+        payload = self._send_get_request_to_api(url=url, params=params)
+        return cast(ResponsePayload, payload)
 
     @override
     def _get_all(self) -> ResponsePayload:  # type: ignore[override]
@@ -245,11 +246,10 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             resource_name=self.ge_cloud_resource_name,
         )
 
-        return self._send_get_request_to_api(url=url)
+        payload = self._send_get_request_to_api(url=url)
+        return cast(ResponsePayload, payload)
 
-    def _send_get_request_to_api(
-        self, url: str, params: dict | None = None
-    ) -> ResponsePayload:
+    def _send_get_request_to_api(self, url: str, params: dict | None = None) -> dict:
         try:
             response = self._session.get(
                 url=url,
@@ -264,7 +264,7 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 raise StoreBackendError(
                     "Unable to get object in GX Cloud Store Backend: Object does not exist."
                 )
-            return cast(ResponsePayload, response.json())
+            return response_json
         except json.JSONDecodeError as jsonError:
             logger.debug(  # noqa: PLE1205
                 "Failed to parse GX Cloud Response into JSON",

--- a/great_expectations/data_context/store/in_memory_store_backend.py
+++ b/great_expectations/data_context/store/in_memory_store_backend.py
@@ -1,14 +1,18 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.data_context_key import DataContextVariableKey
-from great_expectations.data_context.data_context_variables import (
-    DataContextVariableSchema,
-)
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.resource_identifiers import DataContextKey
 from great_expectations.exceptions import InvalidKeyError
 from great_expectations.util import filter_properties_dict
+
+if TYPE_CHECKING:
+    from great_expectations.data_context.data_context_variables import (
+        DataContextVariableSchema,
+    )
 
 
 class InMemoryStoreBackend(StoreBackend):
@@ -52,6 +56,9 @@ class InMemoryStoreBackend(StoreBackend):
             return self._store[key]
         except KeyError as e:
             raise InvalidKeyError(f"{e!s}")
+
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
 
     @override
     def _set(self, key, value, **kwargs) -> None:

--- a/great_expectations/data_context/store/in_memory_store_backend.py
+++ b/great_expectations/data_context/store/in_memory_store_backend.py
@@ -57,6 +57,7 @@ class InMemoryStoreBackend(StoreBackend):
         except KeyError as e:
             raise InvalidKeyError(f"{e!s}")
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -96,6 +96,9 @@ class InlineStoreBackend(StoreBackend):
 
         return variable_config
 
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
+
     @override
     def _set(self, key: tuple[str, ...], value: Any, **kwargs: dict) -> None:
         resource_name = InlineStoreBackend._determine_resource_name(key)

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -96,6 +96,7 @@ class InlineStoreBackend(StoreBackend):
 
         return variable_config
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -198,6 +198,13 @@ class Store:
 
         return None
 
+    def get_all(self) -> list[Any]:
+        objs = self._store_backend.get_all()
+        if self.cloud_mode:
+            objs = list(map(self.ge_cloud_response_json_to_object_dict, objs))
+
+        return list(map(self.deserialize, objs))
+
     def set(self, key: DataContextKey, value: Any, **kwargs) -> None:
         if key == StoreBackend.STORE_BACKEND_ID_KEY:
             return self._store_backend.set(key, value, **kwargs)

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -201,7 +201,7 @@ class Store:
     def get_all(self) -> list[Any]:
         objs = self._store_backend.get_all()
         if self.cloud_mode:
-            objs = list(map(self.ge_cloud_response_json_to_object_dict, objs))
+            objs = self.ge_cloud_response_json_to_object_dict(objs)
 
         return list(map(self.deserialize, objs))
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -326,6 +326,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
 
         return contents
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 
@@ -577,6 +578,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
             .decode(s3_response_object.get("ContentEncoding", "utf-8"))
         )
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 
@@ -864,6 +866,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         else:
             return gcs_response_object.download_as_bytes().decode("utf-8")
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 
@@ -1090,6 +1093,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
             self._container_client.download_blob(az_blob_key).readall().decode("utf-8")
         )
 
+    @override
     def _get_all(self) -> list[Any]:
         raise NotImplementedError
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -326,6 +326,9 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
 
         return contents
 
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
+
     def _set(self, key, value, **kwargs):
         if not isinstance(key, tuple):
             key = key.to_tuple()
@@ -573,6 +576,9 @@ class TupleS3StoreBackend(TupleStoreBackend):
             .read()
             .decode(s3_response_object.get("ContentEncoding", "utf-8"))
         )
+
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
 
     def _set(
         self,
@@ -858,6 +864,9 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         else:
             return gcs_response_object.download_as_bytes().decode("utf-8")
 
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
+
     def _set(
         self,
         key,
@@ -1080,6 +1089,9 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         return (
             self._container_client.download_blob(az_blob_key).readall().decode("utf-8")
         )
+
+    def _get_all(self) -> list[Any]:
+        raise NotImplementedError
 
     def _set(self, key, value, content_encoding="utf-8", **kwargs):
         from great_expectations.compatibility.azure import ContentSettings

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -271,7 +271,24 @@ def test_list_keys(
         store_backend.list_keys()
         mock_get.assert_called_with(
             mock.ANY,  # requests.Session object
-            f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",
+            url=f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",
+            params=None,
+        )
+
+
+def test_get_all(
+    construct_ge_cloud_store_backend: Callable[
+        [GXCloudRESTResource], GXCloudStoreBackend
+    ],
+) -> None:
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.DATASOURCE)
+
+    with mock.patch("requests.Session.get", autospec=True) as mock_get:
+        store_backend.get_all()
+        mock_get.assert_called_with(
+            mock.ANY,  # requests.Session object
+            url=f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/datasources",
+            params=None,
         )
 
 


### PR DESCRIPTION
Retrieval of an entire collection is not currently supported by our stores - we should allow for a `get_all` mechanism to improve performance (especially around datasources).

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
