### PR TITLE
[MAINTENANCE] Column Descriptive Metrics: Empty string instead of UNKNOWN if table column type introspection fails

### DIFF
--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -143,11 +143,11 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
             aborted_metrics=aborted_metrics,
         )
         raw_column_types: list[dict[str, Any]] = value
-        # If type is not found, default to UNKNOWN
+        # If type is not found, default to empty string. This can happen if our db introspection fails.
         column_types_converted_to_str: list[dict[str, str]] = [
             {
                 "name": raw_column_type["name"],
-                "type": str(raw_column_type.get("type", "UNKNOWN")),
+                "type": str(raw_column_type.get("type", "")),
             }
             for raw_column_type in raw_column_types
         ]
@@ -161,7 +161,7 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
     def _get_columns_to_exclude(self, table_column_types: Metric) -> List[str]:
         columns_to_skip: List[str] = []
         for column_type in table_column_types.value:
-            if column_type["type"] == "UNKNOWN":
+            if column_type["type"] == "":
                 columns_to_skip.append(column_type["name"])
         return columns_to_skip
 

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -538,7 +538,7 @@ def test_get_metrics_with_column_type_missing():
             metric_name="table.column_types",
             value=[
                 {"name": "col1", "type": "float"},
-                {"name": "col2", "type": "UNKNOWN"},
+                {"name": "col2", "type": ""},
             ],
             exception=None,
         ),


### PR DESCRIPTION
Empty string instead of UNKNOWN if table column type introspection fails.

Example:

![image](https://github.com/great-expectations/great_expectations/assets/9903066/5a485eee-40ee-4857-a475-aaf8ac6e8d40)



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
