### PR TITLE
[DOCS] Consistent pip install instructions

### DIFF
--- a/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
+++ b/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
@@ -22,7 +22,7 @@ In this quickstart, you'll learn how to connect GX Cloud to Snowflake Data Asset
 3. Run the following command in an empty base directory inside a Python virtual environment to install GX Cloud and its dependencies:
 
     ```bash title="Terminal input"
-    pip install 'great_expectations_cloud[snowflake]'
+    pip install 'great_expectations[cloud,snowflake]'
     ```
 
     It can take several minutes for the installation to complete.

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -28,7 +28,7 @@ To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account,
 3. Run the following command in an empty base directory inside a Python virtual environment to install GX Cloud and its dependencies:
 
     ```bash title="Terminal input"
-    pip install 'great_expectations_cloud[snowflake]'
+    pip install 'great_expectations[cloud,snowflake]'
     ```
 
     It can take several minutes for the installation to complete.
@@ -36,7 +36,7 @@ To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account,
     If you've previously installed GX Cloud, run the following command to upgrade to the latest version:
 
     ```bash title="Terminal input"
-    pip install 'great_expectations_cloud[snowflake]' --upgrade
+    pip install 'great_expectations[cloud,snowflake]' --upgrade
     ```
 
 ## Get your user access token and organization ID
@@ -100,5 +100,5 @@ Confirm the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment v
 Run the following command:
 
 ```bash title="Terminal input"
-    pip install 'great_expectations_cloud[snowflake]'
+    pip install 'great_expectations[cloud,snowflake]'
 ```

--- a/reqs/requirements-dev-cloud.txt
+++ b/reqs/requirements-dev-cloud.txt
@@ -1,2 +1,2 @@
-great_expectations_cloud>=0.0.3.dev3
+great_expectations_cloud>=0.0.3.dev5
 orjson>=3.9.7


### PR DESCRIPTION
Fixing inconsistently applied install instructions

- Followup to https://github.com/great-expectations/great_expectations/pull/8776

We plan to start using `gx-cloud` as our cloud package, but until then let's be consistent with our other extra installs.

* Also bumps the min version of `great_expectations_cloud`