### PR TITLE
[MAINTENANCE] Fix CI - DictDot typing issue

### DIFF
--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Callable, List, TypeVar
+from typing import TYPE_CHECKING, Callable, List, TypeVar
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 from ruamel.yaml import YAML, yaml_object
 
@@ -24,8 +27,8 @@ class DotDict(dict):
     def __getattr__(self, item):
         return self.get(item)
 
-    __setattr__: Callable[[dict[_KT, _VT], _KT, _VT], None] = dict.__setitem__
-    __delattr__: Callable[[dict[_KT, _VT], _KT], None] = dict.__delitem__
+    __setattr__: Callable[[Self, _KT, _VT], None] = dict.__setitem__
+    __delattr__: Callable[[Self, _KT], None] = dict.__delitem__
 
     def __dir__(self):
         return self.keys()

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import copy
 import logging
-from typing import List
+from typing import Callable, List, TypeVar
 
 from ruamel.yaml import YAML, yaml_object
 
 logger = logging.getLogger(__name__)
 yaml = YAML()
+
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
 @yaml_object(yaml)
@@ -19,8 +24,8 @@ class DotDict(dict):
     def __getattr__(self, item):
         return self.get(item)
 
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+    __setattr__: Callable[[dict[_KT, _VT], _KT, _VT], None] = dict.__setitem__
+    __delattr__: Callable[[dict[_KT, _VT], _KT], None] = dict.__delitem__
 
     def __dir__(self):
         return self.keys()

--- a/requirements-types.txt
+++ b/requirements-types.txt
@@ -11,6 +11,7 @@ types-python-dateutil
 types-pytz
 types-requests
 types-six
+types-tabulate
 types-typed-ast
 types-tzlocal
 types-urllib3


### PR DESCRIPTION
Newer type-stubs seem to have better type information for the built-in `dict` which causes our CI to throw type warnings for `DotDict` which inherits from `dict`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
