### PR TITLE
[MAINTENANCE] remove deprecated usage of pydantic Extra

### DIFF
--- a/great_expectations/experimental/metric_repository/cloud_data_store.py
+++ b/great_expectations/experimental/metric_repository/cloud_data_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, TypeVar
 
-from great_expectations.compatibility.pydantic import BaseModel, Extra
+from great_expectations.compatibility.pydantic import BaseModel
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.http import create_session
 from great_expectations.experimental.metric_repository.data_store import DataStore
@@ -25,7 +25,7 @@ class PayloadData(BaseModel):
     attributes: Dict[str, Any]
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 def orjson_dumps(v, *, default):
@@ -49,7 +49,7 @@ class Payload(BaseModel):
     data: PayloadData
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
         json_dumps = orjson_dumps
         json_loads = orjson_loads
 

--- a/great_expectations/experimental/metric_repository/metrics.py
+++ b/great_expectations/experimental/metric_repository/metrics.py
@@ -15,7 +15,6 @@ from typing import (
     Union,
 )
 
-from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.pydantic import BaseModel, Field
 from great_expectations.compatibility.typing_extensions import override
 
@@ -28,7 +27,7 @@ class MetricRepositoryBaseModel(BaseModel):
     """Base class for all MetricRepository related models."""
 
     class Config:
-        extra = pydantic.Extra.forbid
+        extra = "forbid"
 
 
 class MetricException(MetricRepositoryBaseModel):


### PR DESCRIPTION
Pydantic is deprecating the use of Extra class and literal strings should be used in its place

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
