### PR TITLE
[BUGFIX] Column Descriptive Metrics: Convert table name to lowercase for snowflake

### DIFF
--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -394,10 +394,12 @@ def get_sqlalchemy_column_metadata(
                     # We must explicitly create a subquery
                     columns = table_selectable.columns().subquery().columns
             else:
+                # TODO: remove cast to a string once [this](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157) issue is resovled
+                table_name = str(table_selectable)
+                if execution_engine.dialect_name == GXSqlDialect.SNOWFLAKE:
+                    table_name = table_name.lower()
                 columns = inspector.get_columns(
-                    str(
-                        table_selectable
-                    ),  # TODO: remove cast to a string once [this](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157) issue is resovled
+                    table_name=table_name,
                     schema=schema_name,
                 )
         except (


### PR DESCRIPTION
Convert the table name to lowercase to sidestep a longstanding bug in the snowflake-sqlalchemy library: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
