### PR TITLE
[MAINTENANCE] Remove `ge_cloud_mode` from `Store`

### DIFF
--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -251,7 +251,7 @@ class CheckpointStore(ConfigurationStore):
             ]
             checkpoint_config["ge_cloud_id"] = checkpoint_config.pop("id")
             return self.deserialize(checkpoint_config)
-        elif self.ge_cloud_mode:
+        elif self.cloud_mode:
             # if in cloud mode and checkpoint_ref is not a GXCloudResourceRef, a PUT operation occurred
             # re-fetch and return CheckpointConfig from cloud to account for any defaults/new ids added in cloud
             return self.get_checkpoint(name=checkpoint.name, id=None)

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -161,7 +161,7 @@ class ConfigurationStore(Store):
         assert bool(name) ^ bool(id), "Must provide either name or id."
 
         key: Union[GXCloudIdentifier, ConfigurationIdentifier]
-        if id or self.ge_cloud_mode:
+        if id or self.cloud_mode:
             key = GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.CHECKPOINT,
                 id=id,

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -117,11 +117,6 @@ class Store:
         return isinstance(self._store_backend, GXCloudStoreBackend)
 
     @property
-    def ge_cloud_mode(self) -> bool:
-        # <GX_RENAME> Deprecated 0.15.37
-        return self.cloud_mode
-
-    @property
     def store_backend(self) -> StoreBackend:
         return self._store_backend
 

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -295,8 +295,3 @@ def test_gx_cloud_response_json_to_object_dict(
     else:
         actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
         assert actual == expected
-
-
-@pytest.mark.cloud
-def test_gx_cloud_response_json_to_object_dict_data_list() -> None:
-    pass


### PR DESCRIPTION
Minor cleanup of Store since we have a duplicate `cloud_mode` property

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
