### PR TITLE
[MAINTENANCE] Column Descriptive Metrics: Don't add empty string for type

### DIFF
--- a/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
+++ b/great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py
@@ -143,14 +143,19 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
             aborted_metrics=aborted_metrics,
         )
         raw_column_types: list[dict[str, Any]] = value
-        # If type is not found, default to empty string. This can happen if our db introspection fails.
-        column_types_converted_to_str: list[dict[str, str]] = [
-            {
-                "name": raw_column_type["name"],
-                "type": str(raw_column_type.get("type", "")),
-            }
-            for raw_column_type in raw_column_types
-        ]
+        # If type is not found, don't add empty type field. This can happen if our db introspection fails.
+        column_types_converted_to_str: list[dict[str, str]] = []
+        for raw_column_type in raw_column_types:
+            if raw_column_type.get("type"):
+                column_types_converted_to_str.append(
+                    {
+                        "name": raw_column_type["name"],
+                        "type": str(raw_column_type["type"]),
+                    }
+                )
+            else:
+                column_types_converted_to_str.append({"name": raw_column_type["name"]})
+
         return TableMetric[List[str]](
             batch_id=batch_id,
             metric_name=metric_name,
@@ -161,7 +166,7 @@ class ColumnDescriptiveMetricsMetricRetriever(MetricRetriever):
     def _get_columns_to_exclude(self, table_column_types: Metric) -> List[str]:
         columns_to_skip: List[str] = []
         for column_type in table_column_types.value:
-            if column_type["type"] == "":
+            if not column_type.get("type"):
                 columns_to_skip.append(column_type["name"])
         return columns_to_skip
 

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -538,7 +538,9 @@ def test_get_metrics_with_column_type_missing():
             metric_name="table.column_types",
             value=[
                 {"name": "col1", "type": "float"},
-                {"name": "col2", "type": ""},
+                {
+                    "name": "col2",
+                },  # Note: No type for col2
             ],
             exception=None,
         ),


### PR DESCRIPTION
Previously we were adding an empty string if type information couldn't be introspected from the data store. This PR removes the empty string and doesn't populate the `type` field if it doesn't exist.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
