### PR TITLE
[MAINTENANCE] Flakey usage-stats test fixes

### DIFF
--- a/tests/integration/usage_statistics/conftest.py
+++ b/tests/integration/usage_statistics/conftest.py
@@ -7,6 +7,7 @@ from requests.adapters import HTTPAdapter, Retry
 def requests_session_with_retries() -> requests.Session:
     # https://stackoverflow.com/a/35636367
     session = requests.Session()
-    retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
+    # backoff factor above 1.0 means increasing sleep time between retries
+    retries = Retry(total=5, backoff_factor=1.25, status_forcelist=[502, 503, 504])
     session.mount("https://", HTTPAdapter(max_retries=retries))
     return session

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2895,7 +2895,7 @@ def test_usage_statistics_message(
 ):
     """known message formats should be valid"""
     res = requests_session_with_retries.post(
-        USAGE_STATISTICS_QA_URL, json=message, timeout=2
+        USAGE_STATISTICS_QA_URL, json=message, timeout=4
     )
     assert res.status_code == 201
     assert res.json() == {"event_count": 1}

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2894,6 +2894,7 @@ def test_usage_statistics_message(
     message: dict, requests_session_with_retries: requests.Session
 ):
     """known message formats should be valid"""
+    # TODO: test against the mercury container
     res = requests_session_with_retries.post(
         USAGE_STATISTICS_QA_URL, json=message, timeout=4
     )

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2894,7 +2894,6 @@ def test_usage_statistics_message(
     message: dict, requests_session_with_retries: requests.Session
 ):
     """known message formats should be valid"""
-    # TODO: test against the mercury container
     res = requests_session_with_retries.post(
         USAGE_STATISTICS_QA_URL, json=message, timeout=4
     )


### PR DESCRIPTION
Deal with the increasingly frequent flakey test failures of `tests/integration/usage_statistics/test_usage_statistics_messages.py::test_usage_statistics_message`.

1. Double the `request` `timeout` from `2s` to `4s`
2. Adjuct the `requests_session_with_retries` fixture from a static `backoff_factor` of `1` to `> 1.0`, ensuring that the wait time between retries slightly increases each time.


~We should consider running these tests against the mercury container as a followup.~ Tests rely on `aws` lambda.
