### PR TITLE
[MAINTENANCE] Adjust timeouts for cloud-tests services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,8 +299,8 @@ jobs:
 
       - name: Start services
         run: |
-          docker compose -f assets/docker/mercury/docker-compose.yml up -d --quiet-pull --wait --wait-timeout 120 && \
-          docker compose -f assets/docker/spark/docker-compose.yml up -d --quiet-pull --wait --wait-timeout 120
+          docker compose -f assets/docker/mercury/docker-compose.yml up -d --quiet-pull --wait --wait-timeout 150 && \
+          docker compose -f assets/docker/spark/docker-compose.yml up -d --quiet-pull --wait --wait-timeout 90
 
       - name: Run the tests
         env:

--- a/assets/docker/mercury/docker-compose.yml
+++ b/assets/docker/mercury/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       test: timeout 10s bash -c ':> /dev/tcp/0.0.0.0/5000' || exit 1
       interval: 5s
       timeout: 2s
-      retries: 10
+      retries: 20
     depends_on:
       db-provisioner:
         condition: service_completed_successfully


### PR DESCRIPTION
Adjust timeouts for cloud-tests services

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated