### PR TITLE
[BUGFIX] Column Descriptive Metrics: Support numpy metrics

### DIFF
--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -90,6 +90,7 @@ class GXDependencies:
             "mypy",
             "nbconvert",
             "openpyxl",
+            "orjson",
             "pika",
             "pre-commit",
             "psycopg2-binary",

--- a/great_expectations/experimental/metric_repository/cloud_data_store.py
+++ b/great_expectations/experimental/metric_repository/cloud_data_store.py
@@ -39,12 +39,19 @@ def orjson_dumps(v, *, default):
     ).decode()
 
 
+def orjson_loads(v, *args, **kwargs):
+    import orjson  # Import here since this is only installed in the cloud environment
+
+    return orjson.loads(v)
+
+
 class Payload(BaseModel):
     data: PayloadData
 
     class Config:
         extra = Extra.forbid
         json_dumps = orjson_dumps
+        json_loads = orjson_loads
 
 
 class CloudDataStore(DataStore[StorableTypes]):

--- a/great_expectations/experimental/metric_repository/cloud_data_store.py
+++ b/great_expectations/experimental/metric_repository/cloud_data_store.py
@@ -28,11 +28,23 @@ class PayloadData(BaseModel):
         extra = Extra.forbid
 
 
+def orjson_dumps(v, *, default):
+    import orjson  # Import here since this is only installed in the cloud environment
+
+    # orjson.dumps returns bytes, to match standard json.dumps we need to decode
+    return orjson.dumps(
+        v,
+        default=default,
+        option=orjson.OPT_SERIALIZE_NUMPY,
+    ).decode()
+
+
 class Payload(BaseModel):
     data: PayloadData
 
     class Config:
         extra = Extra.forbid
+        json_dumps = orjson_dumps
 
 
 class CloudDataStore(DataStore[StorableTypes]):

--- a/reqs/requirements-dev-cloud.txt
+++ b/reqs/requirements-dev-cloud.txt
@@ -1,1 +1,2 @@
+orjson
 pika==1.3.1

--- a/reqs/requirements-dev-cloud.txt
+++ b/reqs/requirements-dev-cloud.txt
@@ -1,2 +1,2 @@
-orjson
+orjson>=3.9.7
 pika==1.3.1


### PR DESCRIPTION
In this PR we use the orjson library to support serde for numpy metrics.
orjson is added to the cloud requirements since it is only used by the cloud data store. Note we are restricting to the current version or greater but happy to change if there is a reason to be more or less restrictive.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
