### PR TITLE
[MAINTENANCE] Allow re-publishing Pact on same commit

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -75,7 +75,7 @@ def pact(request) -> Pact:
         )
 
     # adding random id to the commit hash allows us to run the build
-    # and publish the contract more than once. we need this ability due to
+    # and publish the contract more than once. we need this because we have
     # the ability to trigger re-run of tests in GH or release build process
     version = f"{get_git_commit_hash()}_{uuid.uuid4()[:5]}"
 

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -63,10 +63,10 @@ def pact(request) -> Pact:
     broker_token: str
     publish_to_broker: bool
     if os.environ.get("PACT_BROKER_READ_WRITE_TOKEN"):
-        broker_token = os.environ.get("PACT_BROKER_READ_WRITE_TOKEN")
+        broker_token = os.environ.get("PACT_BROKER_READ_WRITE_TOKEN", "")
         publish_to_broker = True
     elif os.environ.get("PACT_BROKER_READ_ONLY_TOKEN"):
-        broker_token = os.environ.get("PACT_BROKER_READ_ONLY_TOKEN")
+        broker_token = os.environ.get("PACT_BROKER_READ_ONLY_TOKEN", "")
         publish_to_broker = False
     else:
         pytest.skip(

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -77,7 +77,7 @@ def pact(request) -> Pact:
     # adding random id to the commit hash allows us to run the build
     # and publish the contract more than once. we need this because we have
     # the ability to trigger re-run of tests in GH or release build process
-    version = f"{get_git_commit_hash()}_{uuid.uuid4()[:5]}"
+    version = f"{get_git_commit_hash()}_{str(uuid.uuid4())[:5]}"
 
     pact: Pact = Consumer(
         name=consumer_name,

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -4,6 +4,7 @@ import enum
 import os
 import pathlib
 import subprocess
+import uuid
 from typing import TYPE_CHECKING, Callable, Final, Union
 
 import pytest
@@ -73,9 +74,14 @@ def pact(request) -> Pact:
             "no pact credentials: set PACT_BROKER_READ_ONLY_TOKEN from greatexpectations.pactflow.io"
         )
 
+    # adding random id to the commit hash allows us to run the build
+    # and publish the contract more than once. we need this ability due to
+    # the ability to trigger re-run of tests in GH or release build process
+    version = f"{get_git_commit_hash()}_{uuid.uuid4()[:5]}"
+
     pact: Pact = Consumer(
         name=consumer_name,
-        version=get_git_commit_hash(),
+        version=version,
         tag_with_git_branch=True,
         auto_detect_version_properties=True,
     ).has_pact_with(

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -63,14 +63,15 @@ def pact(request) -> Pact:
     broker_token: str
     publish_to_broker: bool
     if os.environ.get("PACT_BROKER_READ_WRITE_TOKEN"):
-        broker_token = os.environ.get("PACT_BROKER_READ_WRITE_TOKEN", "")
+        broker_token = os.environ.get("PACT_BROKER_READ_WRITE_TOKEN")
         publish_to_broker = True
-    else:
-        broker_token = os.environ.get("PACT_BROKER_READ_ONLY_TOKEN", "")
+    elif os.environ.get("PACT_BROKER_READ_ONLY_TOKEN"):
+        broker_token = os.environ.get("PACT_BROKER_READ_ONLY_TOKEN")
         publish_to_broker = False
-
-    if not broker_token:
-        raise OSError("No Pact broker token was found in the environment.")
+    else:
+        pytest.skip(
+            "no pact credentials: set PACT_BROKER_READ_ONLY_TOKEN from greatexpectations.pactflow.io"
+        )
 
     pact: Pact = Consumer(
         name=consumer_name,


### PR DESCRIPTION
Since we can run the tests multiple times on the same commit, we need the ability to re-publish the contract anyway.

- [X] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [X] Appropriate tests and docs have been updated
