### PR TITLE
[BUGFIX] Snowflake column name case sensitivity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,19 +306,20 @@ jobs:
       SNOWFLAKE_ROLE: ${{secrets.SNOWFLAKE_ROLE}}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         markers:
           - athena or clickhouse or openpyxl or pyarrow or project or sqlite or aws_creds
-          - aws_deps
-          - big
-          - cli
+          # - aws_deps
+          # - big
+          # - cli
           - databricks
-          - filesystem
-          - mssql
-          - mysql
+          # - filesystem
+          # - mssql
+          # - mysql
           - postgresql
           - snowflake
-          - spark
+          # - spark
           - trino
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,20 +306,19 @@ jobs:
       SNOWFLAKE_ROLE: ${{secrets.SNOWFLAKE_ROLE}}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         markers:
           - athena or clickhouse or openpyxl or pyarrow or project or sqlite or aws_creds
-          # - aws_deps
-          # - big
-          # - cli
+          - aws_deps
+          - big
+          - cli
           - databricks
-          # - filesystem
-          # - mssql
-          # - mysql
+          - filesystem
+          - mssql
+          - mysql
           - postgresql
           - snowflake
-          # - spark
+          - spark
           - trino
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -322,23 +322,23 @@ def attempt_allowing_relative_error(dialect):
     return detected_redshift or detected_psycopg2
 
 
-class _CaseInsensitiveString(str):
+class CaseInsensitiveString(str):
     """
     A string that compares equal to another string regardless of case,
     unless it is quoted.
     """
 
     def __init__(self, string: str):
-        # TODO: check if string is already a _CaseInsensitiveString?
+        # TODO: check if string is already a CaseInsensitiveString?
         self._original = string
         self._lower = string.lower()
         self._quote_string = '"'
 
     @override
-    def __eq__(self, other: _CaseInsensitiveString | str | object):
+    def __eq__(self, other: CaseInsensitiveString | str | object):
         if self.is_quoted():
             return self._original == str(other)
-        if isinstance(other, _CaseInsensitiveString):
+        if isinstance(other, CaseInsensitiveString):
             return self._lower == other._lower
         elif isinstance(other, str):
             return self._lower == other.lower()
@@ -367,7 +367,7 @@ class CaseInsensitiveNameDict(UserDict):
         item = self.data[key]
         if key == "name":
             logger.debug(f"CaseInsensitiveNameDict.__getitem__ - {key}:{item}")
-            return _CaseInsensitiveString(item)
+            return CaseInsensitiveString(item)
         return item
 
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -358,7 +359,7 @@ class _CaseInsensitiveString(str):
 class CaseInsensitiveNameDict(UserDict):
     """Normal dict except it returns a case-insensitive string for any `name` key values."""
 
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: dict[str, Any]):
         self.data = data
 
     @override
@@ -374,9 +375,9 @@ def get_sqlalchemy_column_metadata(
     execution_engine: SqlAlchemyExecutionEngine,
     table_selectable: sqlalchemy.Select,
     schema_name: Optional[str] = None,
-) -> Optional[List[Dict[str, Any]]]:
+) -> Sequence[Mapping[str, Any]] | None:
     try:
-        columns: List[Dict[str, Any]]
+        columns: Sequence[Dict[str, Any]]
 
         engine = execution_engine.engine
         inspector = execution_engine.get_inspector()
@@ -431,7 +432,7 @@ def get_sqlalchemy_column_metadata(
         if dialect_name == "snowflake":
             return [
                 # TODO: SmartColumn should know the dialect and do lookups based on that
-                CaseInsensitiveNameDict(column)  # type: ignore[misc]
+                CaseInsensitiveNameDict(column)
                 for column in columns
             ]
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, overload
+from collections import UserDict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    overload,
+)
 
 import numpy as np
 from dateutil.parser import parse
@@ -13,6 +23,7 @@ from great_expectations.compatibility import aws, sqlalchemy, trino
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.execution_engine import (
     PandasExecutionEngine,  # noqa: TCH001
     SqlAlchemyExecutionEngine,  # noqa: TCH001
@@ -20,7 +31,9 @@ from great_expectations.execution_engine import (
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
-from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
+from great_expectations.execution_engine.sqlalchemy_dialect import (
+    GXSqlDialect,
+)
 from great_expectations.execution_engine.util import check_sql_engine_dialect
 
 try:
@@ -308,6 +321,42 @@ def attempt_allowing_relative_error(dialect):
     return detected_redshift or detected_psycopg2
 
 
+class _CaseInsensitiveString(str):
+    def __init__(self, string: str):
+        self._original = string
+        self._lower = string.lower()
+        self._quote_string = '"'
+
+    def __eq__(self, other):
+        if self.is_quoted():
+            return self._original == str(other)
+        if isinstance(other, _CaseInsensitiveString):
+            return self._lower == other._lower
+        elif isinstance(other, str):
+            return self._lower == other.lower()
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self._lower)
+
+    def is_quoted(self):
+        return self._original.startswith(self._quote_string)
+
+
+class SmartColumnLookup(UserDict):
+    def __init__(self, data: Dict[str, Any]):
+        self.data = data
+
+    @override
+    def __getitem__(self, key: Any) -> Any:
+        item = self.data[key]
+        if key == "name":
+            logger.debug(f"SmartColumnLookup - {key}:{item}")
+            return _CaseInsensitiveString(item)
+        return item
+
+
 def get_sqlalchemy_column_metadata(
     execution_engine: SqlAlchemyExecutionEngine,
     table_selectable: sqlalchemy.Select,
@@ -342,7 +391,13 @@ def get_sqlalchemy_column_metadata(
             AttributeError,
             sa.exc.NoSuchTableError,
             sa.exc.ProgrammingError,
-        ):
+        ) as exc:
+            logger.debug(
+                f"{type(exc).__name__} while introspecting columns", exc_info=exc
+            )
+            logger.info(
+                f"While introspecting columns {exc!r}; attempting reflection fallback"
+            )
             # we will get a KeyError for temporary tables, since
             # reflection will not find the temporary schema
             columns = column_reflection_fallback(
@@ -359,9 +414,17 @@ def get_sqlalchemy_column_metadata(
                 sqlalchemy_engine=engine,
             )
 
+        dialect_name = execution_engine.dialect.name
+        if dialect_name == "snowflake":
+            return [
+                # TODO: SmartColumn should know the dialect and do lookups based on that
+                SmartColumnLookup(column)  # type: ignore[misc]
+                for column in columns
+            ]
+
         return columns
     except AttributeError as e:
-        logger.debug(f"Error while introspecting columns: {e!s}")
+        logger.debug(f"Error while introspecting columns: {e!r}", exc_info=e)
         return None
 
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -429,7 +429,7 @@ def get_sqlalchemy_column_metadata(
             )
 
         dialect_name = execution_engine.dialect.name
-        if dialect_name == "snowflake":
+        if dialect_name == GXSqlDialect.SNOWFLAKE:
             return [
                 # TODO: SmartColumn should know the dialect and do lookups based on that
                 CaseInsensitiveNameDict(column)

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -650,13 +650,6 @@ def _is_quote_char_dialect_mismatch(
     return False
 
 
-# TODO: simplify these parametrizations
-# quoted_upper_str
-# unquoted_upper_str
-# quoted_lower_str
-# unquoted_lower_str
-# upper_quoted_name
-# lower_quoted_name
 @pytest.mark.parametrize(
     "column_name",
     [
@@ -666,6 +659,9 @@ def _is_quote_char_dialect_mismatch(
         param("UNQUOTED_UPPER_COL", id="str UNQUOTED_UPPER_COL"),
         param("quoted_lower_col", id="str quoted_lower_col"),
         param("QUOTED_LOWER_COL", id="str QUOTED_LOWER_COL"),
+        param("quoted_upper_col", id="str quoted_upper_col"),
+        param("QUOTED_UPPER_COL", id="str QUOTED_UPPER_COL"),
+        param('"QUOTED_UPPER_COL"', id='str "QUOTED_UPPER_COL"'),
         param('"quoted_lower_col"', id='str "quoted_lower_col"'),
         param(
             quoted_name(
@@ -695,9 +691,6 @@ def _is_quote_char_dialect_mismatch(
             ),
             id="quoted_name QUOTED_LOWER_COL quote=None",
         ),
-        param("quoted_upper_col", id="str quoted_upper_col"),
-        param("QUOTED_UPPER_COL", id="str QUOTED_UPPER_COL"),
-        param('"QUOTED_UPPER_COL"', id='str "QUOTED_UPPER_COL"'),
         param(
             quoted_name(
                 "QUOTED_UPPER_COL",

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -614,6 +614,9 @@ REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str QUOTED_LOWER_COL": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str quoted_upper_col": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     'str "QUOTED_UPPER_COL"': ["postgres", "snowflake", "sqlite"],
+    "quoted_name quoted_lower_col quote=None": ["snowflake"],
+    "quoted_lower_col quote=True": ["snowflake"],
+    "quoted_name quoted_lower_col quote=False]": ["snowflake"],
     "quoted_name quoted_upper_col quote=None": [
         "databricks_sql",
         "postgres",

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -138,8 +138,8 @@ TABLE_NAME_MAPPING: Final[dict[DatabaseType, dict[TableNameCase, str]]] = {
 }
 
 # column names
-UNQUOTED_UPPER: Final[Literal["UNQUOTED_UPPER"]] = "UNQUOTED_UPPER"
-UNQUOTED_LOWER: Final[Literal["unquoted_lower"]] = "unquoted_lower"
+UNQUOTED_UPPER_COL: Final[Literal["UNQUOTED_UPPER_COL"]] = "UNQUOTED_UPPER_COL"
+UNQUOTED_LOWER_COL: Final[Literal["unquoted_lower_col"]] = "unquoted_lower_col"
 
 
 class Row(TypedDict):
@@ -147,8 +147,8 @@ class Row(TypedDict):
     name: str
     upper: str
     lower: str
-    unquoted_upper: str
-    unquoted_lower: str
+    unquoted_upper_col: str
+    unquoted_lower_col: str
 
 
 @pytest.fixture
@@ -268,13 +268,13 @@ def table_factory(
                 create_tables: str = (
                     f"CREATE TABLE IF NOT EXISTS {qualified_table_name}"
                     f" (id INTEGER, name VARCHAR(255), {upper} VARCHAR(255), {lower} VARCHAR(255),"
-                    f" {UNQUOTED_UPPER} VARCHAR(255), {UNQUOTED_LOWER} VARCHAR(255))"
+                    f" {UNQUOTED_UPPER_COL} VARCHAR(255), {UNQUOTED_LOWER_COL} VARCHAR(255))"
                 )
                 conn.execute(TextClause(create_tables))
                 if data:
                     insert_data = (
-                        f"INSERT INTO {qualified_table_name} (id, name, {upper}, {lower}, {UNQUOTED_UPPER}, {UNQUOTED_LOWER})"
-                        " VALUES (:id, :name, :upper, :lower, :unquoted_upper, :unquoted_lower)"
+                        f"INSERT INTO {qualified_table_name} (id, name, {upper}, {lower}, {UNQUOTED_UPPER_COL}, {UNQUOTED_LOWER_COL})"
+                        " VALUES (:id, :name, :upper, :lower, :unquoted_upper_col, :unquoted_lower_col)"
                     )
                     conn.execute(TextClause(insert_data), data)
 
@@ -600,9 +600,9 @@ class TestTableIdentifiers:
 
 # TODO: remove items from this lookup when working on fixes
 REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
-    "str UNQUOTED_LOWER": ["databricks_sql", "postgres", "sqlite"],
-    "str unquoted_upper": ["databricks_sql", "sqlite"],
-    "str UNQUOTED_UPPER": ["databricks_sql", "postgres"],
+    "str UNQUOTED_LOWER_COL": ["databricks_sql", "postgres", "sqlite"],
+    "str unquoted_upper_col": ["databricks_sql", "sqlite"],
+    "str UNQUOTED_UPPER_COL": ["databricks_sql", "postgres"],
     'str "lower"': ["postgres", "snowflake", "sqlite"],
     "str lower": ["snowflake"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
@@ -645,10 +645,10 @@ def _is_quote_char_dialect_mismatch(
 @pytest.mark.parametrize(
     "column_name",
     [
-        param("unquoted_lower", id="str unquoted_lower"),
-        param("UNQUOTED_LOWER", id="str UNQUOTED_LOWER"),
-        param("unquoted_upper", id="str unquoted_upper"),
-        param("UNQUOTED_UPPER", id="str UNQUOTED_UPPER"),
+        param("unquoted_lower_col", id="str unquoted_lower_col"),
+        param("UNQUOTED_LOWER_COL", id="str UNQUOTED_LOWER_COL"),
+        param("unquoted_upper_col", id="str unquoted_upper_col"),
+        param("UNQUOTED_UPPER_COL", id="str UNQUOTED_UPPER_COL"),
         param("lower", id="str lower"),
         param("LOWER", id="str LOWER"),
         param('"lower"', id='str "lower"'),
@@ -754,8 +754,8 @@ class TestColumnIdentifiers:
                     "name": "first",
                     "upper": "uppercase",
                     "lower": "lowercase",
-                    "unquoted_upper": "uppercase",
-                    "unquoted_lower": "lowercase",
+                    "unquoted_upper_col": "uppercase",
+                    "unquoted_lower_col": "lowercase",
                 }
             ],
         )
@@ -856,16 +856,16 @@ class TestColumnIdentifiers:
                     "name": "first",
                     "upper": "my column is uppercase",
                     "lower": "my column is lowercase",
-                    "unquoted_upper": "whatever",
-                    "unquoted_lower": "whatever",
+                    "unquoted_upper_col": "whatever",
+                    "unquoted_lower_col": "whatever",
                 },
                 {
                     "id": 2,
                     "name": "second",
                     "upper": "my column is uppercase",
                     "lower": "my column is lowercase",
-                    "unquoted_upper": "whatever",
-                    "unquoted_lower": "whatever",
+                    "unquoted_upper_col": "whatever",
+                    "unquoted_lower_col": "whatever",
                 },
             ],
         )

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -615,8 +615,8 @@ REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str quoted_upper_col": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     'str "QUOTED_UPPER_COL"': ["postgres", "snowflake", "sqlite"],
     "quoted_name quoted_lower_col quote=None": ["snowflake"],
-    "quoted_lower_col quote=True": ["snowflake"],
-    "quoted_name quoted_lower_col quote=False]": ["snowflake"],
+    "quoted_name quoted_lower_col quote=True": ["snowflake"],
+    "quoted_name quoted_lower_col quote=False": ["snowflake"],
     "quoted_name quoted_upper_col quote=None": [
         "databricks_sql",
         "postgres",

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -842,6 +842,9 @@ class TestColumnIdentifiers:
             else None
         )
 
+        print(f"\ncolumn_name:\n  {column_name!r}")
+        print(f"type:\n  {type(column_name)}\n")
+
         table_factory(
             gx_engine=datasource.get_execution_engine(),
             table_names={TEST_TABLE_NAME},

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -604,6 +604,7 @@ REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str unquoted_upper": ["databricks_sql", "sqlite"],
     "str UNQUOTED_UPPER": ["databricks_sql", "postgres"],
     'str "lower"': ["postgres", "snowflake", "sqlite"],
+    "str lower": ["snowflake"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str upper": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     'str "UPPER"': ["postgres", "snowflake", "sqlite"],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -601,7 +601,7 @@ class TestTableIdentifiers:
 # TODO: remove items from this lookup when working on fixes
 REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str UNQUOTED_LOWER": ["databricks_sql", "postgres", "sqlite"],
-    "str unquoted_upper": ["sqlite"],
+    "str unquoted_upper": ["databricks_sql", "sqlite"],
     "str UNQUOTED_UPPER": ["databricks_sql", "postgres"],
     'str "lower"': ["postgres", "snowflake", "sqlite"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -715,7 +715,8 @@ def _is_quote_char_dialect_mismatch(
     ],
 )
 class TestColumnIdentifiers:
-    @pytest.mark.xfail(reason="sanity checks")
+    # unskip to help debug `test_column_expectation` failures
+    @pytest.mark.skip(reason="sanity checks for helping debug issues")
     def test_raw_queries(
         self,
         context: EphemeralDataContext,

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -600,10 +600,9 @@ class TestTableIdentifiers:
 
 # TODO: remove items from this lookup when working on fixes
 REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
-    "str unquoted_lower": ["sqlite"],
     "str UNQUOTED_LOWER": ["databricks_sql", "postgres", "sqlite"],
     "str unquoted_upper": ["sqlite"],
-    "str UNQUOTED_UPPER": ["databricks_sql", "postgres", "sqlite"],
+    "str UNQUOTED_UPPER": ["databricks_sql", "postgres"],
     'str "lower"': ["postgres", "snowflake", "sqlite"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str upper": ["databricks_sql", "postgres", "snowflake", "sqlite"],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -601,9 +601,9 @@ class TestTableIdentifiers:
 # TODO: remove items from this lookup when working on fixes
 REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str unquoted_lower": ["sqlite"],
-    "str UNQUOTED_LOWER": ["postgres", "sqlite"],
+    "str UNQUOTED_LOWER": ["databricks_sql", "postgres", "sqlite"],
     "str unquoted_upper": ["sqlite"],
-    "str UNQUOTED_UPPER": ["postgres", "sqlite"],
+    "str UNQUOTED_UPPER": ["databricks_sql", "postgres", "sqlite"],
     'str "lower"': ["postgres", "snowflake", "sqlite"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str upper": ["databricks_sql", "postgres", "snowflake", "sqlite"],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -597,6 +597,10 @@ class TestTableIdentifiers:
 
 # TODO: remove items from this lookup when working on fixes
 REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
+    "str unquoted_lower": ["sqlite"],
+    "str UNQUOTED_LOWER": ["postgres", "sqlite"],
+    "str unquoted_upper": ["sqlite"],
+    "str UNQUOTED_UPPER": ["postgres", "sqlite"],
     'str "lower"': ["postgres", "snowflake"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str upper": ["databricks_sql", "postgres", "snowflake", "sqlite"],

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -601,10 +601,10 @@ REQUIRE_FIXES: Final[dict[str, list[DatabaseType]]] = {
     "str UNQUOTED_LOWER": ["postgres", "sqlite"],
     "str unquoted_upper": ["sqlite"],
     "str UNQUOTED_UPPER": ["postgres", "sqlite"],
-    'str "lower"': ["postgres", "snowflake"],
+    'str "lower"': ["postgres", "snowflake", "sqlite"],
     "str LOWER": ["databricks_sql", "postgres", "snowflake", "sqlite"],
     "str upper": ["databricks_sql", "postgres", "snowflake", "sqlite"],
-    'str "UPPER"': ["postgres", "snowflake"],
+    'str "UPPER"': ["postgres", "snowflake", "sqlite"],
     "quoted_name upper quote=None": [
         "databricks_sql",
         "postgres",
@@ -646,69 +646,69 @@ def _is_quote_char_dialect_mismatch(
         param("UNQUOTED_LOWER", id="str UNQUOTED_LOWER"),
         param("unquoted_upper", id="str unquoted_upper"),
         param("UNQUOTED_UPPER", id="str UNQUOTED_UPPER"),
-        # param("lower", id="str lower"),
-        # param("LOWER", id="str LOWER"),
-        # param('"lower"', id='str "lower"'),
-        # param(
-        #     quoted_name(
-        #         "lower",
-        #         quote=None,
-        #     ),
-        #     id="quoted_name lower quote=None",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "lower",
-        #         quote=True,
-        #     ),
-        #     id="quoted_name lower quote=True",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "lower",
-        #         quote=False,
-        #     ),
-        #     id="quoted_name lower quote=False",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "LOWER",
-        #         quote=None,
-        #     ),
-        #     marks=[pytest.mark.xfail],
-        #     id="quoted_name LOWER quote=None",
-        # ),
-        # param("upper", id="str upper"),
-        # param("UPPER", id="str UPPER"),
-        # param('"UPPER"', id='str "UPPER"'),
-        # param(
-        #     quoted_name(
-        #         "UPPER",
-        #         quote=None,
-        #     ),
-        #     id="quoted_name UPPER quote=None",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "UPPER",
-        #         quote=True,
-        #     ),
-        #     id="quoted_name UPPER quote=True",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "UPPER",
-        #         quote=False,
-        #     ),
-        #     id="quoted_name UPPER quote=False",
-        # ),
-        # param(
-        #     quoted_name(
-        #         "upper",
-        #         quote=None,
-        #     ),
-        #     id="quoted_name upper quote=None",
-        # ),
+        param("lower", id="str lower"),
+        param("LOWER", id="str LOWER"),
+        param('"lower"', id='str "lower"'),
+        param(
+            quoted_name(
+                "lower",
+                quote=None,
+            ),
+            id="quoted_name lower quote=None",
+        ),
+        param(
+            quoted_name(
+                "lower",
+                quote=True,
+            ),
+            id="quoted_name lower quote=True",
+        ),
+        param(
+            quoted_name(
+                "lower",
+                quote=False,
+            ),
+            id="quoted_name lower quote=False",
+        ),
+        param(
+            quoted_name(
+                "LOWER",
+                quote=None,
+            ),
+            marks=[pytest.mark.xfail],
+            id="quoted_name LOWER quote=None",
+        ),
+        param("upper", id="str upper"),
+        param("UPPER", id="str UPPER"),
+        param('"UPPER"', id='str "UPPER"'),
+        param(
+            quoted_name(
+                "UPPER",
+                quote=None,
+            ),
+            id="quoted_name UPPER quote=None",
+        ),
+        param(
+            quoted_name(
+                "UPPER",
+                quote=True,
+            ),
+            id="quoted_name UPPER quote=True",
+        ),
+        param(
+            quoted_name(
+                "UPPER",
+                quote=False,
+            ),
+            id="quoted_name UPPER quote=False",
+        ),
+        param(
+            quoted_name(
+                "upper",
+                quote=None,
+            ),
+            id="quoted_name upper quote=None",
+        ),
     ],
 )
 class TestColumnIdentifiers:

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -712,6 +712,7 @@ def _is_quote_char_dialect_mismatch(
     ],
 )
 class TestColumnIdentifiers:
+    @pytest.mark.xfail(reason="sanity checks")
     def test_raw_queries(
         self,
         context: EphemeralDataContext,

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -15,7 +15,7 @@ from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import MetricResolutionError
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.expectations.metrics.util import (
-    _CaseInsensitiveString,
+    CaseInsensitiveString,
     get_dbms_compatible_metric_domain_kwargs,
     get_unexpected_indices_for_multiple_pandas_named_indices,
     get_unexpected_indices_for_single_pandas_named_index,
@@ -500,16 +500,16 @@ class TestCaseInsensitiveString:
         input_str: str,
         other: str,
     ):
-        other_case_insensitive = _CaseInsensitiveString(other)
-        input_case_insensitive = _CaseInsensitiveString(input_str)
+        other_case_insensitive = CaseInsensitiveString(other)
+        input_case_insensitive = CaseInsensitiveString(input_str)
 
         # if either string is quoted, they must be exact match
         if input_case_insensitive.is_quoted() or other_case_insensitive.is_quoted():
             if input == other:
                 assert input_case_insensitive == other_case_insensitive
-            assert input_case_insensitive != _CaseInsensitiveString(other.swapcase())
+            assert input_case_insensitive != CaseInsensitiveString(other.swapcase())
         elif input_str.lower() == other.lower():
-            assert input_case_insensitive == _CaseInsensitiveString(other.swapcase())
+            assert input_case_insensitive == CaseInsensitiveString(other.swapcase())
         else:
             assert input_case_insensitive != other_case_insensitive
 

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -506,12 +506,15 @@ class TestCaseInsensitiveString:
         # if either string is quoted, they must be exact match
         if input_case_insensitive.is_quoted() or other_case_insensitive.is_quoted():
             if input == other:
+                assert input_case_insensitive == other
                 assert input_case_insensitive == other_case_insensitive
             assert input_case_insensitive != CaseInsensitiveString(other.swapcase())
         elif input_str.lower() == other.lower():
+            assert input_case_insensitive == other.swapcase()
             assert input_case_insensitive == CaseInsensitiveString(other.swapcase())
         else:
             assert input_case_insensitive != other_case_insensitive
+            assert input_case_insensitive != other
 
 
 if __name__ == "__main__":

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Final, List, Union
 
 import pytest
 from _pytest import monkeypatch
@@ -15,6 +15,7 @@ from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import MetricResolutionError
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.expectations.metrics.util import (
+    _CaseInsensitiveString,
     get_dbms_compatible_metric_domain_kwargs,
     get_unexpected_indices_for_multiple_pandas_named_indices,
     get_unexpected_indices_for_single_pandas_named_index,
@@ -478,3 +479,40 @@ def test_get_dbms_compatible_metric_domain_column_list_kwargs(
         batch_columns_list=test_column_names,
     )
     assert sorted(metric_domain_kwargs["column_list"]) == sorted(output_column_list)
+
+
+_CASE_PARAMS: Final[list[str]] = [
+    "mixedCase",
+    "UPPERCASE",
+    "lowercase",
+    '"quotedMixedCase"',
+    '"QUOTED_UPPERCASE"',
+    '"quoted_lowercase"',
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("input_str", _CASE_PARAMS)
+class TestCaseInsensitiveString:
+    @pytest.mark.parametrize("other", _CASE_PARAMS)
+    def test__eq__(
+        self,
+        input_str: str,
+        other: str,
+    ):
+        other_case_insensitive = _CaseInsensitiveString(other)
+        input_case_insensitive = _CaseInsensitiveString(input_str)
+
+        # if either string is quoted, they must be exact match
+        if input_case_insensitive.is_quoted() or other_case_insensitive.is_quoted():
+            if input == other:
+                assert input_case_insensitive == other_case_insensitive
+            assert input_case_insensitive != _CaseInsensitiveString(other.swapcase())
+        elif input_str.lower() == other.lower():
+            assert input_case_insensitive == _CaseInsensitiveString(other.swapcase())
+        else:
+            assert input_case_insensitive != other_case_insensitive
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
Due to a known issue in the `snowflake-sqlalchemy` package, column_names are always converted to lowercase when we pull down column metadata. This meant that our column based expectations would fail if anything other than unquoted lowercase columns were used (regardless of the actual casing of the column in question).

### Related Issues
 - https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157

- https://github.com/great-expectations/great_expectations/pull/8526
- #8630 


This change adds conditional logic (snowflake only) to our `metrics.util.get_sqlalchemy_column_metadata()` function that returns a special dictionary object that returns a `CaseInsenitiveString` whenever the column `name` key is accessed. This eliminates the bug in the most important cases, but will be breaking change in others.

### Note
There is another related issue that is still being worked on that causes expectations to fail because of how we are defining our metric keys.

## TODO:
- [x] test [QUOTED_IDENTIFIERS_IGNORE_CASE](https://docs.snowflake.com/en/sql-reference/parameters#label-quoted-identifiers-ignore-case) with this fix
- [ ] Merge `SnowflakeDatasource` update to accept `QUOTED_IDENTIFIERS_IGNORE_CASE`??
- [ ] Metric key lookup fix - https://github.com/great-expectations/great_expectations/pull/8725

## Column casing behavior

This fix supports the most common uses, but it makes using quoted columns unusable with `great_expectations`, unless combined with the `QUOTED_IDENTIFIERS_IGNORE_CASE` session param.

**Table represents the results of an `expect_column_to_exist` checkpoint run.**
✅ Means the validation succeeded
❌ Means the validation failed
`*` Snowflake lowercase, unquoted column names are not possible, these tables will still default to `FOOBAR`

DDL COLUMN_NAME | Expectation `column_name` arg | expected | current | with fix | with fix + <br>`IQUOTED_IDENTIFIERS_IGNORE_CASE` param
-----------------| ---------------------------------|--------|-------|----|---
`foobar`* | `foobar`| ✅ | ✅  | ✅ | ✅
`foobar`* | `FOOBAR`| ✅| ❌ | ✅ | ✅
`foobar`* | `"foobar"`|❌| ❌ | ❌ | ❌ 
`foobar`* | `"FOOBAR"`|✅| ❌  | ❌ | ❌ 
`FOOBAR` | `FOOBAR`|✅| ❌ | ✅ | ✅
`FOOBAR` | `foobar` | ✅ | ✅  | ✅ | ✅ 
`FOOBAR` | `"foobar"` | ❌  | ❌   | ❌ | ❌ 
`FOOBAR` | `"FOOBAR"` | ✅  | ❌   | ❌ | ❌ 
`"foobar"` | `foobar` | ❌  | ✅  | ❌ | ❌ 
`"foobar"` | `FOOBAR` | ❌  | ❌ | ❌| ❌ 
`"foobar"` | `"foobar"`| ✅ | ❌ | ❌ | ❌ 
`"foobar"` | `"FOOBAR"`| ❌  | ❌ | ❌ | ❌ 
`"FOOBAR"` | `foobar` | ✅ |✅ | ❌ | ✅
`"FOOBAR"` | `FOOBAR`| ✅ | ❌ | ✅|✅ 
`"FOOBAR"` | `"foobar"`| ❌ | ❌ | ❌ |❌ 
`"FOOBAR"` | `"FOOBAR"`|✅| ❌ | ❌ | ❌ 


