### PR TITLE
[BUGFIX] Resolve issue around listing keys with empty state in `GXCloudStoreBackend`

### DIFF
--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -257,13 +257,6 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             )
             response.raise_for_status()
             response_json: dict = response.json()
-            if (
-                isinstance(response_json["data"], list)
-                and len(response_json["data"]) == 0
-            ):
-                raise StoreBackendError(
-                    "Unable to get object in GX Cloud Store Backend: Object does not exist."
-                )
             return response_json
         except json.JSONDecodeError as jsonError:
             logger.debug(  # noqa: PLE1205

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pandas as pd
 import pytest
 
+import great_expectations.exceptions as gx_exceptions
 from great_expectations.checkpoint import Checkpoint
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context import get_context
@@ -430,8 +431,11 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_pre
     with mock.patch(
         "requests.Session.post", autospec=True, side_effect=mocked_post_response
     ) as mock_post, mock.patch(
-        "great_expectations.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend.has_key",
-        side_effect=False,
+        "requests.Session.get",
+        autospec=True,
+        side_effect=gx_exceptions.StoreBackendError(
+            "Unable to get object in GX Cloud Store Backend"
+        ),
     ):
         checkpoint = context.add_or_update_checkpoint(**checkpoint_config)
 

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -416,7 +416,6 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_pre
     validation_ids: Tuple[str, str],
     checkpoint_config: dict,
     mocked_post_response: Callable[[], MockResponse],
-    mocked_get_by_name_response_0_results: Callable[[], MockResponse],
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
 ) -> None:
@@ -431,9 +430,8 @@ def test_cloud_backed_data_context_add_or_update_checkpoint_adds_when_id_not_pre
     with mock.patch(
         "requests.Session.post", autospec=True, side_effect=mocked_post_response
     ) as mock_post, mock.patch(
-        "requests.Session.get",
-        autospec=True,
-        side_effect=mocked_get_by_name_response_0_results,
+        "great_expectations.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend.has_key",
+        side_effect=False,
     ):
         checkpoint = context.add_or_update_checkpoint(**checkpoint_config)
 

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Set, Union
 from unittest import mock
 
 import pytest
+import responses
 
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
@@ -274,6 +275,25 @@ def test_list_keys(
             url=f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",
             params=None,
         )
+
+
+@responses.activate
+def test_list_keys_with_empty_payload_from_backend(
+    construct_ge_cloud_store_backend: Callable[
+        [GXCloudRESTResource], GXCloudStoreBackend
+    ],
+):
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.DATASOURCE)
+
+    responses.add(
+        responses.GET,
+        f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/datasources",
+        json={"data": []},
+        status=200,
+    )
+
+    assert store_backend.list_keys() == []
+    assert len(responses.calls) == 1
 
 
 def test_get_all(


### PR DESCRIPTION
We sometimes will run into situations where we are calling `store.list_keys()` but don't actually have any keys available - this should return an empty list instead of erroring out.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
