### PR TITLE
[DOCS] add `FabricPowerBIDatasource` api docs

### DIFF
--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "FabricPowerBIDatasource",
-    "description": "Microsoft Fabric Datasource.\n\nhttps://pypi.org/project/semantic-link/",
+    "description": "--Public API--\nMicrosoft Fabric Datasource.\n\nhttps://pypi.org/project/semantic-link/",
     "type": "object",
     "properties": {
         "type": {
@@ -98,7 +98,7 @@
         },
         "PowerBITable": {
             "title": "PowerBITable",
-            "description": "Microsoft PowerBI Table.",
+            "description": "--Public API--Microsoft PowerBI Table.",
             "type": "object",
             "properties": {
                 "name": {
@@ -162,7 +162,7 @@
         },
         "PowerBIMeasure": {
             "title": "PowerBIMeasure",
-            "description": "Microsoft PowerBI Measure.",
+            "description": "--Public API--Microsoft PowerBI Measure.",
             "type": "object",
             "properties": {
                 "name": {
@@ -252,7 +252,7 @@
         },
         "PowerBIDax": {
             "title": "PowerBIDax",
-            "description": "Microsoft PowerBI DAX.",
+            "description": "--Public API--Microsoft PowerBI DAX.",
             "type": "object",
             "properties": {
                 "name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
@@ -1,6 +1,6 @@
 {
     "title": "PowerBIDax",
-    "description": "Microsoft PowerBI DAX.",
+    "description": "--Public API--Microsoft PowerBI DAX.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
@@ -1,6 +1,6 @@
 {
     "title": "PowerBIMeasure",
-    "description": "Microsoft PowerBI Measure.",
+    "description": "--Public API--Microsoft PowerBI Measure.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
@@ -1,6 +1,6 @@
 {
     "title": "PowerBITable",
-    "description": "Microsoft PowerBI Table.",
+    "description": "--Public API--Microsoft PowerBI Table.",
     "type": "object",
     "properties": {
         "name": {

--- a/great_expectations/experimental/datasource/fabric.py
+++ b/great_expectations/experimental/datasource/fabric.py
@@ -25,6 +25,7 @@ from typing_extensions import Annotated, TypeAlias
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.core.batch_spec import FabricBatchSpec
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
@@ -177,6 +178,7 @@ class _PowerBIAsset(DataAsset):
             )
 
 
+@public_api
 class PowerBIDax(_PowerBIAsset):
     """Microsoft PowerBI DAX."""
 
@@ -187,6 +189,7 @@ class PowerBIDax(_PowerBIAsset):
     pandas_convert_dtypes: bool = True
 
 
+@public_api
 class PowerBIMeasure(_PowerBIAsset):
     """Microsoft PowerBI Measure."""
 
@@ -202,6 +205,7 @@ class PowerBIMeasure(_PowerBIAsset):
     use_xmla: bool = False
 
 
+@public_api
 class PowerBITable(_PowerBIAsset):
     """Microsoft PowerBI Table."""
 
@@ -224,6 +228,7 @@ AssetTypes = Annotated[
 ]
 
 
+@public_api
 class FabricPowerBIDatasource(Datasource):
     """
     Microsoft Fabric Datasource.
@@ -287,6 +292,7 @@ class FabricPowerBIDatasource(Datasource):
                 asset._datasource = self
                 asset.test_connection()
 
+    @public_api
     def add_powerbi_dax_asset(  # noqa: PLR0913
         self,
         name: str,
@@ -316,6 +322,7 @@ class FabricPowerBIDatasource(Datasource):
         )
         return self._add_asset(asset)
 
+    @public_api
     def add_powerbi_measure_asset(  # noqa: PLR0913
         self,
         name: str,
@@ -355,6 +362,7 @@ class FabricPowerBIDatasource(Datasource):
         )
         return self._add_asset(asset)
 
+    @public_api
     def add_powerbi_table_asset(  # noqa: PLR0913
         self,
         name: str,


### PR DESCRIPTION
Add `@public_api` decorators to `FabricPowerBIDatasource` so that it starts showing up in our API docs.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
