### PR TITLE
[BUGFIX] Fix missing `config_provider`

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -820,7 +820,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         updated_datasource = self.datasources.set_datasource(
             name=datasource_name, ds=updated_datasource
         )
-        updated_datasource._data_context = self
+        updated_datasource._data_context = self  # TODO: move from here?
         self._save_project_config()
 
         assert isinstance(updated_datasource, FluentDatasource)

--- a/great_expectations/datasource/fluent/fluent_base_model.py
+++ b/great_expectations/datasource/fluent/fluent_base_model.py
@@ -267,8 +267,11 @@ class FluentBaseModel(pydantic.BaseModel):
             )
             _recursively_set_config_value(result, config_provider)
         elif raise_on_missing_config_provider:
+            class_name = self.__class__.__name__
             raise ValueError(
-                f"{self.__class__.__name__}.dict() - config_provider must be provided if raise_on_missing_config_provider is True"
+                f"{class_name}.dict() -"
+                " `config_provider` must be provided if `raise_on_missing_config_provider` is True."
+                f" {class_name} may be missing a context."
             )
 
         return result

--- a/great_expectations/datasource/fluent/fluent_base_model.py
+++ b/great_expectations/datasource/fluent/fluent_base_model.py
@@ -261,17 +261,20 @@ class FluentBaseModel(pydantic.BaseModel):
             exclude_none=exclude_none,
             skip_defaults=skip_defaults,
         )
+
+        class_name = self.__class__.__name__
         if config_provider:
-            logger.info(
-                f"{self.__class__.__name__}.dict() - substituting config values"
-            )
+            logger.info(f"{class_name}.dict() - substituting config values")
             _recursively_set_config_value(result, config_provider)
         elif raise_on_missing_config_provider:
-            class_name = self.__class__.__name__
             raise ValueError(
                 f"{class_name}.dict() -"
                 " `config_provider` must be provided if `raise_on_missing_config_provider` is True."
                 f" {class_name} may be missing a context."
+            )
+        else:
+            logger.info(
+                f"{class_name}.dict() - missing `config_provider`, skipping config substitution"
             )
 
         return result

--- a/great_expectations/datasource/fluent/fluent_base_model.py
+++ b/great_expectations/datasource/fluent/fluent_base_model.py
@@ -240,6 +240,7 @@ class FluentBaseModel(pydantic.BaseModel):
         skip_defaults: bool | None = None,
         # custom
         config_provider: _ConfigurationProvider | None = None,
+        raise_on_missing_config_provider: bool = False,
     ) -> dict[str, Any]:
         """
         Generate a dictionary representation of the model, optionally specifying which
@@ -265,6 +266,11 @@ class FluentBaseModel(pydantic.BaseModel):
                 f"{self.__class__.__name__}.dict() - substituting config values"
             )
             _recursively_set_config_value(result, config_provider)
+        elif raise_on_missing_config_provider:
+            raise ValueError(
+                f"{self.__class__.__name__}.dict() - config_provider must be provided if raise_on_missing_config_provider is True"
+            )
+
         return result
 
     @staticmethod

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -8,7 +8,10 @@ from great_expectations.compatibility.snowflake import URL
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.datasource.fluent.config_str import ConfigStr
+from great_expectations.datasource.fluent.config_str import (
+    ConfigStr,
+    _check_config_substitutions_needed,
+)
 from great_expectations.datasource.fluent.sql_datasource import (
     SQLDatasource,
     SQLDatasourceError,
@@ -127,8 +130,8 @@ class SnowflakeDatasource(SQLDatasource):
                 model_dict = self.dict(
                     exclude=self._get_exec_engine_excludes(),
                     config_provider=self._config_provider,
-                    raise_on_missing_config_provider=True,
                 )
+                _check_config_substitutions_needed(self, model_dict, True)
 
                 kwargs = model_dict.pop("kwargs", {})
                 connection_string = model_dict.pop("connection_string")

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -131,7 +131,9 @@ class SnowflakeDatasource(SQLDatasource):
                     exclude=self._get_exec_engine_excludes(),
                     config_provider=self._config_provider,
                 )
-                _check_config_substitutions_needed(self, model_dict, True)
+                _check_config_substitutions_needed(
+                    self, model_dict, raise_warning_if_provider_not_present=True
+                )
 
                 kwargs = model_dict.pop("kwargs", {})
                 connection_string: str | None = model_dict.pop(

--- a/great_expectations/datasource/fluent/snowflake_datasource.py
+++ b/great_expectations/datasource/fluent/snowflake_datasource.py
@@ -127,6 +127,7 @@ class SnowflakeDatasource(SQLDatasource):
                 model_dict = self.dict(
                     exclude=self._get_exec_engine_excludes(),
                     config_provider=self._config_provider,
+                    raise_on_missing_config_provider=True,
                 )
 
                 kwargs = model_dict.pop("kwargs", {})

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -519,6 +519,7 @@ class _SourceFactories:
             if id_:
                 updated_datasource.id = id_
 
+            updated_datasource._data_context = self._data_context
             updated_datasource.test_connection()
             return_obj = self._data_context._update_fluent_datasource(
                 datasource=updated_datasource

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -573,6 +573,7 @@ class _SourceFactories:
             if id_:
                 new_datasource.id = id_
 
+            new_datasource._data_context = self._data_context
             new_datasource.test_connection()
             if datasource_name in self._data_context.datasources:
                 return_obj = self._data_context._update_fluent_datasource(

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -30,7 +30,10 @@ from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,
 )
-from great_expectations.datasource.fluent.config_str import ConfigStr
+from great_expectations.datasource.fluent.config_str import (
+    ConfigStr,
+    _check_config_substitutions_needed,
+)
 from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
 from great_expectations.datasource.fluent.fluent_base_model import FluentBaseModel
 from great_expectations.datasource.fluent.interfaces import (
@@ -1030,8 +1033,8 @@ class SQLDatasource(Datasource):
         model_dict = self.dict(
             exclude=self._get_exec_engine_excludes(),
             config_provider=self._config_provider,
-            raise_on_missing_config_provider=True,
         )
+        _check_config_substitutions_needed(self, model_dict, True)
         connection_string = model_dict.pop("connection_string")
         kwargs = model_dict.pop("kwargs", {})
         return sa.create_engine(connection_string, **kwargs)

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1030,6 +1030,7 @@ class SQLDatasource(Datasource):
         model_dict = self.dict(
             exclude=self._get_exec_engine_excludes(),
             config_provider=self._config_provider,
+            raise_on_missing_config_provider=True,
         )
         connection_string = model_dict.pop("connection_string")
         kwargs = model_dict.pop("kwargs", {})

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1034,7 +1034,9 @@ class SQLDatasource(Datasource):
             exclude=self._get_exec_engine_excludes(),
             config_provider=self._config_provider,
         )
-        _check_config_substitutions_needed(self, model_dict, True)
+        _check_config_substitutions_needed(
+            self, model_dict, raise_warning_if_provider_not_present=True
+        )
         connection_string = model_dict.pop("connection_string")
         kwargs = model_dict.pop("kwargs", {})
         return sa.create_engine(connection_string, **kwargs)

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -44,7 +44,7 @@ def test_kwargs_are_passed_to_create_engine(
     monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
 
     context = ephemeral_context_with_defaults
-    ds = context.sources.add_sql(name="my_datasource", **ds_kwargs)
+    ds = context.sources.add_or_update_sql(name="my_datasource", **ds_kwargs)
     print(ds)
     ds.test_connection()
 

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -13,16 +13,38 @@ from great_expectations.datasource.fluent.sql_datasource import TableAsset
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+    from great_expectations.data_context import EphemeralDataContext
+
+
+@pytest.fixture
+def create_engine_spy(mocker: MockerFixture) -> mock.MagicMock:
+    return mocker.spy(sa, "create_engine")
+
 
 @pytest.mark.unit
-def test_kwargs_are_passed_to_create_engine(mocker: MockerFixture):
-    create_engine_spy = mocker.spy(sa, "create_engine")
+@pytest.mark.parametrize(
+    "ds_kwargs",
+    [
+        dict(
+            connection_string="sqlite:///",
+            kwargs={"isolation_level": "SERIALIZABLE"},
+        ),
+        dict(
+            connection_string="${MY_CONN_STR}",
+            kwargs={"isolation_level": "SERIALIZABLE"},
+        ),
+    ],
+)
+def test_kwargs_are_passed_to_create_engine(
+    create_engine_spy: mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    ds_kwargs: dict,
+):
+    monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
 
-    ds = SQLDatasource(
-        name="my_datasource",
-        connection_string="sqlite:///",
-        kwargs={"isolation_level": "SERIALIZABLE"},
-    )
+    context = ephemeral_context_with_defaults
+    ds = context.sources.add_sql(name="my_datasource", **ds_kwargs)
     print(ds)
     ds.test_connection()
 


### PR DESCRIPTION
- Followup to #8773 

The `_data_context` was not being attached to the `datasource` before calling `test_connection()` as part of the `context.sources.add_or_update_<DS_TYPE>()` flow.

This causes the `test_connection()` to fail if the user's datasource needs to do a variable config substitution. 
The `config_provider` is pulled from the `data_context`.
