### PR TITLE
[BUGFIX] Column Descriptive Metrics: Add `id` to excluded list

### DIFF
--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -84,6 +84,7 @@ class _FilePathDataAsset(DataAsset):
         "kwargs",  # kwargs need to be unpacked and passed separately
         "batch_metadata",  # noqa: PLW0130
         "connect_options",
+        "id",
     }
 
     # General file-path DataAsset pertaining attributes.


### PR DESCRIPTION
This was causing an `TypeError: read_csv() got an unexpected keyword argument 'id'` when trying to use a pandas datasource with column descriptive metrics.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
