### PR TITLE
[MAINTENANCE] Improve test coverage around `GXCloudStoreBackend.gx_cloud_response_json_to_object_dict`

### DIFF
--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -40,16 +40,24 @@ class CheckpointStore(ConfigurationStore):
     _configuration_class = CheckpointConfig
 
     @override
-    def ge_cloud_response_json_to_object_dict(self, response_json: Dict) -> Dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object
         """
+        response_data = response_json["data"]
+
         cp_data: Dict
-        if isinstance(response_json["data"], list):
-            cp_data = response_json["data"][0]
+        if isinstance(response_data, list):
+            if len(response_data) == 0:
+                raise ValueError(
+                    f"Cannot parse empty data from GX Cloud payload: {response_json}"
+                )
+            cp_data = response_data[0]
         else:
-            cp_data = response_json["data"]
+            cp_data = response_data
+
         ge_cloud_checkpoint_id: str = cp_data["id"]
         checkpoint_config_dict: Dict = cp_data["attributes"]["checkpoint_config"]
         checkpoint_config_dict["ge_cloud_id"] = ge_cloud_checkpoint_id

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -41,7 +41,7 @@ class CheckpointStore(ConfigurationStore):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/data_asset_store.py
+++ b/great_expectations/data_context/store/data_asset_store.py
@@ -99,7 +99,7 @@ class DataAssetStore(Store):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(
+    def gx_cloud_response_json_to_object_dict(
         response_json: CloudResponsePayloadTD,  # type: ignore[override]
     ) -> dict:
         """

--- a/great_expectations/data_context/store/data_asset_store.py
+++ b/great_expectations/data_context/store/data_asset_store.py
@@ -98,8 +98,9 @@ class DataAssetStore(Store):
         return data_asset_model(**value)
 
     @override
+    @staticmethod
     def ge_cloud_response_json_to_object_dict(
-        self, response_json: CloudResponsePayloadTD  # type: ignore[override]
+        response_json: CloudResponsePayloadTD,  # type: ignore[override]
     ) -> dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -125,7 +125,7 @@ class DatasourceStore(Store):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(
+    def gx_cloud_response_json_to_object_dict(
         response_json: CloudResponsePayloadTD,  # type: ignore[override]
     ) -> dict:
         """

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -124,8 +124,9 @@ class DatasourceStore(Store):
             return self._schema.loads(value)
 
     @override
+    @staticmethod
     def ge_cloud_response_json_to_object_dict(
-        self, response_json: CloudResponsePayloadTD  # type: ignore[override]
+        response_json: CloudResponsePayloadTD,  # type: ignore[override]
     ) -> dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -166,7 +166,8 @@ class ExpectationsStore(Store):
         filter_properties_dict(properties=self._config, clean_falsy=True, inplace=True)
 
     @override
-    def ge_cloud_response_json_to_object_dict(self, response_json: Dict) -> Dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -167,7 +167,7 @@ class ExpectationsStore(Store):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/gx_cloud_store_backend.py
+++ b/great_expectations/data_context/store/gx_cloud_store_backend.py
@@ -236,6 +236,14 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             params = None
 
         payload = self._send_get_request_to_api(url=url, params=params)
+
+        # Requests using query params may return {"data": []} if the object doesn't exist
+        # We need to validate that even if we have a 200, there are contents to support existence
+        if not bool(payload.get("data")):
+            raise StoreBackendError(
+                "Unable to get object in GX Cloud Store Backend: Object does not exist."
+            )
+
         return cast(ResponsePayload, payload)
 
     @override
@@ -628,10 +636,8 @@ class GXCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     @override
     def _has_key(self, key: Tuple[GXCloudRESTResource, str | None, str | None]) -> bool:
         try:
-            # Requests using query params may return {"data": []} if the object doesn't exist
-            # We need to validate that even if we have a 200, there are contents to support existence
-            payload = self._get(key)
-            return bool(payload["data"])
+            _ = self._get(key)
+            return True
         except StoreBackendTransientError:
             raise
         except StoreBackendError as e:

--- a/great_expectations/data_context/store/json_site_store.py
+++ b/great_expectations/data_context/store/json_site_store.py
@@ -50,7 +50,7 @@ class JsonSiteStore(Store):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/json_site_store.py
+++ b/great_expectations/data_context/store/json_site_store.py
@@ -49,7 +49,8 @@ class JsonSiteStore(Store):
         filter_properties_dict(properties=self._config, clean_falsy=True, inplace=True)
 
     @override
-    def ge_cloud_response_json_to_object_dict(self, response_json: Dict) -> Dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -66,7 +66,8 @@ class ProfilerStore(ConfigurationStore):
             )
 
     @override
-    def ge_cloud_response_json_to_object_dict(self, response_json: dict) -> dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: dict) -> dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -67,7 +67,7 @@ class ProfilerStore(ConfigurationStore):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: dict) -> dict:
+    def gx_cloud_response_json_to_object_dict(response_json: dict) -> dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -94,7 +94,7 @@ class Store:
         self._use_fixed_length_key = self._store_backend.fixed_length_key
 
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object
@@ -189,7 +189,7 @@ class Store:
             value = self._store_backend.get(self.key_to_tuple(key))
             # TODO [Robby] MER-285: Handle non-200 http errors
             if value:
-                value = self.ge_cloud_response_json_to_object_dict(response_json=value)
+                value = self.gx_cloud_response_json_to_object_dict(response_json=value)
         else:
             self._validate_key(key)
             value = self._store_backend.get(self.key_to_tuple(key))
@@ -202,7 +202,7 @@ class Store:
     def get_all(self) -> list[Any]:
         objs = self._store_backend.get_all()
         if self.cloud_mode:
-            objs = self.ge_cloud_response_json_to_object_dict(objs)
+            objs = self.gx_cloud_response_json_to_object_dict(objs)
 
         return list(map(self.deserialize, objs))
 

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -93,7 +93,8 @@ class Store:
             )
         self._use_fixed_length_key = self._store_backend.fixed_length_key
 
-    def ge_cloud_response_json_to_object_dict(self, response_json: Dict) -> Dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -155,7 +155,8 @@ class ValidationsStore(Store):
         filter_properties_dict(properties=self._config, clean_falsy=True, inplace=True)
 
     @override
-    def ge_cloud_response_json_to_object_dict(self, response_json: Dict) -> Dict:
+    @staticmethod
+    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -156,7 +156,7 @@ class ValidationsStore(Store):
 
     @override
     @staticmethod
-    def ge_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -287,8 +287,6 @@ store_backend:
 
 @pytest.mark.cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
-    store = CheckpointStore(store_name="checkpoint_store")
-
     checkpoint_id = "7b5e962c-3c67-4a6d-b311-b48061d52103"
     checkpoint_config = {
         "name": "oss_test_checkpoint",
@@ -320,9 +318,17 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = checkpoint_config
     expected["ge_cloud_id"] = checkpoint_id
 
-    actual = store.ge_cloud_response_json_to_object_dict(response_json)
+    actual = CheckpointStore.ge_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected
+
+
+@pytest.mark.cloud
+def test_ge_cloud_response_json_to_object_dict_no_data_in_payload():
+    response_json = {"data": []}
+
+    with pytest.raises(ValueError):
+        CheckpointStore.ge_cloud_response_json_to_object_dict(response_json)
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -318,7 +318,7 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = checkpoint_config
     expected["ge_cloud_id"] = checkpoint_id
 
-    actual = CheckpointStore.ge_cloud_response_json_to_object_dict(response_json)
+    actual = CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected
 
@@ -328,7 +328,7 @@ def test_ge_cloud_response_json_to_object_dict_no_data_in_payload():
     response_json = {"data": []}
 
     with pytest.raises(ValueError):
-        CheckpointStore.ge_cloud_response_json_to_object_dict(response_json)
+        CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -286,7 +286,7 @@ store_backend:
 
 
 @pytest.mark.cloud
-def test_ge_cloud_response_json_to_object_dict() -> None:
+def test_gx_cloud_response_json_to_object_dict() -> None:
     checkpoint_id = "7b5e962c-3c67-4a6d-b311-b48061d52103"
     checkpoint_config = {
         "name": "oss_test_checkpoint",
@@ -324,7 +324,7 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
 
 
 @pytest.mark.cloud
-def test_ge_cloud_response_json_to_object_dict_no_data_in_payload():
+def test_gx_cloud_response_json_to_object_dict_no_data_in_payload():
     response_json = {"data": []}
 
     with pytest.raises(ValueError):

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -399,14 +399,6 @@ def test_gx_cloud_response_json_to_object_dict(
         assert actual == expected
 
 
-@pytest.mark.cloud
-def test_gx_cloud_response_json_to_object_dict_no_data_in_payload():
-    response_json = {"data": []}
-
-    with pytest.raises(ValueError):
-        CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
-
-
 @pytest.mark.unit
 def test_serialization_self_check(capsys) -> None:
     store = CheckpointStore(store_name="checkpoint_store")

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
@@ -286,41 +288,115 @@ store_backend:
 
 
 @pytest.mark.cloud
-def test_gx_cloud_response_json_to_object_dict() -> None:
-    checkpoint_id = "7b5e962c-3c67-4a6d-b311-b48061d52103"
-    checkpoint_config = {
-        "name": "oss_test_checkpoint",
-        "config_version": 1.0,
-        "class_name": "Checkpoint",
-        "expectation_suite_name": "oss_test_expectation_suite",
-        "validations": [
+@pytest.mark.parametrize(
+    "response_json, expected, error_type",
+    [
+        pytest.param(
             {
-                "expectation_suite_name": "taxi.demo_pass",
+                "data": {
+                    "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                    "attributes": {
+                        "checkpoint_config": {
+                            "name": "oss_test_checkpoint",
+                            "config_version": 1.0,
+                            "class_name": "Checkpoint",
+                            "expectation_suite_name": "oss_test_expectation_suite",
+                            "validations": [
+                                {
+                                    "expectation_suite_name": "taxi.demo_pass",
+                                },
+                                {
+                                    "batch_request": {
+                                        "datasource_name": "oss_test_datasource",
+                                        "data_connector_name": "oss_test_data_connector",
+                                        "data_asset_name": "users",
+                                    },
+                                },
+                            ],
+                        }
+                    },
+                }
             },
             {
-                "batch_request": {
-                    "datasource_name": "oss_test_datasource",
-                    "data_connector_name": "oss_test_data_connector",
-                    "data_asset_name": "users",
-                },
+                "class_name": "Checkpoint",
+                "config_version": 1.0,
+                "expectation_suite_name": "oss_test_expectation_suite",
+                "ge_cloud_id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                "name": "oss_test_checkpoint",
+                "validations": [
+                    {"expectation_suite_name": "taxi.demo_pass"},
+                    {
+                        "batch_request": {
+                            "data_asset_name": "users",
+                            "data_connector_name": "oss_test_data_connector",
+                            "datasource_name": "oss_test_datasource",
+                        },
+                    },
+                ],
             },
-        ],
-    }
-    response_json = {
-        "data": {
-            "id": checkpoint_id,
-            "attributes": {
-                "checkpoint_config": checkpoint_config,
+            None,
+            id="single_config",
+        ),
+        pytest.param({"data": []}, None, ValueError, id="empty_payload"),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                        "attributes": {
+                            "checkpoint_config": {
+                                "name": "oss_test_checkpoint",
+                                "config_version": 1.0,
+                                "class_name": "Checkpoint",
+                                "expectation_suite_name": "oss_test_expectation_suite",
+                                "validations": [
+                                    {
+                                        "expectation_suite_name": "taxi.demo_pass",
+                                    },
+                                    {
+                                        "batch_request": {
+                                            "datasource_name": "oss_test_datasource",
+                                            "data_connector_name": "oss_test_data_connector",
+                                            "data_asset_name": "users",
+                                        },
+                                    },
+                                ],
+                            }
+                        },
+                    }
+                ]
             },
-        }
-    }
-
-    expected = checkpoint_config
-    expected["ge_cloud_id"] = checkpoint_id
-
-    actual = CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
-
-    assert actual == expected
+            {
+                "class_name": "Checkpoint",
+                "config_version": 1.0,
+                "expectation_suite_name": "oss_test_expectation_suite",
+                "ge_cloud_id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                "name": "oss_test_checkpoint",
+                "validations": [
+                    {"expectation_suite_name": "taxi.demo_pass"},
+                    {
+                        "batch_request": {
+                            "data_asset_name": "users",
+                            "data_connector_name": "oss_test_data_connector",
+                            "datasource_name": "oss_test_datasource",
+                        },
+                    },
+                ],
+            },
+            None,
+            id="single_config_in_list",
+        ),
+    ],
+)
+def test_gx_cloud_response_json_to_object_dict(
+    response_json: dict, expected: dict | None, error_type: Exception | None
+) -> None:
+    if error_type:
+        with pytest.raises(error_type):
+            _ = CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
+    else:
+        actual = CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
+        assert actual == expected
 
 
 @pytest.mark.cloud

--- a/tests/data_context/store/test_data_asset_store.py
+++ b/tests/data_context/store/test_data_asset_store.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.cloud
+def test_gx_cloud_response_to_object_dict():
+    pass

--- a/tests/data_context/store/test_data_asset_store.py
+++ b/tests/data_context/store/test_data_asset_store.py
@@ -1,6 +1,99 @@
+from __future__ import annotations
+
 import pytest
+
+from great_expectations.data_context.store.data_asset_store import DataAssetStore
 
 
 @pytest.mark.cloud
-def test_gx_cloud_response_to_object_dict():
-    pass
+@pytest.mark.parametrize(
+    "response_json, expected, error_type",
+    [
+        pytest.param(
+            {
+                "data": {
+                    "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                    "attributes": {
+                        "data_asset_config": {
+                            "name": "my_asset",
+                            "type": "pandas",
+                        },
+                    },
+                }
+            },
+            {
+                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                "name": "my_asset",
+                "type": "pandas",
+            },
+            None,
+            id="single_config",
+        ),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                        "attributes": {
+                            "data_asset_config": {
+                                "name": "my_asset",
+                                "type": "pandas",
+                            },
+                        },
+                    }
+                ]
+            },
+            {
+                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                "name": "my_asset",
+                "type": "pandas",
+            },
+            None,
+            id="single_config_in_list",
+        ),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "data": [
+                            {
+                                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                                "attributes": {
+                                    "data_asset_config": {
+                                        "name": "my_asset",
+                                        "type": "pandas",
+                                    },
+                                },
+                            }
+                        ]
+                    },
+                    {
+                        "data": [
+                            {
+                                "id": "ffg61d4e-003f-48e7-a3b2-f9f842384da3",
+                                "attributes": {
+                                    "data_asset_config": {
+                                        "name": "my_other_asset",
+                                        "type": "pandas",
+                                    },
+                                },
+                            }
+                        ]
+                    },
+                ]
+            },
+            None,
+            TypeError,
+            id="multiple_config_in_list",
+        ),
+    ],
+)
+def test_gx_cloud_response_json_to_object_dict(
+    response_json: dict, expected: dict | None, error_type: Exception | None
+) -> None:
+    if error_type:
+        with pytest.raises(error_type):
+            _ = DataAssetStore.gx_cloud_response_json_to_object_dict(response_json)
+    else:
+        actual = DataAssetStore.gx_cloud_response_json_to_object_dict(response_json)
+        assert actual == expected

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import pathlib
 from typing import Callable, List, Optional, cast
@@ -528,5 +530,99 @@ def test_datasource_store_with_inline_store_backend_config_with_names_does_not_s
 
 
 @pytest.mark.cloud
-def test_gx_cloud_response_to_object_dict():
-    pass
+@pytest.mark.parametrize(
+    "response_json, expected, error_type",
+    [
+        pytest.param(
+            {
+                "data": {
+                    "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                    "attributes": {
+                        "datasource_config": {
+                            "name": "my_pandas",
+                            "type": "pandas",
+                            "assets": [],
+                        },
+                    },
+                }
+            },
+            {
+                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                "name": "my_pandas",
+                "type": "pandas",
+                "assets": [],
+            },
+            None,
+            id="single_config",
+        ),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                        "attributes": {
+                            "datasource_config": {
+                                "name": "my_pandas",
+                                "type": "pandas",
+                                "assets": [],
+                            },
+                        },
+                    }
+                ]
+            },
+            {
+                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                "name": "my_pandas",
+                "type": "pandas",
+                "assets": [],
+            },
+            None,
+            id="single_config_in_list",
+        ),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "data": [
+                            {
+                                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                                "attributes": {
+                                    "datasource_config": {
+                                        "name": "my_pandas",
+                                        "type": "pandas",
+                                        "assets": [],
+                                    },
+                                },
+                            }
+                        ]
+                    },
+                    {
+                        "data": [
+                            {
+                                "id": "ffg61d4e-003f-48e7-a3b2-f9f842384da3",
+                                "attributes": {
+                                    "data_asset_config": {
+                                        "name": "my_other_pandas",
+                                        "type": "pandas",
+                                    },
+                                },
+                            }
+                        ]
+                    },
+                ]
+            },
+            None,
+            TypeError,
+            id="multiple_config_in_list",
+        ),
+    ],
+)
+def test_gx_cloud_response_json_to_object_dict(
+    response_json: dict, expected: dict | None, error_type: Exception | None
+) -> None:
+    if error_type:
+        with pytest.raises(error_type):
+            _ = DatasourceStore.gx_cloud_response_json_to_object_dict(response_json)
+    else:
+        actual = DatasourceStore.gx_cloud_response_json_to_object_dict(response_json)
+        assert actual == expected

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -525,3 +525,8 @@ def test_datasource_store_with_inline_store_backend_config_with_names_does_not_s
             "data_connectors"
         ]["tripdata_monthly_configured"]
     )
+
+
+@pytest.mark.cloud
+def test_gx_cloud_response_to_object_dict():
+    pass

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -257,6 +257,6 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = suite_config
     expected["ge_cloud_id"] = suite_id
 
-    actual = ExpectationsStore.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -241,8 +241,6 @@ store_backend:
 
 @pytest.mark.cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
-    store = ExpectationsStore(store_name="expectations_store")
-
     suite_id = "03d61d4e-003f-48e7-a3b2-f9f842384da3"
     suite_config = {
         "expectation_suite_name": "my_suite",
@@ -259,6 +257,6 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = suite_config
     expected["ge_cloud_id"] = suite_id
 
-    actual = store.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ExpectationsStore.ge_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -240,7 +240,7 @@ store_backend:
 
 
 @pytest.mark.cloud
-def test_ge_cloud_response_json_to_object_dict() -> None:
+def test_gx_cloud_response_json_to_object_dict() -> None:
     suite_id = "03d61d4e-003f-48e7-a3b2-f9f842384da3"
     suite_config = {
         "expectation_suite_name": "my_suite",
@@ -260,3 +260,8 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected
+
+
+@pytest.mark.cloud
+def test_gx_cloud_response_json_to_object_dict_data_list() -> None:
+    pass

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest
@@ -240,26 +242,59 @@ store_backend:
 
 
 @pytest.mark.cloud
-def test_gx_cloud_response_json_to_object_dict() -> None:
-    suite_id = "03d61d4e-003f-48e7-a3b2-f9f842384da3"
-    suite_config = {
-        "expectation_suite_name": "my_suite",
-    }
-    response_json = {
-        "data": {
-            "id": suite_id,
-            "attributes": {
-                "suite": suite_config,
+@pytest.mark.parametrize(
+    "response_json, expected, error_type",
+    [
+        pytest.param(
+            {
+                "data": {
+                    "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                    "attributes": {
+                        "suite": {
+                            "expectation_suite_name": "my_suite",
+                        },
+                    },
+                }
             },
-        }
-    }
-
-    expected = suite_config
-    expected["ge_cloud_id"] = suite_id
-
-    actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
-
-    assert actual == expected
+            {
+                "expectation_suite_name": "my_suite",
+                "ge_cloud_id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+            },
+            None,
+            id="single_config",
+        ),
+        pytest.param({"data": []}, None, ValueError, id="empty_payload"),
+        pytest.param(
+            {
+                "data": [
+                    {
+                        "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+                        "attributes": {
+                            "suite": {
+                                "expectation_suite_name": "my_suite",
+                            },
+                        },
+                    }
+                ]
+            },
+            {
+                "expectation_suite_name": "my_suite",
+                "ge_cloud_id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+            },
+            None,
+            id="single_config_in_list",
+        ),
+    ],
+)
+def test_gx_cloud_response_json_to_object_dict(
+    response_json: dict, expected: dict | None, error_type: Exception | None
+) -> None:
+    if error_type:
+        with pytest.raises(error_type):
+            _ = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
+    else:
+        actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
+        assert actual == expected
 
 
 @pytest.mark.cloud

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -17,6 +17,7 @@ from unittest import mock
 import pytest
 import responses
 
+import great_expectations.exceptions as gx_exceptions
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
     GXCloudRESTResource,
@@ -316,6 +317,32 @@ def test_has_key_with_empty_payload_from_backend(
 
     key = (GXCloudRESTResource.EXPECTATION_SUITE, None, name)
     assert store_backend.has_key(key) is False
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_get_with_empty_payload_from_backend(
+    construct_ge_cloud_store_backend: Callable[
+        [GXCloudRESTResource], GXCloudStoreBackend
+    ],
+):
+    store_backend = construct_ge_cloud_store_backend(
+        GXCloudRESTResource.EXPECTATION_SUITE
+    )
+
+    name = "my_nonexistent_suite"
+    responses.add(
+        responses.GET,
+        f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/expectation-suites?name={name}",
+        json={"data": []},
+        status=200,
+    )
+
+    key = (GXCloudRESTResource.EXPECTATION_SUITE, None, name)
+
+    with pytest.raises(gx_exceptions.StoreBackendError):
+        _ = store_backend.get(key)
+    assert len(responses.calls) == 1
 
 
 def test_get_all(

--- a/tests/data_context/store/test_json_site_store.py
+++ b/tests/data_context/store/test_json_site_store.py
@@ -1,0 +1,27 @@
+import pytest
+
+from great_expectations.data_context.store.json_site_store import JsonSiteStore
+
+
+@pytest.mark.cloud
+def test_gx_cloud_response_json_to_object_dict():
+    response_json = {
+        "data": {
+            "id": "683df05f-efec-48d4-a45a-02e8318043b8",
+            "attributes": {
+                "rendered_data_doc": {
+                    "sections": [],
+                    "data_asset_name": "my_asset",
+                }
+            },
+        }
+    }
+
+    actual = JsonSiteStore.gx_cloud_response_json_to_object_dict(response_json)
+    expected = {
+        "ge_cloud_id": "683df05f-efec-48d4-a45a-02e8318043b8",
+        "sections": [],
+        "data_asset_name": "my_asset",
+    }
+
+    assert actual == expected

--- a/tests/data_context/store/test_profiler_store.py
+++ b/tests/data_context/store/test_profiler_store.py
@@ -105,7 +105,7 @@ def test_profiler_store_integration(
 
 
 @pytest.mark.cloud
-def test_ge_cloud_response_json_to_object_dict(
+def test_gx_cloud_response_json_to_object_dict(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ) -> None:
     profiler_id = "b1445fa5-d034-45d7-a4ae-d6dca19b207b"

--- a/tests/data_context/store/test_profiler_store.py
+++ b/tests/data_context/store/test_profiler_store.py
@@ -108,8 +108,6 @@ def test_profiler_store_integration(
 def test_ge_cloud_response_json_to_object_dict(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ) -> None:
-    store = ProfilerStore(store_name="profiler_store")
-
     profiler_id = "b1445fa5-d034-45d7-a4ae-d6dca19b207b"
 
     profiler_config = profiler_config_with_placeholder_args.to_dict()
@@ -125,7 +123,7 @@ def test_ge_cloud_response_json_to_object_dict(
     expected = profiler_config
     expected["id"] = profiler_id
 
-    actual = store.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ProfilerStore.ge_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected
 

--- a/tests/data_context/store/test_profiler_store.py
+++ b/tests/data_context/store/test_profiler_store.py
@@ -123,7 +123,7 @@ def test_ge_cloud_response_json_to_object_dict(
     expected = profiler_config
     expected["id"] = profiler_id
 
-    actual = ProfilerStore.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ProfilerStore.gx_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected
 

--- a/tests/data_context/store/test_store.py
+++ b/tests/data_context/store/test_store.py
@@ -9,9 +9,8 @@ from great_expectations.exceptions.exceptions import StoreBackendError
 
 @pytest.mark.unit
 def test_ge_cloud_response_json_to_object_dict() -> None:
-    store = Store()
     data = {"foo": "bar", "baz": "qux"}
-    assert store.ge_cloud_response_json_to_object_dict(response_json=data) == data
+    assert Store.ge_cloud_response_json_to_object_dict(response_json=data) == data
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_store.py
+++ b/tests/data_context/store/test_store.py
@@ -10,7 +10,7 @@ from great_expectations.exceptions.exceptions import StoreBackendError
 @pytest.mark.unit
 def test_ge_cloud_response_json_to_object_dict() -> None:
     data = {"foo": "bar", "baz": "qux"}
-    assert Store.ge_cloud_response_json_to_object_dict(response_json=data) == data
+    assert Store.gx_cloud_response_json_to_object_dict(response_json=data) == data
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_store.py
+++ b/tests/data_context/store/test_store.py
@@ -8,7 +8,7 @@ from great_expectations.exceptions.exceptions import StoreBackendError
 
 
 @pytest.mark.unit
-def test_ge_cloud_response_json_to_object_dict() -> None:
+def test_gx_cloud_response_json_to_object_dict() -> None:
     data = {"foo": "bar", "baz": "qux"}
     assert Store.gx_cloud_response_json_to_object_dict(response_json=data) == data
 

--- a/tests/data_context/store/test_validations_store.py
+++ b/tests/data_context/store/test_validations_store.py
@@ -355,7 +355,7 @@ store_backend:
 
 
 @pytest.mark.cloud
-def test_ge_cloud_response_json_to_object_dict() -> None:
+def test_gx_cloud_response_json_to_object_dict() -> None:
     validation_id = "c1e8f964-ba44-4a13-a9b6-7331a358f12d"
     validation_config = {
         "results": [],

--- a/tests/data_context/store/test_validations_store.py
+++ b/tests/data_context/store/test_validations_store.py
@@ -379,6 +379,6 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = validation_config
     expected["ge_cloud_id"] = validation_id
 
-    actual = ValidationsStore.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ValidationsStore.gx_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected

--- a/tests/data_context/store/test_validations_store.py
+++ b/tests/data_context/store/test_validations_store.py
@@ -356,8 +356,6 @@ store_backend:
 
 @pytest.mark.cloud
 def test_ge_cloud_response_json_to_object_dict() -> None:
-    store = ValidationsStore(store_name="validations_store")
-
     validation_id = "c1e8f964-ba44-4a13-a9b6-7331a358f12d"
     validation_config = {
         "results": [],
@@ -381,6 +379,6 @@ def test_ge_cloud_response_json_to_object_dict() -> None:
     expected = validation_config
     expected["ge_cloud_id"] = validation_id
 
-    actual = store.ge_cloud_response_json_to_object_dict(response_json)
+    actual = ValidationsStore.ge_cloud_response_json_to_object_dict(response_json)
 
     assert actual == expected


### PR DESCRIPTION
A few changes:
* Revert legacy behavior - move check into `_get` instead of `has_key`
* Rename method to use `gx_` prefix
* Add unit tests for ALL parsing methods

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
