### PR TITLE
[DOCS] Remove TOC  Content Duplication

### DIFF
--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -483,8 +483,6 @@ module.exports = {
             },
             'terms/expectation_suite',
             'terms/metric',
-            'conceptual_guides/metricproviders',
-            'terms/metric',
             {
               type: 'category',
               label: 'Stores',


### PR DESCRIPTION
In the current TOC duplicate entries for MetricProviders and Metric are causing confusion. This PR removes the duplicate entries. 
