### PR TITLE
[BUGFIX] Patch faulty `GXCloudStoreBackend.has_key` logic

### DIFF
--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -628,7 +628,10 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     @override
     def _has_key(self, key: Tuple[GXCloudRESTResource, str | None, str | None]) -> bool:
         try:
-            _ = self._get(key)
+            # Requests using query params may return {"data": []} if the object doesn't exist
+            # We need to validate that even if we have a 200, there are contents to support existence
+            payload = self._get(key)
+            return bool(payload["data"])
         except StoreBackendTransientError:
             raise
         except StoreBackendError as e:

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -637,7 +637,6 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         except StoreBackendError as e:
             logger.info(f"Could not find object associated with key {key}: {e}")
             return False
-        return True
 
     @property
     @override

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -296,6 +296,28 @@ def test_list_keys_with_empty_payload_from_backend(
     assert len(responses.calls) == 1
 
 
+@responses.activate
+def test_has_key_with_empty_payload_from_backend(
+    construct_ge_cloud_store_backend: Callable[
+        [GXCloudRESTResource], GXCloudStoreBackend
+    ],
+):
+    store_backend = construct_ge_cloud_store_backend(
+        GXCloudRESTResource.EXPECTATION_SUITE
+    )
+
+    name = "my_nonexistent_suite"
+    responses.add(
+        responses.GET,
+        f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/expectation-suites?name={name}",
+        json={"data": []},
+        status=200,
+    )
+
+    key = (GXCloudRESTResource.EXPECTATION_SUITE, None, name)
+    assert store_backend.has_key(key) is False
+
+
 def test_get_all(
     construct_ge_cloud_store_backend: Callable[
         [GXCloudRESTResource], GXCloudStoreBackend


### PR DESCRIPTION
We need to evaluate the contents of the return payload in this existence method (simply relying on a 200 is not good enough when using query params).

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
