### PR TITLE
[CONTRIB] Adding tests for S3 Validation and Expectation Store prefix

### DIFF
--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_confirm_that_the_new_validation_results_store_has_been_added_by_running_great_expectations_store_list.mdx
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_confirm_that_the_new_validation_results_store_has_been_added_by_running_great_expectations_store_list.mdx
@@ -7,7 +7,7 @@ class_name: ValidationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     endpoint_url: ${S3_ENDPOINT} # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.
     region_name: '<your_aws_region_name>'
@@ -20,7 +20,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     aws_access_key_id: ${AWS_ACCESS_KEY_ID} # Uses the AWS_ACCESS_KEY_ID environment variable to get aws_access_key_id.
     aws_secret_access_key: ${AWS_ACCESS_KEY_ID}
@@ -34,7 +34,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>' # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     assume_role_arn: '<your_role_to_assume>'
     region_name: '<your_aws_region_name>'

--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_store_reference.mdx
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_store_reference.mdx
@@ -18,7 +18,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     aws_access_key_id: ${AWS_ACCESS_KEY_ID} # Uses the AWS_ACCESS_KEY_ID environment variable to get aws_access_key_id.
     aws_secret_access_key: ${AWS_ACCESS_KEY_ID}
@@ -32,7 +32,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     assume_role_arn: '<your_role_to_assume>'
     region_name: '<your_aws_region_name>'

--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_validation_results_on_s.mdx
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_validation_results_on_s.mdx
@@ -14,7 +14,7 @@ class_name: ValidationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     endpoint_url: ${S3_ENDPOINT} # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.
     region_name: '<your_aws_region_name>'
@@ -32,7 +32,7 @@ class_name: ValidationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>' # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     aws_access_key_id: ${AWS_ACCESS_KEY_ID} # Uses the AWS_ACCESS_KEY_ID environment variable to get aws_access_key_id.
     aws_secret_access_key: ${AWS_ACCESS_KEY_ID}
@@ -46,7 +46,7 @@ class_name: ValidationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>' # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     assume_role_arn: '<your_role_to_assume>'
     region_name: '<your_aws_region_name>'

--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_confirm_that_the_new_expectations_store_has_been_added_by_running_great_expectations_store_list.mdx
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_confirm_that_the_new_expectations_store_has_been_added_by_running_great_expectations_store_list.mdx
@@ -12,7 +12,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 ```
 
 Only one Expectation Store is listed. Your configuration contains the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` you configured, but the `great_expectations store list` command only lists your active stores.  For your Expectation Store, this is the one that you set as the value of the ``expectations_store_name`` variable in the ``expectations_S3_store`` configuration file.

--- a/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_expectations_on_s.mdx
+++ b/docs/docusaurus/docs/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_expectations_on_s.mdx
@@ -13,7 +13,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     endpoint_url: ${S3_ENDPOINT} # Uses the S3_ENDPOINT environment variable to determine which endpoint to use.
     region_name: '<your_aws_region_name>'
@@ -33,7 +33,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  
   boto3_options:
     aws_access_key_id: ${AWS_ACCESS_KEY_ID} # Uses the AWS_ACCESS_KEY_ID environment variable to get aws_access_key_id.
     aws_secret_access_key: ${AWS_ACCESS_KEY_ID}
@@ -47,7 +47,7 @@ class_name: ExpectationsStore
 store_backend:
   class_name: TupleS3StoreBackend
   bucket: '<your_s3_bucket_name>'
-  prefix: '<your_s3_bucket_folder_name>'
+  prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
   boto3_options:
     assume_role_arn: '<your_role_to_assume>'
     region_name: '<your_aws_region_name>'

--- a/docs_rtd/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
+++ b/docs_rtd/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
@@ -60,7 +60,7 @@ Steps
                         store_backend:
                             class_name: TupleS3StoreBackend
                             bucket: '<your_s3_bucket_name>'
-                            prefix: '<your_s3_bucket_folder_name>'
+                            prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 
         4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
@@ -95,7 +95,7 @@ Steps
                 store_backend:
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
-                    prefix: '<your_s3_bucket_folder_name>'
+                    prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
     .. tab-container:: tab1
         :title: Show Docs for V3 (Batch Request) API
@@ -140,7 +140,7 @@ Steps
                         store_backend:
                             class_name: TupleS3StoreBackend
                             bucket: '<your_s3_bucket_name>'
-                            prefix: '<your_s3_bucket_folder_name>'
+                            prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 
         4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
@@ -175,7 +175,7 @@ Steps
                 store_backend:
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
-                    prefix: '<your_s3_bucket_folder_name>'
+                    prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 6. **Confirm that the Validations store has been correctly configured.**
 

--- a/docs_rtd/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
+++ b/docs_rtd/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
@@ -59,7 +59,7 @@ Steps
                         store_backend:
                             class_name: TupleS3StoreBackend
                             bucket: '<your_s3_bucket_name>'
-                            prefix: '<your_s3_bucket_folder_name>'
+                            prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 
         4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
@@ -93,7 +93,7 @@ Steps
                 store_backend:
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
-                    prefix: '<your_s3_bucket_folder_name>'
+                    prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 
         6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations suite list``.
@@ -150,7 +150,7 @@ Steps
                         store_backend:
                             class_name: TupleS3StoreBackend
                             bucket: '<your_s3_bucket_name>'
-                            prefix: '<your_s3_bucket_folder_name>'
+                            prefix: '<your_s3_bucket_folder_name>'  # Bucket and prefix in combination must be unique across all stores
 
 
         4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
@@ -184,7 +184,7 @@ Steps
                 store_backend:
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
-                    prefix: '<your_s3_bucket_folder_name>'
+                    prefix: '<your_s3_bucket_folder_name>'  
 
 
         6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations --v3-api suite list``.

--- a/docs_rtd/reference/spare_parts/data_context_reference.rst
+++ b/docs_rtd/reference/spare_parts/data_context_reference.rst
@@ -175,7 +175,7 @@ providing the bucket/prefix combination:
           class_name: TupleS3StoreBackend
           base_directory: expectations/
           bucket: gx.my_org.com
-          prefix:
+          prefix: common_expectations
       validations_store:
         class_name: ValidationsStore
         store_backend:

--- a/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_pandas.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_pandas.py
@@ -64,8 +64,8 @@ stores:
     class_name: ExpectationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 EXPECTATION BUCKET NAME>'
+      prefix: '<YOUR S3 EXPECTATION PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 
 expectations_store_name: expectations_S3_store
 # </snippet>
@@ -144,8 +144,8 @@ stores:
     class_name: ValidationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 VALIDATION BUCKET NAME>'
+      prefix: '<YOUR S3 VALIDATION PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
 # <snippet name="tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_pandas.py set_new_validations_store">
@@ -192,7 +192,7 @@ data_docs_sites:
     class_name: SiteBuilder
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
+      bucket: '<YOUR S3 BUCKET NAME>'
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 # </snippet>

--- a/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py
@@ -71,8 +71,8 @@ stores:
     class_name: ExpectationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 BUCKET NAME>'
+      prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 
 expectations_store_name: expectations_S3_store
 # </snippet>
@@ -151,8 +151,8 @@ stores:
     class_name: ValidationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 BUCKET NAME>'
+      prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
 # <snippet name="tests/integration/docusaurus/deployment_patterns/aws_cloud_storage_spark.py set_new_validations_store">

--- a/tests/integration/docusaurus/deployment_patterns/aws_redshift_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_redshift_deployment_patterns.py
@@ -66,8 +66,8 @@ stores:
     class_name: ExpectationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 BUCKET NAME>'
+      prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 
 expectations_store_name: expectations_S3_store
 # </snippet>
@@ -146,8 +146,8 @@ stores:
     class_name: ValidationsStore
     store_backend:
       class_name: TupleS3StoreBackend
-      bucket: <YOUR S3 BUCKET NAME>
-      prefix: <YOUR S3 PREFIX NAME>
+      bucket: '<YOUR S3 BUCKET NAME>'
+      prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
 # <snippet name="tests/integration/docusaurus/deployment_patterns/aws_redshift_deployment_patterns.py set_new_validations_store">


### PR DESCRIPTION
S3 Tuple Store Backend takes prefix for Validation and Expectation Suite. These must not use the same bucket/prefix combo. Adding tests to demonstrate the behavior.



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
