### PR TITLE
[CONTRIB] Adding simple tests for CloudDataStore add_expectation_suite

### DIFF
--- a/tests/datasource/fluent/_fake_cloud_api.py
+++ b/tests/datasource/fluent/_fake_cloud_api.py
@@ -472,7 +472,7 @@ def get_expectation_suites_cb(request: PreparedRequest) -> CallbackResult:
     exp_suite_list: list[dict] = list(exp_suites.values())
     if queried_names:
         exp_suite_list = [
-            d
+            d["data"]
             for d in exp_suite_list
             if d["data"]["attributes"]["suite"]["expectation_suite_name"]
             in queried_names

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import pytest
 
 from great_expectations.data_context import CloudDataContext
+from great_expectations.exceptions.exceptions import ExpectationSuiteError
 from great_expectations.experimental.metric_repository.cloud_data_store import (
     CloudDataStore,
 )
@@ -21,6 +22,26 @@ from tests.datasource.fluent.conftest import (
     cloud_details,  # noqa: F401  # used as a fixture
     empty_cloud_context_fluent,  # noqa: F401  # used as a fixture
 )
+
+
+class TestCloudDataStore:
+    def test_add_expectation_suite_success(
+        self, empty_cloud_context_fluent: CloudDataContext  # noqa: F811
+    ):  # used as a fixture
+        context = empty_cloud_context_fluent
+        created_expectation_suite = context.add_expectation_suite("test_suite")
+        retrieved_expectation_suite = context.get_expectation_suite("test_suite")
+        assert created_expectation_suite == retrieved_expectation_suite
+
+    def test_add_expectation_suite_name_collision_failure(
+        self, empty_cloud_context_fluent: CloudDataContext  # noqa: F811
+    ):  # used as a fixture
+        context = empty_cloud_context_fluent
+        created_expectation_suite = context.add_expectation_suite("test_suite")
+        retrieved_expectation_suite = context.get_expectation_suite("test_suite")
+        assert created_expectation_suite == retrieved_expectation_suite
+        with pytest.raises(ExpectationSuiteError):
+            context.add_expectation_suite("test_suite")
 
 
 class TestCloudDataStoreMetricRun:

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -24,6 +24,7 @@ from tests.datasource.fluent.conftest import (
 )
 
 
+@pytest.mark.cloud
 class TestCloudDataStore:
     def test_add_expectation_suite_success(
         self, empty_cloud_context_fluent: CloudDataContext  # noqa: F811


### PR DESCRIPTION
Testing this API for get_expectation_suite works correctly without the mock. I believe the mock response json is incorrect and have updated that.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
