### PR TITLE
[MAINTENANCE] Expectations typings

### DIFF
--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     render_evaluation_parameter_string,
 )
@@ -46,6 +44,11 @@ from great_expectations.expectations.expectation import ColumnAggregateExpectati
 from great_expectations.render.renderer.renderer import renderer
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -207,6 +210,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
     }
     args_keys = ("column", "min_value", "max_value", "strict_min", "strict_max")
 
+    @override
     @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
@@ -227,6 +231,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -279,11 +284,12 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -337,14 +343,12 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -369,6 +373,7 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
             f"{result.result['observed_value']:.2f}",
         ]
 
+    @override
     def _validate(
         self,
         configuration: ExpectationConfiguration,

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     ColumnAggregateExpectation,
     render_evaluation_parameter_string,
@@ -39,6 +37,11 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -250,6 +253,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         "required": ["column"],
     }
 
+    @override
     @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
@@ -270,6 +274,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -315,11 +320,12 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -368,14 +374,12 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -400,6 +404,7 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
             f"{result.result['observed_value']:.2f}",
         ]
 
+    @override
     def _validate(
         self,
         configuration: ExpectationConfiguration,

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -1,10 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
-from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.expectation import (
     ColumnAggregateExpectation,
     render_evaluation_parameter_string,
@@ -34,6 +32,11 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -193,6 +196,7 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
         "strict_max",
     )
 
+    @override
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
@@ -210,6 +214,7 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -255,11 +260,12 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -306,17 +312,16 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
+    @override
     def _validate(
         self,
         configuration: ExpectationConfiguration,

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -1,10 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
-from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.expectation import (
     ColumnAggregateExpectation,
     render_evaluation_parameter_string,
@@ -38,6 +36,11 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -205,6 +208,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         "strict_max",
     )
 
+    @override
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
@@ -222,6 +226,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -274,11 +279,12 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -332,14 +338,12 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -364,6 +368,7 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
             f"{result.result['observed_value']:.2f}",
         ]
 
+    @override
     def _validate(
         self,
         configuration: ExpectationConfiguration,

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
@@ -28,6 +27,10 @@ except ImportError:
     pass
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -94,6 +97,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
+    @override
     @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
@@ -135,6 +139,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
             raise InvalidExpectationConfigurationError(str(e))
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -166,11 +171,12 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -209,13 +215,11 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, Optional
 
-from great_expectations.core import (
-    ExpectationConfiguration,
-    ExpectationValidationResult,
-)
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     BatchExpectation,
     render_evaluation_parameter_string,
@@ -22,6 +20,11 @@ from great_expectations.render.util import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 
@@ -95,6 +98,7 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
         "max_value",
     )
 
+    @override
     @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
@@ -116,6 +120,7 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod
+    @override
     def _prescriptive_template(
         cls,
         renderer_configuration: RendererConfiguration,
@@ -134,14 +139,14 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
         if not params.min_value and not params.max_value:
             template_str = "May have any number of columns."
         else:
-            at_least_str = "greater than or equal to"
+            at_least_str: str = "greater than or equal to"
             if params.strict_min:
-                at_least_str: str = cls._get_strict_min_string(
+                at_least_str = cls._get_strict_min_string(
                     renderer_configuration=renderer_configuration
                 )
-            at_most_str = "less than or equal to"
+            at_most_str: str = "less than or equal to"
             if params.strict_max:
-                at_most_str: str = cls._get_strict_max_string(
+                at_most_str = cls._get_strict_max_string(
                     renderer_configuration=renderer_configuration
                 )
 
@@ -157,11 +162,12 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
         return renderer_configuration
 
     @classmethod
+    @override
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,
@@ -186,17 +192,16 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
+    @override
     def _validate(
         self,
         configuration: ExpectationConfiguration,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ exclude = [
     'expectations/core/expect_table_columns_to_match_set\.py',                                             # 8
     'expectations/core/expect_table_columns_to_match_ordered_list\.py',                                    # 11
     'expectations/core/expect_table_column_count_to_equal\.py',                                            # 5
-    'expectations/core/expect_table_column_count_to_be_between\.py',                                       # 3
     'expectations/core/expect_table_row_count_to_equal_other_table\.py',                                   # 11
     'expectations/regex_based_column_map_expectation\.py',                                                 # 3
     'expectations/row_conditions\.py',                                                                     # 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ exclude = [
     'core/usage_statistics/anonymizers/datasource_anonymizer\.py',                                         # 9
     'core/usage_statistics/anonymizers/expectation_anonymizer\.py',                                        # 6
     'core/usage_statistics/anonymizers/validation_operator_anonymizer\.py',                                # 5
-    # 'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
+    'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
     'expectations/core/expect_column_values_to_not_match_regex_list\.py',                                  # 2
     'expectations/core/expect_column_values_to_not_match_regex\.py',                                       # 2
     'expectations/core/expect_column_values_to_not_match_like_pattern_list\.py',                           # 3
@@ -95,13 +95,11 @@ exclude = [
     'expectations/core/expect_column_values_to_match_regex\.py',                                           # 1
     'expectations/core/expect_column_values_to_match_like_pattern_list\.py',                               # 3
     'expectations/core/expect_column_values_to_match_like_pattern\.py',                                    # 2
-    # 'expectations/core/expect_column_values_to_match_json_schema\.py',                                     # 1
-    # 'expectations/core/expect_column_values_to_be_unique\.py',                                             # 1
-    # 'expectations/core/expect_column_values_to_be_null\.py',                                               # 3
+    'expectations/core/expect_column_values_to_match_json_schema\.py',                                     # 1
+    'expectations/core/expect_column_values_to_be_null\.py',                                               # 3
     'expectations/core/expect_column_values_to_be_json_parseable\.py',                                     # 1
     'expectations/core/expect_column_values_to_be_increasing\.py',                                         # 1
-    # 'expectations/core/expect_column_values_to_be_in_type_list\.py',                                       # 11
-    # 'expectations/core/expect_column_values_to_be_in_set\.py',                                             # 1
+    'expectations/core/expect_column_values_to_be_in_type_list\.py',                                       # 11
     'expectations/core/expect_column_values_to_be_decreasing\.py',                                         # 1
     'expectations/core/expect_column_values_to_be_dateutil_parseable\.py',                                 # 1
     'expectations/core/expect_column_values_to_be_between\.py',                                            # 3
@@ -116,10 +114,6 @@ exclude = [
     'expectations/core/expect_column_values_a_to_be_greater_than_b\.py',                                   # 3
     'expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than\.py',                          # 7
     'expectations/core/expect_column_most_common_value_to_be_in_set\.py',                                  # 3
-    # 'expectations/core/expect_column_min_to_be_between\.py',                                               # 1
-    # 'expectations/core/expect_column_median_to_be_between\.py',                                            # 1
-    # 'expectations/core/expect_column_mean_to_be_between\.py',                                              # 1
-    # 'expectations/core/expect_column_max_to_be_between\.py',                                               # 1
     'expectations/core/expect_column_kl_divergence_to_be_less_than\.py',                                   # 22
     'expectations/core/expect_column_pair_values_to_be_in_set\.py',                                        # 2
     'expectations/core/expect_column_pair_values_to_be_equal\.py',                                         # 3
@@ -132,7 +126,7 @@ exclude = [
     'expectations/core/expect_multicolumn_values_to_be_unique\.py',                                        # 3
     'expectations/core/expect_select_column_values_to_be_unique_within_record\.py',                        # 3
     'expectations/core/expect_table_columns_to_match_set\.py',                                             # 8
-    # 'expectations/core/expect_table_columns_to_match_ordered_list\.py',                                    # 11
+    'expectations/core/expect_table_columns_to_match_ordered_list\.py',                                    # 11
     'expectations/core/expect_table_column_count_to_equal\.py',                                            # 5
     'expectations/core/expect_table_column_count_to_be_between\.py',                                       # 3
     'expectations/core/expect_table_row_count_to_equal_other_table\.py',                                   # 11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ exclude = [
     'core/usage_statistics/anonymizers/datasource_anonymizer\.py',                                         # 9
     'core/usage_statistics/anonymizers/expectation_anonymizer\.py',                                        # 6
     'core/usage_statistics/anonymizers/validation_operator_anonymizer\.py',                                # 5
-    'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
+    # 'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
     'expectations/core/expect_column_values_to_not_match_regex_list\.py',                                  # 2
     'expectations/core/expect_column_values_to_not_match_regex\.py',                                       # 2
     'expectations/core/expect_column_values_to_not_match_like_pattern_list\.py',                           # 3
@@ -95,13 +95,13 @@ exclude = [
     'expectations/core/expect_column_values_to_match_regex\.py',                                           # 1
     'expectations/core/expect_column_values_to_match_like_pattern_list\.py',                               # 3
     'expectations/core/expect_column_values_to_match_like_pattern\.py',                                    # 2
-    'expectations/core/expect_column_values_to_match_json_schema\.py',                                     # 1
-    'expectations/core/expect_column_values_to_be_unique\.py',                                             # 1
-    'expectations/core/expect_column_values_to_be_null\.py',                                               # 3
+    # 'expectations/core/expect_column_values_to_match_json_schema\.py',                                     # 1
+    # 'expectations/core/expect_column_values_to_be_unique\.py',                                             # 1
+    # 'expectations/core/expect_column_values_to_be_null\.py',                                               # 3
     'expectations/core/expect_column_values_to_be_json_parseable\.py',                                     # 1
     'expectations/core/expect_column_values_to_be_increasing\.py',                                         # 1
-    'expectations/core/expect_column_values_to_be_in_type_list\.py',                                       # 11
-    'expectations/core/expect_column_values_to_be_in_set\.py',                                             # 1
+    # 'expectations/core/expect_column_values_to_be_in_type_list\.py',                                       # 11
+    # 'expectations/core/expect_column_values_to_be_in_set\.py',                                             # 1
     'expectations/core/expect_column_values_to_be_decreasing\.py',                                         # 1
     'expectations/core/expect_column_values_to_be_dateutil_parseable\.py',                                 # 1
     'expectations/core/expect_column_values_to_be_between\.py',                                            # 3
@@ -116,10 +116,10 @@ exclude = [
     'expectations/core/expect_column_values_a_to_be_greater_than_b\.py',                                   # 3
     'expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than\.py',                          # 7
     'expectations/core/expect_column_most_common_value_to_be_in_set\.py',                                  # 3
-    'expectations/core/expect_column_min_to_be_between\.py',                                               # 1
-    'expectations/core/expect_column_median_to_be_between\.py',                                            # 1
-    'expectations/core/expect_column_mean_to_be_between\.py',                                              # 1
-    'expectations/core/expect_column_max_to_be_between\.py',                                               # 1
+    # 'expectations/core/expect_column_min_to_be_between\.py',                                               # 1
+    # 'expectations/core/expect_column_median_to_be_between\.py',                                            # 1
+    # 'expectations/core/expect_column_mean_to_be_between\.py',                                              # 1
+    # 'expectations/core/expect_column_max_to_be_between\.py',                                               # 1
     'expectations/core/expect_column_kl_divergence_to_be_less_than\.py',                                   # 22
     'expectations/core/expect_column_pair_values_to_be_in_set\.py',                                        # 2
     'expectations/core/expect_column_pair_values_to_be_equal\.py',                                         # 3
@@ -132,7 +132,7 @@ exclude = [
     'expectations/core/expect_multicolumn_values_to_be_unique\.py',                                        # 3
     'expectations/core/expect_select_column_values_to_be_unique_within_record\.py',                        # 3
     'expectations/core/expect_table_columns_to_match_set\.py',                                             # 8
-    'expectations/core/expect_table_columns_to_match_ordered_list\.py',                                    # 11
+    # 'expectations/core/expect_table_columns_to_match_ordered_list\.py',                                    # 11
     'expectations/core/expect_table_column_count_to_equal\.py',                                            # 5
     'expectations/core/expect_table_column_count_to_be_between\.py',                                       # 3
     'expectations/core/expect_table_row_count_to_equal_other_table\.py',                                   # 11


### PR DESCRIPTION
Remove type checking exclude for the following expectation modules

0c6d0cb71 `expect_columns_values_to_be_unique.py`
01edbfe1d `expect_column_min_to_be_between.py`
fd23bbbd8 `expect_column_median_to_be_between.py`
e79c8feb1 `expect_column_mean_to_be_between.py`
feaa7852b `expect_column_max_to_be_between.py`
651ed6985 `expect_table_column_count_to_be_between.py`
