### PR TITLE
[MAINTENANCE] Increase docker compose up services timeout

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1168,7 +1168,7 @@ def service(
                     "-d",
                     "--quiet-pull",
                     "--wait",
-                    "--wait-timeout 90",
+                    "--wait-timeout 120",
                 ]
             )
             ctx.run(" ".join(cmds), echo=True, pty=pty)


### PR DESCRIPTION
Increasing due to feedback that `cloud-tests` job is failing due to unhealthy services. This timeout increase only waits longer for the services to become healthy. If services are healthy it will not wait 120 seconds.

- [X] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [X] Appropriate tests and docs have been updated