### PR TITLE
[DOCS] add 'user' access token clarification to GX Cloud quickstart

### DIFF
--- a/docs/docusaurus/docs/gx_cloud/tutorials/getting_started/getting_started_with_gx_cloud.md
+++ b/docs/docusaurus/docs/gx_cloud/tutorials/getting_started/getting_started_with_gx_cloud.md
@@ -31,9 +31,9 @@ Once you have completed this guide you will have a foundation in the basics of u
 
 ### 1. Setup
 
-#### 1.1 Generate access token
+#### 1.1 Generate user access token
 
-Go to [“Settings” > “Tokens”](https://app.greatexpectations.io/tokens) in the navigation panel and generate an access token. Both `admin` and `editor` roles will suffice for this guide.
+Go to [“Settings” > “Tokens”](https://app.greatexpectations.io/tokens) in the navigation panel and generate a user access token. Both `admin` and `editor` roles will suffice for this guide.
 These tokens are view-once and stored as a hash in Great Expectation Cloud's backend database. Once you copy the API key and close the dialog, the Cloud UI will never show the token value again.
 
 #### 1.2 Import modules
@@ -59,7 +59,7 @@ Please note that access tokens are sensitive information and should not be commi
 :::
 
 ```python title="Jupyter Notebook"
-os.environ["GX_CLOUD_ACCESS_TOKEN"] = "<your_gx_cloud_access_token>"
+os.environ["GX_CLOUD_ACCESS_TOKEN"] = "<your_gx_cloud_user_access_token>"
 # your organization_id is indicated on https://app.greatexpectations.io/tokens page
 os.environ["GX_CLOUD_ORGANIZATION_ID"] = "<organization_id_from_the_app>"
 


### PR DESCRIPTION
## Purpose of change:

Provide additional clarification about tokens to decrease user confusion between "user" and "organization" access tokens.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
