### PR TITLE
[DOCS] Update Section Link in GX Cloud TOC

### DIFF
--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -13,7 +13,7 @@ module.exports = {
             {
               type: 'link',
               label: 'Request a GX Cloud Beta account',
-              href: '/docs/cloud/set_up_gx_cloud#srequest-a-gx-cloud-beta-account',
+              href: '/docs/cloud/set_up_gx_cloud#request-a-gx-cloud-beta-account',
             },
             {
               type: 'link',


### PR DESCRIPTION
The existing link to the _Request a GX Cloud Beta account_ section isn't working as expected due to a typo in the link reference. This PR corrects this issue.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated