### PR TITLE
[DOCS]  Document Add Data Asset to Existing Data Source Functionality

### DIFF
--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -97,6 +97,27 @@ The following table lists the available Data Asset metrics.
 | **Null %**                                | The percentage of missing values in a column.             |
 
 
+## Add a Data Asset to an Existing Data Source
+
+1. In GX Cloud, click **Data Assets** and then select **New Data Asset**.
+
+2. Click the **Existing Data Source** tab and then select a Data Source.
+
+3. Click **Add another Data Asset**.
+
+4. Select **Table Asset** or **Query Asset** and complete the following fields:
+
+    - **Asset name**: Enter a name for the Data Asset. Data Asset names must be unique. If you use the same name for multiple Data Assets, each Data Asset must be associated with a unique Data Source.
+
+    - **Table name**: When **Table Asset** is selected, enter a name for the table you're creating in the Data Asset.
+
+    - **Query**: When **Query Asset** is selected, enter the query that you want to run on the table. 
+
+5. Optional. Select **Add another Data Asset** to add additional tables or queries and repeat step 4.
+
+6. Click **Finish**.
+
+
 ## Edit a Data Asset
 
 1. In Jupyter Notebook, run the following code to import the `great_expectations` module and the existing Data Context:

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -99,9 +99,11 @@ The following table lists the available Data Asset metrics.
 
 ## Add a Data Asset to an Existing Data Source
 
+Additional Data Assets can only be added to an existing Snowflake Data Source.
+
 1. In GX Cloud, click **Data Assets** and then select **New Data Asset**.
 
-2. Click the **Existing Data Source** tab and then select a Data Source.
+2. Click the **Existing Data Source** tab and then select a Snowflake Data Source.
 
 3. Click **Add another Data Asset**.
 

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -102,7 +102,7 @@ module.exports = {
             {
               type: 'link',
               label: 'Add a Data Asset to an Existing Data Source',
-              href: '/docs/cloud/data_assets//manage_data_assets#add-a-data-asset-to-an-existing-data-source',
+              href: '/docs/cloud/data_assets/manage_data_assets#add-a-data-asset-to-an-existing-data-source',
             },
             {
               type: 'link',

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -101,6 +101,11 @@ module.exports = {
             },
             {
               type: 'link',
+              label: 'Add a Data Asset to an Existing Data Source',
+              href: '/docs/cloud/data_assets//manage_data_assets#add-a-data-asset-to-an-existing-data-source',
+            },
+            {
+              type: 'link',
               label: 'Edit a Data Asset',
               href: '/docs/cloud/data_assets/manage_data_assets#edit-a-data-asset',
             },


### PR DESCRIPTION
[DOC-610](https://greatexpectations.atlassian.net/browse/DOC-610) requests the addition of content to [Manage Data Assets](https://docs.greatexpectations.io/docs/cloud/data_assets/manage_data_assets) that documents the process of adding a Data Asset to an existing Data Source. This PR implements this update.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated

[DOC-610]: https://greatexpectations.atlassian.net/browse/DOC-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ