### PR TITLE
[BUGFIX] Fix Snowflake `'connection_string'` `TestConnectionError`

### DIFF
--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -130,7 +130,9 @@ class SnowflakeDatasource(SQLDatasource):
                 )
 
                 kwargs = model_dict.pop("kwargs", {})
-                connection_string = model_dict.pop("connection_string")
+                connection_string: str | None = model_dict.pop(
+                    "connection_string", None
+                )
 
                 if connection_string:
                     self._engine = sa.create_engine(connection_string, **kwargs)

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -12,7 +12,7 @@ from great_expectations.datasource.fluent.snowflake_datasource import (
 )
 
 
-@pytest.mark.unit
+@pytest.mark.snowflake  # TODO: make this a unit test
 @pytest.mark.parametrize(
     "config_kwargs",
     [

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -12,6 +12,7 @@ from great_expectations.datasource.fluent.snowflake_datasource import (
 )
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "config_kwargs",
     [

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import sqlalchemy as sa
 
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.snowflake import snowflake
@@ -9,6 +10,21 @@ from great_expectations.datasource.fluent.snowflake_datasource import (
     SnowflakeDatasource,
     SnowflakeDsn,
 )
+
+
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        {"connection_string": "snowflake://my_user:password@my_account"},
+        {"user": "my_user", "password": "password", "account": "my_account"},
+    ],
+)
+def test_valid_config(config_kwargs: dict):
+    my_sf_ds_1 = SnowflakeDatasource(name="my_sf_ds_1", **config_kwargs)
+    assert my_sf_ds_1
+
+    sql_engine = my_sf_ds_1.get_engine()
+    assert isinstance(sql_engine, sa.engine.Engine)
 
 
 @pytest.mark.unit
@@ -127,3 +143,7 @@ def test_get_execution_engine_succeeds():
     )
     # testing that this doesn't raise an exception
     datasource.get_execution_engine()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
Fix an issue that prevents using a Snowflake datasource if it was created without using a `connection_string`.

Adds tests to prevent regression.