### PR TITLE
[MAINTENANCE] Refactor pact contract tests for Data Context and Expectation Suites

### DIFF
--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -13,6 +13,7 @@ from typing_extensions import Annotated, TypeAlias  # noqa: TCH002
 
 from great_expectations.compatibility import pydantic
 from great_expectations.core.http import create_session
+from great_expectations.data_context import CloudDataContext
 
 if TYPE_CHECKING:
     from requests import Session
@@ -41,6 +42,34 @@ class RequestMethods(str, enum.Enum):
     PATCH = "PATCH"
     POST = "POST"
     PUT = "PUT"
+
+
+@pytest.fixture
+def cloud_base_url() -> str:
+    try:
+        return os.environ["GX_CLOUD_BASE_URL"]
+    except KeyError as e:
+        raise OSError("GX_CLOUD_BASE_URL is not set in this environment.") from e
+
+
+@pytest.fixture
+def cloud_access_token() -> str:
+    try:
+        return os.environ["GX_CLOUD_ACCESS_TOKEN"]
+    except KeyError as e:
+        raise OSError("GX_CLOUD_ACCESS_TOKEN is not set in this environment.") from e
+
+
+@pytest.fixture
+def cloud_data_context(
+    cloud_base_url: str,
+    cloud_access_token: str,
+) -> CloudDataContext:
+    return CloudDataContext(
+        cloud_base_url=cloud_base_url,
+        cloud_organization_id=EXISTING_ORGANIZATION_ID,
+        cloud_access_token=cloud_access_token,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/cloud/rest_contracts/conftest.py
+++ b/tests/integration/cloud/rest_contracts/conftest.py
@@ -75,6 +75,7 @@ def cloud_data_context(
     cloud_base_url: str,
     cloud_access_token: str,
 ) -> CloudDataContext:
+    """This is a real Cloud Data Context that points to the pact mock service instead of the Mercury API."""
     cloud_data_context = CloudDataContext(
         cloud_base_url=cloud_base_url,
         cloud_organization_id=EXISTING_ORGANIZATION_ID,

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Final
 
 import pact
@@ -28,22 +27,6 @@ GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
         "expectation_suite": True,
     },
 }
-
-
-@pytest.fixture
-def cloud_base_url() -> str:
-    try:
-        return os.environ["GX_CLOUD_BASE_URL"]
-    except KeyError as e:
-        raise OSError("GX_CLOUD_BASE_URL is not set in this environment.") from e
-
-
-@pytest.fixture
-def cloud_access_token() -> str:
-    try:
-        return os.environ["GX_CLOUD_ACCESS_TOKEN"]
-    except KeyError as e:
-        raise OSError("GX_CLOUD_ACCESS_TOKEN is not set in this environment.") from e
 
 
 @pytest.mark.cloud

--- a/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
+++ b/tests/integration/cloud/rest_contracts/test_data_context_configuration.py
@@ -8,10 +8,12 @@ import pytest
 import great_expectations as gx
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
+    PACT_MOCK_SERVICE_URL,
 )
 
 if TYPE_CHECKING:
     import requests
+
 
 GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
     "anonymous_usage_statistics": pact.Like(
@@ -32,14 +34,13 @@ GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY: Final[dict] = {
 @pytest.mark.cloud
 def test_data_context_configuration(
     gx_cloud_session: requests.Session,
-    cloud_base_url: str,
     cloud_access_token: str,
     pact_test: pact.Pact,
 ) -> None:
     provider_state = "the Data Context exists"
     scenario = "a request for a Data Context"
     method = "GET"
-    path = f"{cloud_base_url}/organizations/{EXISTING_ORGANIZATION_ID}/data-context-configuration"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/data-context-configuration"
     status = 200
     response_body = GET_DATA_CONTEXT_CONFIGURATION_MIN_RESPONSE_BODY
 
@@ -60,7 +61,7 @@ def test_data_context_configuration(
     with pact_test:
         _ = gx.get_context(
             mode="cloud",
-            cloud_base_url=cloud_base_url,
+            cloud_base_url=PACT_MOCK_SERVICE_URL,
             cloud_organization_id=EXISTING_ORGANIZATION_ID,
             cloud_access_token=cloud_access_token,
         )

--- a/tests/integration/cloud/rest_contracts/test_expectation_suites.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suites.py
@@ -12,6 +12,7 @@ from tests.integration.cloud.rest_contracts.conftest import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.data_context import CloudDataContext
     from tests.integration.cloud.rest_contracts.conftest import PactBody
 
 
@@ -96,83 +97,92 @@ GET_EXPECTATION_SUITES_MIN_RESPONSE_BODY: Final[PactBody] = {
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="GET",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-                EXISTING_EXPECTATION_SUITE_ID,
-            ),
-            upon_receiving="a request to get an Expectation Suite",
-            given="the Expectation Suite does exist",
-            response_status=200,
-            response_body=GET_EXPECTATION_SUITE_MIN_RESPONSE_BODY,
-        ),
-    ],
-)
 def test_get_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does exist"
+    scenario = "a request to get an Expectation Suite"
+    method = "GET"
+    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{EXISTING_EXPECTATION_SUITE_ID}"
+    status = 200
+    response_body = GET_EXPECTATION_SUITE_MIN_RESPONSE_BODY
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+        )
+        .will_respond_with(
+            status=status,
+            body=response_body,
+        )
+    )
+
+    with pact_test:
+        cloud_data_context.get_expectation_suite(
+            ge_cloud_id=EXISTING_EXPECTATION_SUITE_ID
+        )
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="GET",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-                NON_EXISTENT_EXPECTATION_SUITE_ID,
-            ),
-            upon_receiving="a request to get an Expectation Suite",
-            given="the Expectation Suite does not exist",
-            response_status=404,
-            response_body=None,
-        ),
-    ],
-)
 def test_get_non_existent_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does not exist"
+    scenario = "a request to get an Expectation Suite"
+    method = "GET"
+    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{NON_EXISTENT_EXPECTATION_SUITE_ID}"
+    status = 404
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+        )
+        .will_respond_with(
+            status=status,
+        )
+    )
+
+    with pact_test:
+        cloud_data_context.get_expectation_suite(
+            ge_cloud_id=NON_EXISTENT_EXPECTATION_SUITE_ID
+        )
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="GET",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-            ),
-            upon_receiving="a request to get Expectation Suites",
-            given="Expectation Suite exist",
-            response_status=200,
-            response_body=GET_EXPECTATION_SUITES_MIN_RESPONSE_BODY,
-        ),
-    ],
-)
 def test_get_expectation_suites(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "Expectation Suite exist"
+    scenario = "a request to get Expectation Suites"
+    method = "GET"
+    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    status = 200
+    response_body = GET_EXPECTATION_SUITES_MIN_RESPONSE_BODY
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+        )
+        .will_respond_with(
+            status=status,
+            body=response_body,
+        )
+    )
+
+    with pact_test:
+        cloud_data_context.list_expectation_suites()
 
 
 @pytest.mark.cloud

--- a/tests/integration/cloud/rest_contracts/test_expectation_suites.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suites.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, Callable, Final
 import pact
 import pytest
 
+from great_expectations.data_context import CloudDataContext
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
     ContractInteraction,
 )
 
 if TYPE_CHECKING:
-    from great_expectations.data_context import CloudDataContext
     from tests.integration.cloud.rest_contracts.conftest import PactBody
 
 
@@ -104,7 +104,7 @@ def test_get_expectation_suite(
     provider_state = "the Expectation Suite does exist"
     scenario = "a request to get an Expectation Suite"
     method = "GET"
-    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{EXISTING_EXPECTATION_SUITE_ID}"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{EXISTING_EXPECTATION_SUITE_ID}"
     status = 200
     response_body = GET_EXPECTATION_SUITE_MIN_RESPONSE_BODY
 
@@ -135,7 +135,7 @@ def test_get_non_existent_expectation_suite(
     provider_state = "the Expectation Suite does not exist"
     scenario = "a request to get an Expectation Suite"
     method = "GET"
-    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{NON_EXISTENT_EXPECTATION_SUITE_ID}"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{NON_EXISTENT_EXPECTATION_SUITE_ID}"
     status = 404
 
     (
@@ -164,7 +164,7 @@ def test_get_expectation_suites(
     provider_state = "Expectation Suite exist"
     scenario = "a request to get Expectation Suites"
     method = "GET"
-    path = f"{cloud_data_context._cloud_config.base_url}/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
     status = 200
     response_body = GET_EXPECTATION_SUITES_MIN_RESPONSE_BODY
 

--- a/tests/integration/cloud/rest_contracts/test_expectation_suites.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suites.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import pathlib
-from typing import TYPE_CHECKING, Callable, Final
+from typing import TYPE_CHECKING, Final
 
 import pact
 import pytest
 
+from great_expectations.core import ExpectationSuite
 from great_expectations.data_context import CloudDataContext
+from great_expectations.exceptions import DataContextError
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
-    ContractInteraction,
 )
 
 if TYPE_CHECKING:
@@ -19,6 +19,26 @@ if TYPE_CHECKING:
 NON_EXISTENT_EXPECTATION_SUITE_ID: Final[str] = "6ed9a340-8469-4ee2-a300-ffbe5d09b49d"
 
 EXISTING_EXPECTATION_SUITE_ID: Final[str] = "3705d38a-0eec-4bd8-9956-fdb34df924b6"
+
+
+POST_EXPECTATION_SUITE_MIN_REQUEST_BODY: Final[PactBody] = {
+    "data": {
+        "type": "expectation_suite",
+        "attributes": {
+            "suite": {
+                "meta": {"great_expectations_version": "0.13.23"},
+                "expectations": [
+                    {
+                        "kwargs": {"max_value": 3, "min_value": 1},
+                        "meta": {},
+                        "expectation_type": "expect_table_row_count_to_be_between",
+                    },
+                ],
+                "expectation_suite_name": "brand new suite",
+            }
+        },
+    },
+}
 
 POST_EXPECTATION_SUITE_MIN_RESPONSE_BODY: Final[PactBody] = {
     "data": {
@@ -151,9 +171,10 @@ def test_get_non_existent_expectation_suite(
     )
 
     with pact_test:
-        cloud_data_context.get_expectation_suite(
-            ge_cloud_id=NON_EXISTENT_EXPECTATION_SUITE_ID
-        )
+        with pytest.raises(DataContextError):
+            cloud_data_context.get_expectation_suite(
+                ge_cloud_id=NON_EXISTENT_EXPECTATION_SUITE_ID
+            )
 
 
 @pytest.mark.cloud
@@ -186,245 +207,212 @@ def test_get_expectation_suites(
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="POST",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-            ),
-            upon_receiving="a request to post an Expectation Suite",
-            given="the Expectation Suite does not exist",
-            request_body={
-                "data": {
-                    "type": "expectation_suite",
-                    "attributes": {
-                        "suite": {
-                            "meta": {"great_expectations_version": "0.13.23"},
-                            "expectations": [
-                                {
-                                    "kwargs": {"max_value": 3, "min_value": 1},
-                                    "meta": {},
-                                    "expectation_type": "expect_table_row_count_to_be_between",
-                                },
-                            ],
-                            "expectation_suite_name": "brand new suite",
-                        }
-                    },
-                },
-            },
-            response_status=201,
-            response_body=POST_EXPECTATION_SUITE_MIN_RESPONSE_BODY,
-        ),
-    ],
-)
 def test_post_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does not exist"
+    scenario = "a request to post an Expectation Suite"
+    method = "POST"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    request_body = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY
+    status = 201
+    response_body = POST_EXPECTATION_SUITE_MIN_RESPONSE_BODY
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            body=request_body,
+        )
+        .will_respond_with(
+            status=status,
+            body=response_body,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+    expectation_suite = ExpectationSuite(**suite_dict)
+
+    with pact_test:
+        cloud_data_context.add_expectation_suite(expectation_suite=expectation_suite)
+    cloud_data_context.delete_expectation_suite(expectation_suite=expectation_suite)
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="POST",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-            ),
-            upon_receiving="a request to post an Expectation Suite",
-            given="an Expectation Suite with same name exists",
-            request_body={
-                "data": {
-                    "type": "expectation_suite",
-                    "attributes": {
-                        "suite": {
-                            "meta": {"great_expectations_version": "0.13.23"},
-                            "expectations": [
-                                {
-                                    "kwargs": {"max_value": 3, "min_value": 1},
-                                    "meta": {},
-                                    "expectation_type": "expect_table_row_count_to_be_between",
-                                },
-                            ],
-                            "expectation_suite_name": "brand new suite",
-                        }
-                    },
-                },
-            },
-            response_status=400,
-            response_body={
-                "errors": [
-                    {
-                        "detail": pact.Like(
-                            "Expectation Suite with name brand new suite already exists."
-                        )
-                    }
-                ]
-            },
-        ),
-    ],
-)
 def test_post_expectation_suite_with_existing_name(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "an Expectation Suite with same name exists"
+    scenario = "a request to post an Expectation Suite"
+    method = "POST"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    request_body = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY
+    status = 400
+    response_body = {
+        "errors": [
+            {
+                "detail": pact.Like(
+                    "Expectation Suite with name brand new suite already exists."
+                )
+            }
+        ]
+    }
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            body=request_body,
+        )
+        .will_respond_with(
+            status=status,
+            body=response_body,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+    expectation_suite = ExpectationSuite(**suite_dict)
+
+    with pact_test:
+        cloud_data_context.add_expectation_suite(expectation_suite=expectation_suite)
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="PUT",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-                EXISTING_EXPECTATION_SUITE_ID,
-            ),
-            upon_receiving="a request to put an Expectation Suite",
-            given="the Expectation Suite does exist",
-            request_body={
-                "data": {
-                    "type": "expectation_suite",
-                    "attributes": {
-                        "suite": {
-                            "meta": {"great_expectations_version": "0.13.23"},
-                            "expectations": [
-                                {
-                                    "kwargs": {"max_value": 3, "min_value": 1},
-                                    "meta": {},
-                                    "expectation_type": "expect_table_row_count_to_be_between",
-                                },
-                            ],
-                            "expectation_suite_name": "renamed suite",
-                        }
-                    },
-                },
-            },
-            response_status=204,
-            response_body=None,
-        ),
-    ],
-)
 def test_put_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does exist"
+    scenario = "a request to put an Expectation Suite"
+    method = "PUT"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{EXISTING_EXPECTATION_SUITE_ID}"
+    request_body = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY
+    status = 204
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            body=request_body,
+        )
+        .will_respond_with(
+            status=status,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+    expectation_suite = ExpectationSuite(**suite_dict)
+
+    with pact_test:
+        cloud_data_context.add_expectation_suite(expectation_suite=expectation_suite)
+    cloud_data_context.delete_expectation_suite(expectation_suite=expectation_suite)
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="PUT",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-                NON_EXISTENT_EXPECTATION_SUITE_ID,
-            ),
-            upon_receiving="a request to put an Expectation Suite",
-            given="the Expectation Suite does not exist",
-            request_body={
-                "data": {
-                    "type": "expectation_suite",
-                    "attributes": {
-                        "suite": {
-                            "meta": {"great_expectations_version": "0.13.23"},
-                            "expectations": [
-                                {
-                                    "kwargs": {"max_value": 3, "min_value": 1},
-                                    "meta": {},
-                                    "expectation_type": "expect_table_row_count_to_be_between",
-                                },
-                            ],
-                            "expectation_suite_name": "renamed suite",
-                        }
-                    },
-                },
-            },
-            response_status=404,
-            response_body=None,
-        ),
-    ],
-)
 def test_put_non_existent_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does not exist"
+    scenario = "a request to put an Expectation Suite"
+    method = "PUT"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites/{NON_EXISTENT_EXPECTATION_SUITE_ID}"
+    request_body = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY
+    status = 404
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            body=request_body,
+        )
+        .will_respond_with(
+            status=status,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+    expectation_suite = ExpectationSuite(**suite_dict)
+
+    with pact_test:
+        cloud_data_context.add_expectation_suite(expectation_suite=expectation_suite)
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="DELETE",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-            ),
-            request_params={
-                "name": "brand new suite",
-            },
-            upon_receiving="a request to delete an Expectation Suite",
-            given="the Expectation Suite does exist",
-            response_status=204,
-            response_body=None,
-        ),
-    ],
-)
 def test_delete_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does exist"
+    scenario = "a request to delete an Expectation Suite"
+    method = "DELETE"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    query = {
+        "name": "brand new suite",
+    }
+    status = 204
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            query=query,
+        )
+        .will_respond_with(
+            status=status,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+
+    with pact_test:
+        cloud_data_context.delete_expectation_suite(
+            expectation_suite_name=suite_dict["expectation_suite_name"]
+        )
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        ContractInteraction(
-            method="DELETE",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "expectation-suites",
-                NON_EXISTENT_EXPECTATION_SUITE_ID,
-            ),
-            request_params={
-                "name": "brand new suite",
-            },
-            upon_receiving="a request to delete an Expectation Suite",
-            given="the Expectation Suite does not exist",
-            response_status=404,
-            response_body=None,
-        ),
-    ],
-)
 def test_delete_non_existent_expectation_suite(
-    contract_interaction: ContractInteraction,
-    run_pact_test: Callable[[ContractInteraction], None],
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
 ) -> None:
-    run_pact_test(contract_interaction)
+    provider_state = "the Expectation Suite does not exist"
+    scenario = "a request to delete an Expectation Suite"
+    method = "DELETE"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/expectation-suites"
+    query = {
+        "name": "brand new suite",
+    }
+    status = 404
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            query=query,
+        )
+        .will_respond_with(
+            status=status,
+        )
+    )
+
+    suite_dict = POST_EXPECTATION_SUITE_MIN_REQUEST_BODY["data"]["attributes"]["suite"]
+
+    with pact_test:
+        cloud_data_context.delete_expectation_suite(
+            expectation_suite_name=suite_dict["expectation_suite_name"]
+        )


### PR DESCRIPTION
Refactor pact contract tests

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated
