### PR TITLE
[FEATURE] Warn users if more specific SQL Datasource is available.

### DIFF
--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -7,6 +7,8 @@ from great_expectations.datasource.fluent.interfaces import (
     Datasource,
     Sorter,
     BatchMetadata,
+    GxDatasourceWarning,
+    TestConnectionError,
 )
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -83,7 +83,14 @@ class TestConnectionError(Exception):
     pass
 
 
-class GxSerializationWarning(UserWarning):
+class GxDatasourceWarning(UserWarning):
+    """
+    Warning related to usage or configuration of a Datasource that could lead to
+    unexpected behavior.
+    """
+
+
+class GxSerializationWarning(GxDatasourceWarning):
     pass
 
 

--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -50,6 +50,7 @@ from great_expectations.datasource.fluent.interfaces import (
 from great_expectations.datasource.fluent.snowflake_datasource import SnowflakeDsn
 from great_expectations.datasource.fluent.spark_datasource import SparkConfig
 from great_expectations.datasource.fluent.sqlite_datasource import SqliteDsn
+from great_expectations.datasource.fluent.type_lookup import TypeLookup
 
 SourceFactoryFn: TypeAlias = Callable[..., Datasource]
 logger: Logger
@@ -68,7 +69,7 @@ def _get_field_details(
 ) -> _FieldDetails: ...
 
 class _SourceFactories:
-    type_lookup: ClassVar
+    type_lookup: ClassVar[TypeLookup]
     def __init__(self, data_context: GXDataContext) -> None: ...
     @classmethod
     def register_datasource(

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -988,7 +988,6 @@ def _warn_for_more_specific_datasource_type(connection_string: str) -> None:
     )
 
     more_specific_datasource: str | None = type_lookup_plus.get(connector)
-    # TODO: handle postgresql vs postgres type
     if more_specific_datasource:
         warnings.warn(
             f"You are using a generic SQLDatasource but a more specific {more_specific_datasource} "

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1027,6 +1027,8 @@ class SQLDatasource(Datasource):
         if cls.__name__ != "SQLDatasource":
             # This is already subclass of SQLDatasource, so we don't need to warn
             return v
+        if isinstance(v, ConfigStr):
+            v = v.template_str
         connector = v.split("://")[0].split("+")[0]
         if connector:
             from great_expectations.datasource.fluent.sources import _SourceFactories

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1043,7 +1043,7 @@ class SQLDatasource(Datasource):
             # TODO: handle postgresql vs postgres type
             if more_specific_datasource:
                 warnings.warn(
-                    f"You a using a generic SQLDatasource but a more specific {more_specific_datasource.__name__} "
+                    f"You are using a generic SQLDatasource but a more specific {more_specific_datasource.__name__} "
                     "may be more appropriate"
                     " https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/fluent/database/connect_sql_source_data"
                 )

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1027,9 +1027,13 @@ class SQLDatasource(Datasource):
         if cls.__name__ != "SQLDatasource":
             # This is already subclass of SQLDatasource, so we don't need to warn
             return v
+
         if isinstance(v, ConfigStr):
-            v = v.template_str
-        connector = v.split("://")[0].split("+")[0]
+            connection_str = v.template_str
+        else:
+            connection_str = v
+
+        connector = connection_str.split("://")[0].split("+")[0]
         if connector:
             from great_expectations.datasource.fluent.sources import _SourceFactories
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import random
 import shutil
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Final, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Final, Generator, List, Optional
 from unittest import mock
 
 import numpy as np
@@ -82,7 +82,7 @@ from great_expectations.dataset.pandas_dataset import PandasDataset
 from great_expectations.datasource.data_connector.util import (
     get_filesystem_one_level_directory_glob_path_list,
 )
-from great_expectations.datasource.fluent import PandasDatasource
+from great_expectations.datasource.fluent import GxDatasourceWarning, PandasDatasource
 from great_expectations.datasource.new_datasource import BaseDatasource, Datasource
 from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig
@@ -8421,3 +8421,11 @@ def aws_credentials():
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "testing"
+
+
+@pytest.fixture(scope="function")
+def filter_gx_datasource_warnings() -> Generator[None, None, None]:
+    """Filter out GxDatasourceWarning warnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=GxDatasourceWarning)
+        yield

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -25,7 +25,8 @@ LOGGER = logging.getLogger(__name__)
 def create_engine_spy(mocker: MockerFixture) -> Generator[mock.MagicMock, None, None]:
     spy = mocker.spy(sa, "create_engine")
     yield spy
-    assert spy.call_count >= 1, "create_engine was not called"
+    if not spy.call_count:
+        LOGGER.warning("SQLAlchemy create_engine was not called")
 
 
 @pytest.fixture

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -60,6 +60,7 @@ def test_kwargs_are_passed_to_create_engine(
     monkeypatch: pytest.MonkeyPatch,
     ephemeral_context_with_defaults: EphemeralDataContext,
     ds_kwargs: dict,
+    filter_gx_datasource_warnings: None,
 ):
     monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
 

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Generator
 from unittest import mock
 
 import pytest
 
 from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
-from great_expectations.datasource.fluent import SQLDatasource
+from great_expectations.datasource.fluent import GxDatasourceWarning, SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
 
 if TYPE_CHECKING:
@@ -16,9 +17,26 @@ if TYPE_CHECKING:
     from great_expectations.data_context import EphemeralDataContext
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 @pytest.fixture
-def create_engine_spy(mocker: MockerFixture) -> mock.MagicMock:
-    return mocker.spy(sa, "create_engine")
+def create_engine_spy(mocker: MockerFixture) -> Generator[mock.MagicMock, None, None]:
+    spy = mocker.spy(sa, "create_engine")
+    yield spy
+    assert spy.call_count >= 1, "create_engine was not called"
+
+
+@pytest.fixture
+def create_engine_fake(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Monkeypatch sqlalchemy.create_engine to always return a in-memory sqlite engine."""
+    in_memory_sqlite_engine = sa.create_engine("sqlite:///")
+
+    def _fake_create_engine(*args, **kwargs) -> sa.engine.Engine:
+        LOGGER.info(f"Mock create_engine called with {args=} {kwargs=}")
+        return in_memory_sqlite_engine
+
+    monkeypatch.setattr(sa, "create_engine", _fake_create_engine, raising=True)
 
 
 @pytest.mark.unit
@@ -187,6 +205,28 @@ def test_table_quoted_name_type_all_lower_case_normalizion_full():
             assert isinstance(table_asset.table_name, sqlalchemy.quoted_name)
             assert table_asset.table_name in table_names_in_dbms_schema
             assert table_asset.table_name in quoted_table_names
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ["connection_string", "suggested_datasource_class"],
+    [
+        ("sqlite:///", "SqliteDatasource"),
+        ("snowflake+pyodbc://", "SnowflakeDatasource"),
+        ("postgresql+psycopg2://bob:secret@localhost:5432/my_db", "PostgresDatasource"),
+        ("databricks://", "DatabricksSQLDatasource"),
+    ],
+)
+def test_specific_datasource_warnings(
+    create_engine_fake: None, connection_string: str, suggested_datasource_class: str
+):
+    """
+    This test ensures that a warning is raised when a specific datasource class is suggested.
+    """
+    with pytest.warns(GxDatasourceWarning, match=suggested_datasource_class):
+        SQLDatasource(
+            name="my_datasource", connection_string=connection_string
+        ).test_connection()
 
 
 if __name__ == "__main__":

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -142,7 +142,11 @@ def test_instantiation_via_url_with_kwargs(sa):
 
 
 @pytest.mark.sqlite
-def test_instantiation_via_fluent_data_sources_with_kwargs(sa, empty_data_context):
+def test_instantiation_via_fluent_data_sources_with_kwargs(
+    sa,
+    empty_data_context,
+    filter_gx_datasource_warnings: None,
+):
     db_file = file_relative_path(
         __file__,
         os.path.join(  # noqa: PTH118


### PR DESCRIPTION
Users can almost always use the generic `SQLDatasource` for any SQL dialect, but the experience will be better if using a more specific Datasource.

### Proposed Change

Compare the `connection_string` with our Datasource `type_lookup` to see if a more specific datasource is available and raise a warning if it is.
The warning links to our documentation and suggests a more specific Datasource class.


### Testing Considerations

Added a `filter_gx_datasource_warnings` fixture that can be used to temporarily filter out this warning in tests.