### PR TITLE
[BUGFIX] Column Descriptive Metrics: Single connection

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_excludes.py
+++ b/docs/sphinx_api_docs_source/public_api_excludes.py
@@ -806,4 +806,11 @@ DEFAULT_EXCLUDES: list[IncludeExcludeDefinition] = [
         name="add_dataframe_asset",
         filepath=pathlib.Path("great_expectations/core/datasource_dict.py"),
     ),
+    IncludeExcludeDefinition(
+        reason="This method shares a name with a public API method.",
+        name="get_validator",
+        filepath=pathlib.Path(
+            "great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py"
+        ),
+    ),
 ]

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -455,3 +455,49 @@ def test_get_metrics_with_exception():
             column="col2",
         ),
     ]
+
+
+def test_get_metrics_only_gets_a_validator_once():
+    mock_context = Mock(spec=CloudDataContext)
+    mock_validator = Mock(spec=Validator)
+    mock_context.get_validator.return_value = mock_validator
+
+    aborted_metrics = {}
+
+    computed_metrics = {
+        ("table.row_count", (), ()): 2,
+        ("table.columns", (), ()): ["col1", "col2"],
+        ("table.column_types", (), "include_nested=True"): [
+            {"name": "col1", "type": "float"},
+            {"name": "col2", "type": "float"},
+        ],
+        ("column.min", "column=col1", ()): 2.5,
+        ("column.min", "column=col2", ()): 2.7,
+        ("column.max", "column=col1", ()): 5.5,
+        ("column.max", "column=col2", ()): 5.7,
+        ("column.mean", "column=col1", ()): 2.5,
+        ("column.mean", "column=col2", ()): 2.7,
+        ("column.median", "column=col1", ()): 2.5,
+        ("column.median", "column=col2", ()): 2.7,
+        ("column_values.null.count", "column=col1", ()): 1,
+        ("column_values.null.count", "column=col2", ()): 1,
+    }
+    mock_validator.compute_metrics_with_aborted_metrics.return_value = (
+        computed_metrics,
+        aborted_metrics,
+    )
+    mock_batch = Mock(spec=Batch)
+    mock_batch.id = "batch_id"
+    mock_validator.active_batch = mock_batch
+
+    metric_retriever = ColumnDescriptiveMetricsMetricRetriever(context=mock_context)
+
+    mock_batch_request = Mock(spec=BatchRequest)
+
+    with mock.patch(
+        f"{ColumnDomainBuilder.__module__}.{ColumnDomainBuilder.__name__}.get_effective_column_names",
+        return_value=["col1", "col2"],
+    ):
+        metric_retriever.get_metrics(batch_request=mock_batch_request)
+
+    mock_context.get_validator.assert_called_once_with(batch_request=mock_batch_request)


### PR DESCRIPTION
Only call context.get_validator() once to avoid attempting to reconnect to your database.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
