### PR TITLE
[BUGFIX] Patch `docs_integration` tests failures resulting from context root dir rename

### DIFF
--- a/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_pandas.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_pandas.py
@@ -20,7 +20,7 @@ context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
 
 # parse great_expectations.yml for comparison
 great_expectations_yaml_file_path = pathlib.Path(
-    full_path_to_project_directory, "great_expectations/great_expectations.yml"
+    full_path_to_project_directory, FileDataContext.GX_DIR, FileDataContext.GX_YML
 )
 great_expectations_yaml = yaml.load(great_expectations_yaml_file_path.read_text())
 

--- a/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py
@@ -27,7 +27,7 @@ context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
 
 # parse great_expectations.yml for comparison
 great_expectations_yaml_file_path = pathlib.Path(
-    full_path_to_project_directory, "great_expectations/great_expectations.yml"
+    full_path_to_project_directory, FileDataContext.GX_DIR, FileDataContext.GX_YML
 )
 great_expectations_yaml = yaml.load(great_expectations_yaml_file_path.read_text())
 

--- a/tests/integration/docusaurus/deployment_patterns/aws_redshift_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_redshift_deployment_patterns.py
@@ -22,7 +22,7 @@ context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
 
 # parse great_expectations.yml for comparison
 great_expectations_yaml_file_path = pathlib.Path(
-    full_path_to_project_directory, "great_expectations/great_expectations.yml"
+    full_path_to_project_directory, FileDataContext.GX_DIR, FileDataContext.GX_YML
 )
 great_expectations_yaml = yaml.load(great_expectations_yaml_file_path.read_text())
 

--- a/tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py
+++ b/tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery.py
@@ -29,7 +29,7 @@ BIGQUERY_DATASET = "demo"
 
 # parse great_expectations.yml for comparison
 great_expectations_yaml_file_path = pathlib.Path(
-    full_path_to_project_directory, "great_expectations/great_expectations.yml"
+    full_path_to_project_directory, FileDataContext.GX_DIR, FileDataContext.GX_YML
 )
 great_expectations_yaml = yaml.load(great_expectations_yaml_file_path.read_text())
 

--- a/tests/integration/docusaurus/expectations/advanced/failed_rows_pandas.py
+++ b/tests/integration/docusaurus/expectations/advanced/failed_rows_pandas.py
@@ -18,7 +18,7 @@ file_path: str = folder_path + "/visits.csv"
 # <snippet name="tests/integration/docusaurus/expectations/advanced/failed_rows_pandas.py get context">
 import great_expectations as gx
 
-context = gx.get_context(context_root_dir="./great_expectations")
+context = gx.get_context(project_root_dir=".")
 # </snippet>
 
 # add datasource and asset

--- a/tests/integration/docusaurus/expectations/advanced/failed_rows_spark.py
+++ b/tests/integration/docusaurus/expectations/advanced/failed_rows_spark.py
@@ -16,7 +16,7 @@ folder_path = str(
 # <snippet name="tests/integration/docusaurus/expectations/advanced/failed_rows_spark.py get context">
 import great_expectations as gx
 
-context = gx.get_context(context_root_dir="./great_expectations")
+context = gx.get_context(project_root_dir=".")
 # </snippet>
 
 # add datasource and asset

--- a/tests/integration/docusaurus/expectations/advanced/failed_rows_sql.py
+++ b/tests/integration/docusaurus/expectations/advanced/failed_rows_sql.py
@@ -17,7 +17,7 @@ connection_string: str = f"sqlite:///{folder_path}/visits.db"
 # <snippet name="tests/integration/docusaurus/expectations/advanced/failed_rows_sql.py get context">
 import great_expectations as gx
 
-context = gx.get_context(context_root_dir="./great_expectations")
+context = gx.get_context(project_root_dir=".")
 # </snippet>
 
 # add datasource and asset


### PR DESCRIPTION
The rename from `great_expectations/` to `gx/` messed up some of our docs integration tests - here's a quick fix

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
