### PR TITLE
[MAINTENANCE] Quieter logging

### DIFF
--- a/great_expectations/core/http.py
+++ b/great_expectations/core/http.py
@@ -19,6 +19,8 @@ def _log_request_method_and_response(r: requests.Response, *args, **kwargs):
         LOGGER.debug(f"{r}\n{pf(r.json(), depth=3)}")
     except json.JSONDecodeError:
         LOGGER.debug(f"{r}\n{r.content.decode()}")
+    except Exception as other_err:
+        LOGGER.info(f"{r} - Error logging response {other_err!r}")
 
 
 class _TimeoutHTTPAdapter(HTTPAdapter):

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4148,7 +4148,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         config_with_global_config_overrides: DataContextConfig = copy.deepcopy(config)
         usage_stats_enabled: bool = self._is_usage_stats_enabled()
         if not usage_stats_enabled:
-            logger.info(
+            logger.debug(
                 "Usage statistics is disabled globally. Applying override to project_config."
             )
             config_with_global_config_overrides.anonymous_usage_statistics.enabled = (
@@ -4179,7 +4179,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
                 {"usage_statistics_url": global_usage_statistics_url}
             )
             if not usage_statistics_url_errors:
-                logger.info(
+                logger.debug(
                     "usage_statistics_url is defined globally. Applying override to project_config."
                 )
                 config_with_global_config_overrides.anonymous_usage_statistics.usage_statistics_url = (
@@ -5450,7 +5450,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
 
     def _load_fluent_config(self, config_provider: _ConfigurationProvider) -> GxConfig:
         """Called at beginning of DataContext __init__ after config_providers init."""
-        logger.info(
+        logger.debug(
             f"{self.__class__.__name__} has not implemented `_load_fluent_config()` returning empty `GxConfig`"
         )
         return GxConfig(fluent_datasources=[])

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -4116,6 +4116,14 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         except ValidationError:
             raise
 
+    @overload
+    def _normalize_absolute_or_relative_path(self, path: str) -> str:
+        ...
+
+    @overload
+    def _normalize_absolute_or_relative_path(self, path: None) -> None:
+        ...
+
     def _normalize_absolute_or_relative_path(
         self, path: Optional[str]
     ) -> Optional[str]:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -226,7 +226,7 @@ class CloudDataContext(SerializableDataContext):
         )
         if context_root_dir is None:
             context_root_dir = os.getcwd()  # noqa: PTH109
-            logger.info(
+            logger.debug(
                 f'context_root_dir was not provided - defaulting to current working directory "'
                 f'{context_root_dir}".'
             )

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -503,17 +503,24 @@ class CloudDataContext(SerializableDataContext):
             ),
             "usage_statistics_url": DEFAULT_USAGE_STATISTICS_URL,
         }
+        missing_config_vars_and_subs: list[tuple[str, str]] = []
         for config_variable, value in cloud_config_variable_defaults.items():
             if substitutions.get(config_variable) is None:
-                logger.info(
-                    f'Config variable "{config_variable}" was not found in environment or global config ('
-                    f'{self.GLOBAL_CONFIG_PATHS}). Using default value "{value}" instead. If you would '
-                    f"like to "
-                    f"use a different value, please specify it in an environment variable or in a "
-                    f"great_expectations.conf file located at one of the above paths, in a section named "
-                    f'"ge_cloud_config".'
-                )
                 substitutions[config_variable] = value
+                missing_config_vars_and_subs.append((config_variable, value))
+
+        if missing_config_vars_and_subs:
+            missing_config_var_repr = ", ".join(
+                [f"{var}={sub}" for var, sub in missing_config_vars_and_subs]
+            )
+            logger.info(
+                "Config variables were not found in environment or global config ("
+                f"{self.GLOBAL_CONFIG_PATHS}). Using default values instead. {missing_config_var_repr} ;"
+                " If you would like to "
+                "use a different value, please specify it in an environment variable or in a "
+                "great_expectations.conf file located at one of the above paths, in a section named "
+                '"ge_cloud_config".'
+            )
 
         return DataContextConfig(**self.config_provider.substitute_config(config))
 

--- a/great_expectations/datasource/fluent/fluent_base_model.py
+++ b/great_expectations/datasource/fluent/fluent_base_model.py
@@ -264,7 +264,7 @@ class FluentBaseModel(pydantic.BaseModel):
 
         class_name = self.__class__.__name__
         if config_provider:
-            logger.info(f"{class_name}.dict() - substituting config values")
+            logger.debug(f"{class_name}.dict() - substituting config values")
             _recursively_set_config_value(result, config_provider)
         elif raise_on_missing_config_provider:
             raise ValueError(


### PR DESCRIPTION
1. Reduce the amount of noisy and unhelpful `INFO` level logging messages.
2. Handle possible exceptions when logging HTTP responses
3. 1 log message for `get_config_with_variables_substituted()` with missing config vars.
