### PR TITLE
[MAINTENANCE] Fix `docs-snippets` CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,17 @@ jobs:
     name: docs-snippets
     needs: [unit-tests, docs-changes, doc-checks, ci-is-on-main-repo]
     # run on non-draft PRs with docs changes
-    if: |
-      (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
+    # TODO: re-enable before merge
+    # if: |
+    #   (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||
+    #   (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        markers:
+          - docs-creds-needed
+          - docs-basic
+          - docs-spark
     env:
       # google
       GE_TEST_GCP_CREDENTIALS: ${{secrets.GE_TEST_GCP_CREDENTIALS}}
@@ -161,17 +168,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
-          invoke deps --gx-install -m 'docs-basic' -m 'docs-creds-needed' -m 'docs-spark'
+          invoke deps --gx-install -m '${{ matrix.markers }}'
       - name: Run the tests
-        run: |
-          invoke docs-snippet-tests 'docs-basic' --up-services --verbose
-      - name: Run the tests needing cloud credentials
-        run: |
-          invoke docs-snippet-tests 'docs-creds-needed' --up-services --verbose
-      # Spark tests are run as part of a separate task as we have not migrated all of Spark tests just yet (ie. Spark+Athena, Spark+S3 etc)
-      - name: Run the Spark tests
-        run: |
-          invoke docs-snippet-tests 'docs-spark' --up-services --verbose
+        run: invoke docs-snippet-tests '${{ matrix.markers }}' --up-services --verbose
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   docs-snippets:
     name: docs-snippets
-    needs: [unit-tests, docs-changes, doc-checks, ci-is-on-main-repo]
+    needs: [unit-tests, docs-changes, ci-is-on-main-repo]  # TODO: add back doc-changes
     # run on non-draft PRs with docs changes
     # TODO: re-enable before merge
     # if: |
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        markers:
+        doc-step:
           - docs-creds-needed
           - docs-basic
           - docs-spark
@@ -168,9 +168,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
-          invoke deps --gx-install -m '${{ matrix.markers }}'
+          invoke deps --gx-install -m '${{ matrix.doc-step }}'
       - name: Run the tests
-        run: invoke docs-snippet-tests '${{ matrix.markers }}' --up-services --verbose
+        run: invoke docs-snippet-tests '${{ matrix.doc-step }}' --up-services --verbose
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,11 @@ jobs:
 
   docs-snippets:
     name: docs-snippets
-    needs: [unit-tests, docs-changes, ci-is-on-main-repo]  # TODO: add back doc-changes
+    needs: [unit-tests, docs-changes, doc-checks, ci-is-on-main-repo]
     # run on non-draft PRs with docs changes
-    # TODO: re-enable before merge
-    # if: |
-    #   (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||
-    #   (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
+    if: |
+      (github.event.pull_request.draft == false && needs.docs-changes.outputs.docs == 'true') ||
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/tasks.py
+++ b/tasks.py
@@ -833,6 +833,7 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
     "docs-creds-needed": TestDependencies(
         # these installs are handled by the CI
         requirement_files=(
+            "reqs/requirements-dev-test.txt",
             "reqs/requirements-dev-azure.txt",
             "reqs/requirements-dev-bigquery.txt",
             "reqs/requirements-dev-redshift.txt",


### PR DESCRIPTION
Breakup the `doc-snippets` steps to fix size limit errors and for better parallelization.

![image](https://github.com/great-expectations/great_expectations/assets/13108583/5f148011-0f70-4c22-bc52-7fced739a8d6)
