### PR TITLE
[MAINTENANCE] Typing render/view 

### DIFF
--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 import nbformat
 
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.render.renderer.renderer import Renderer
 from great_expectations.util import (
     convert_json_string_to_be_python_compliant,
@@ -48,7 +49,7 @@ class BaseNotebookRenderer(Renderer):
             code = lint_code(code).rstrip("\n")
 
         cell = nbformat.v4.new_code_cell(code)
-        self._notebook["cells"].append(cell)
+        self._notebook["cells"].append(cell)  # type: ignore[index] # _notebook could be None
 
     def add_markdown_cell(self, markdown: str) -> None:
         """
@@ -60,7 +61,7 @@ class BaseNotebookRenderer(Renderer):
             Nothing, adds a cell to the class instance notebook
         """
         cell = nbformat.v4.new_markdown_cell(markdown)
-        self._notebook["cells"].append(cell)
+        self._notebook["cells"].append(cell)  # type: ignore[index] # _notebook could be None
 
     @classmethod
     def write_notebook_to_disk(
@@ -75,6 +76,7 @@ class BaseNotebookRenderer(Renderer):
         with open(notebook_file_path, "w") as f:
             nbformat.write(notebook, f)
 
+    @override
     def render(self, **kwargs: dict) -> nbformat.NotebookNode:
         """
         Render a notebook from parameters.

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -575,7 +575,7 @@ class DefaultMarkdownPageView(DefaultJinjaView):
         index: Any | None = None,
         content_block_id: str | None = None,
         render_to_markdown: bool = True,
-    ) -> str:
+    ) -> RenderedComponentContent | dict | str:
         """
         Render a content block to markdown using jinja templates.
         Args:

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -32,7 +32,8 @@ from great_expectations.render import (
 )
 
 if TYPE_CHECKING:
-    from jinja2 import BaseLoader, Template
+    from jinja2 import BaseLoader
+    from jinja2 import Template as jTemplate
 
 
 class NoOpTemplate:
@@ -117,7 +118,7 @@ class DefaultJinjaView:
             document = document.to_json_dict()
         return t.render(document, **kwargs)
 
-    def _get_template(self, template_str: str) -> Template:
+    def _get_template(self, template_str: str) -> jTemplate:
         template = self.env.get_template(template_str)
         template.globals["now"] = lambda: datetime.datetime.now(datetime.timezone.utc)
 

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -36,11 +36,6 @@ if TYPE_CHECKING:
     from jinja2 import Template as jTemplate
 
 
-class NoOpTemplate:
-    def render(self, document):
-        return document
-
-
 class PrettyPrintTemplate:
     def render(self, document, indent=2) -> None:
         print(json.dumps(document, indent=indent))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ exclude = [
     'render/renderer/suite_edit_notebook_renderer\.py',                  # 7 - This is legacy code and will not be typed.
     'render/renderer/suite_scaffold_notebook_renderer\.py',              # 7 - This is legacy code and will not be typed.
     'render/renderer/datasource_new_notebook_renderer\.py',              # 4 - This is legacy code and will not be typed.
+    'render/renderer/checkpoint_new_notebook_renderer\.py',              # 9 - This is legacy code and will not be typed.
     # END ALWAYS EXCLUDE SECTION ######################################################
     #
     # #################################################################################
@@ -139,7 +140,6 @@ exclude = [
     'expectations/regex_based_column_map_expectation\.py',                                                 # 3
     'expectations/row_conditions\.py',                                                                     # 4
     'expectations/set_based_column_map_expectation\.py',                                                   # 3
-    'render/renderer/checkpoint_new_notebook_renderer\.py',                                                # 9
     'render/renderer/content_block/content_block\.py',                                                     # 5
     'render/renderer/content_block/exception_list_content_block\.py',                                      # 4
     'render/renderer/page_renderer\.py',                                                                   # 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ exclude = [
     'render/renderer/suite_scaffold_notebook_renderer\.py',                                                # 7
     'render/renderer/v3/suite_edit_notebook_renderer\.py',                                                 # 11
     'render/renderer/v3/suite_profile_notebook_renderer\.py',                                              # 4
-    'render/view/view\.py',                                                                                # 11
     'rule_based_profiler/domain_builder/map_metric_column_domain_builder\.py',                             # 8
     'rule_based_profiler/estimators/bootstrap_numeric_range_estimator\.py',                                # 8
     'rule_based_profiler/estimators/kde_numeric_range_estimator\.py',                                      # 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,18 +73,24 @@ exclude = [
     'cli/upgrade_helpers/upgrade_helper_v13\.py',                        # 17 - This is legacy code and will not be typed.
     'dataset/sparkdf_dataset\.py',                                       #  3 - This is legacy code and will not be typed.
     'dataset/sqlalchemy_dataset\.py',                                    # 16 - This is legacy code and will not be typed.
+    'core/usage_statistics/anonymizers/batch_anonymizer\.py',            # 10 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/batch_request_anonymizer\.py',    # 16 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/checkpoint_anonymizer\.py',       # 16 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/data_docs_anonymizer\.py',        # 5 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/datasource_anonymizer\.py',       # 9 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/expectation_anonymizer\.py',      # 6 - This code will be removed in 1.0
+    'core/usage_statistics/anonymizers/validation_operator_anonymizer\.py',  # 5 - This code will be removed in 1.0
+    'render/renderer/v3/suite_edit_notebook_renderer\.py',               # 11 - This is legacy code and will not be typed.
+    'render/renderer/v3/suite_profile_notebook_renderer\.py',            # 4 - This is legacy code and will not be typed.
+    'render/renderer/suite_edit_notebook_renderer\.py',                  # 7 - This is legacy code and will not be typed.
+    'render/renderer/suite_scaffold_notebook_renderer\.py',              # 7 - This is legacy code and will not be typed.
+    'render/renderer/datasource_new_notebook_renderer\.py',              # 4 - This is legacy code and will not be typed.
     # END ALWAYS EXCLUDE SECTION ######################################################
     #
     # #################################################################################
     # TODO: complete typing for the following modules and remove from exclude list
     # number is the current number of typing errors for the excluded pattern
-    'core/usage_statistics/anonymizers/batch_anonymizer\.py',                                              # 10
-    'core/usage_statistics/anonymizers/batch_request_anonymizer\.py',                                      # 16
-    'core/usage_statistics/anonymizers/checkpoint_anonymizer\.py',                                         # 16
-    'core/usage_statistics/anonymizers/data_docs_anonymizer\.py',                                          # 5
-    'core/usage_statistics/anonymizers/datasource_anonymizer\.py',                                         # 9
-    'core/usage_statistics/anonymizers/expectation_anonymizer\.py',                                        # 6
-    'core/usage_statistics/anonymizers/validation_operator_anonymizer\.py',                                # 5
+
     'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
     'expectations/core/expect_column_values_to_not_match_regex_list\.py',                                  # 2
     'expectations/core/expect_column_values_to_not_match_regex\.py',                                       # 2
@@ -136,16 +142,10 @@ exclude = [
     'render/renderer/checkpoint_new_notebook_renderer\.py',                                                # 9
     'render/renderer/content_block/content_block\.py',                                                     # 5
     'render/renderer/content_block/exception_list_content_block\.py',                                      # 4
-    'render/renderer/datasource_new_notebook_renderer\.py',                                                #  4
-    'render/renderer/notebook_renderer\.py',                                                               # 2
     'render/renderer/page_renderer\.py',                                                                   # 10
     'render/renderer/profiling_results_overview_section_renderer\.py',                                     # 2
     'render/renderer/site_builder\.py',                                                                    # 3
     'render/renderer/slack_renderer\.py',                                                                  # 9
-    'render/renderer/suite_edit_notebook_renderer\.py',                                                    # 7
-    'render/renderer/suite_scaffold_notebook_renderer\.py',                                                # 7
-    'render/renderer/v3/suite_edit_notebook_renderer\.py',                                                 # 11
-    'render/renderer/v3/suite_profile_notebook_renderer\.py',                                              # 4
     'rule_based_profiler/domain_builder/map_metric_column_domain_builder\.py',                             # 8
     'rule_based_profiler/estimators/bootstrap_numeric_range_estimator\.py',                                # 8
     'rule_based_profiler/estimators/kde_numeric_range_estimator\.py',                                      # 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ exclude = [
     # #################################################################################
     # TODO: complete typing for the following modules and remove from exclude list
     # number is the current number of typing errors for the excluded pattern
-
     'expectations/core/expect_column_values_to_be_of_type\.py',                                            # 12
     'expectations/core/expect_column_values_to_not_match_regex_list\.py',                                  # 2
     'expectations/core/expect_column_values_to_not_match_regex\.py',                                       # 2


### PR DESCRIPTION
Type checking for `render/view/view.py`

This change includes some runtime changes, notable the removal of the `NoOpTemplate` and the default `_template` class attribute for `DefaultJinjaView`
