### PR TITLE
[MAINTENANCE] Refactor ExpectationSuite.expectations

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -256,6 +256,9 @@ class ExpectationSuite(SerializableDictDot):
         memo[id(self)] = result
 
         attributes_to_copy = set(ExpectationSuiteSchema().fields.keys())
+        # map expectations to expectation_configurations
+        attributes_to_copy.remove("expectations")
+        attributes_to_copy.add("expectation_configurations")
         for key in attributes_to_copy:
             setattr(result, key, deepcopy(getattr(self, key)))
 

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -277,7 +277,9 @@ class ExpectationSuite(SerializableDictDot):
         myself = expectationSuiteSchema.dump(self)
         # NOTE - JPC - 20191031: migrate to expectation-specific schemas that subclass result with properly-typed
         # schemas to get serialization all-the-way down via dump
-        myself["expectations"] = convert_to_json_serializable(myself["expectations"])
+        myself["expectations"] = convert_to_json_serializable(
+            myself["expectation_configurations"]
+        )
         try:
             myself["evaluation_parameters"] = convert_to_json_serializable(
                 myself["evaluation_parameters"]

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -781,7 +781,6 @@ class ExpectationSuite(SerializableDictDot):
         try:
             class_ = get_expectation_impl(expectation_configuration.expectation_type)
             expectation = class_(configuration=expectation_configuration)
-            expectation.validate_configuration(expectation_configuration)
             return expectation
         except (
             gx_exceptions.ExpectationNotFoundError,

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -780,7 +780,7 @@ class ExpectationSuite(SerializableDictDot):
     ) -> Expectation:
         try:
             class_ = get_expectation_impl(expectation_configuration.expectation_type)
-            expectation = class_()
+            expectation = class_(configuration=expectation_configuration)
             expectation.validate_configuration(expectation_configuration)
             return expectation
         except (

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -1149,9 +1149,11 @@ class ExpectationSuiteSchema(Schema):
 
     @post_dump(pass_original=True)
     def insert_expectations(self, data, original_data, **kwargs) -> dict:
-        data["expectations"] = convert_to_json_serializable(
-            original_data.expectation_configurations
-        )
+        if isinstance(original_data, dict):
+            expectations = original_data.get("expectations", [])
+        else:
+            expectations = original_data.expectation_configurations
+        data["expectations"] = convert_to_json_serializable(expectations)
         return data
 
     @post_load

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -278,7 +278,7 @@ class ExpectationSuite(SerializableDictDot):
         # NOTE - JPC - 20191031: migrate to expectation-specific schemas that subclass result with properly-typed
         # schemas to get serialization all-the-way down via dump
         myself["expectations"] = convert_to_json_serializable(
-            myself["expectation_configurations"]
+            self.expectation_configurations
         )
         try:
             myself["evaluation_parameters"] = convert_to_json_serializable(

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -473,7 +473,7 @@ class DataAsset:
         """
 
         expectation_suite = copy.deepcopy(self._expectation_suite)
-        expectations = expectation_suite.expectations
+        expectations = expectation_suite.expectation_configurations
 
         discards = defaultdict(int)
 
@@ -536,7 +536,7 @@ class DataAsset:
         ):  # Only add this if we added one of the settings above.
             settings_message += " settings filtered."
 
-        expectation_suite.expectations = expectations
+        expectation_suite.expectation_configurations = expectations
         if not suppress_logging:
             logger.info(message + settings_message)
         return expectation_suite
@@ -781,7 +781,7 @@ class DataAsset:
             # Group expectations by column
             columns = {}
 
-            for expectation in expectation_suite.expectations:
+            for expectation in expectation_suite.expectation_configurations:
                 if "column" in expectation.kwargs and isinstance(
                     expectation.kwargs["column"], Hashable
                 ):

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3646,7 +3646,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             new_column_count = len(
                 {
                     exp.kwargs["column"]
-                    for exp in expectation_suite.expectations
+                    for exp in expectation_suite.expectation_configurations
                     if "column" in exp.kwargs
                 }
             )

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -736,7 +736,9 @@ Notes:
                 )
             )
             if len(existing_expectations) == 1:
-                self._expectation_suite.expectations.pop(existing_expectations[0])
+                self._expectation_suite.expectation_configurations.pop(
+                    existing_expectations[0]
+                )
 
             # Now, rename the expectation we just added
             new_expectations = self._expectation_suite.find_expectation_indexes(
@@ -746,14 +748,18 @@ Notes:
                 )
             )
             assert len(new_expectations) == 1
-            old_config = self._expectation_suite.expectations[new_expectations[0]]
+            old_config = self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ]
             new_config = ExpectationConfiguration(
                 expectation_type="expect_column_values_to_be_of_type",
                 kwargs=old_config.kwargs,
                 meta=old_config.meta,
                 success_on_last_run=old_config.success_on_last_run,
             )
-            self._expectation_suite.expectations[new_expectations[0]] = new_config
+            self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ] = new_config
         else:
             res = self._expect_column_values_to_be_of_type__map(column, type_, **kwargs)
             # Note: this logic is similar to the logic in _append_expectation for deciding when to overwrite an
@@ -772,7 +778,9 @@ Notes:
                 )
             )
             if len(existing_expectations) == 1:
-                self._expectation_suite.expectations.pop(existing_expectations[0])
+                self._expectation_suite.expectation_configurations.pop(
+                    existing_expectations[0]
+                )
 
             # Now, rename the expectation we just added
             new_expectations = self._expectation_suite.find_expectation_indexes(
@@ -782,14 +790,18 @@ Notes:
                 )
             )
             assert len(new_expectations) == 1
-            old_config = self._expectation_suite.expectations[new_expectations[0]]
+            old_config = self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ]
             new_config = ExpectationConfiguration(
                 expectation_type="expect_column_values_to_be_of_type",
                 kwargs=old_config.kwargs,
                 meta=old_config.meta,
                 success_on_last_run=old_config.success_on_last_run,
             )
-            self._expectation_suite.expectations[new_expectations[0]] = new_config
+            self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ] = new_config
 
         return res
 
@@ -959,7 +971,9 @@ Notes:
                 )
             )
             if len(existing_expectations) == 1:
-                self._expectation_suite.expectations.pop(existing_expectations[0])
+                self._expectation_suite.expectation_configurations.pop(
+                    existing_expectations[0]
+                )
 
             new_expectations = self._expectation_suite.find_expectation_indexes(
                 ExpectationConfiguration(
@@ -968,14 +982,18 @@ Notes:
                 )
             )
             assert len(new_expectations) == 1
-            old_config = self._expectation_suite.expectations[new_expectations[0]]
+            old_config = self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ]
             new_config = ExpectationConfiguration(
                 expectation_type="expect_column_values_to_be_in_type_list",
                 kwargs=old_config.kwargs,
                 meta=old_config.meta,
                 success_on_last_run=old_config.success_on_last_run,
             )
-            self._expectation_suite.expectations[new_expectations[0]] = new_config
+            self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ] = new_config
         else:
             res = self._expect_column_values_to_be_in_type_list__map(
                 column, type_list, **kwargs
@@ -996,7 +1014,9 @@ Notes:
                 )
             )
             if len(existing_expectations) == 1:
-                self._expectation_suite.expectations.pop(existing_expectations[0])
+                self._expectation_suite.expectation_configurations.pop(
+                    existing_expectations[0]
+                )
 
             # Now, rename the expectation we just added
             new_expectations = self._expectation_suite.find_expectation_indexes(
@@ -1006,14 +1026,18 @@ Notes:
                 )
             )
             assert len(new_expectations) == 1
-            old_config = self._expectation_suite.expectations[new_expectations[0]]
+            old_config = self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ]
             new_config = ExpectationConfiguration(
                 expectation_type="expect_column_values_to_be_in_type_list",
                 kwargs=old_config.kwargs,
                 meta=old_config.meta,
                 success_on_last_run=old_config.success_on_last_run,
             )
-            self._expectation_suite.expectations[new_expectations[0]] = new_config
+            self._expectation_suite.expectation_configurations[
+                new_expectations[0]
+            ] = new_config
 
         return res
 

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -351,7 +351,7 @@ def display_column_expectations_as_section(
     # TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
     column_expectation_list = [
         e
-        for e in expectation_suite.expectations
+        for e in expectation_suite.expectation_configurations
         if "column" in e.kwargs and e.kwargs["column"] == column
     ]
 

--- a/great_expectations/profile/base.py
+++ b/great_expectations/profile/base.py
@@ -206,9 +206,10 @@ class DatasetProfiler(DataAssetProfiler):
             expectation_suite.meta[class_name]["batch_kwargs"] = batch_kwargs
 
         new_expectations = [
-            cls.add_expectation_meta(exp) for exp in expectation_suite.expectations
+            cls.add_expectation_meta(exp)
+            for exp in expectation_suite.expectation_configurations
         ]
-        expectation_suite.expectations = new_expectations
+        expectation_suite.expectation_configurations = new_expectations
 
         if "notes" not in expectation_suite.meta:
             expectation_suite.meta["notes"] = {

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -738,7 +738,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
         Returns:
             The ExpectationSuite
         """
-        expectations = suite.expectations
+        expectations = suite.expectation_configurations
         expectations_by_column = {}
         for expectation in expectations:
             domain = expectation["kwargs"].get("column") or "table_level_expectations"

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -803,7 +803,7 @@ class ExpectationSuitePageRenderer(Renderer):
 
         total_expectations = len(expectations.expectations)
         columns = []
-        for exp in expectations.expectations:
+        for exp in expectations.expectation_configurations:
             if "column" in exp.kwargs:
                 columns.append(exp.kwargs["column"])
         total_columns = len(set(columns))

--- a/great_expectations/render/renderer/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/suite_edit_notebook_renderer.py
@@ -292,7 +292,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
             suite_name, batch_kwargs, suite_notes=suite.meta.get("notes", None)
         )
         self.add_authoring_intro()
-        self.add_expectation_cells_from_suite(suite.expectations)
+        self.add_expectation_cells_from_suite(suite.expectation_configurations)
         self.add_footer()
 
         return self._notebook

--- a/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
@@ -378,7 +378,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         self.add_header(suite_name=suite_name, batch_request=batch_request)
         self.add_authoring_intro(batch_request=batch_request)
         self.add_expectation_cells_from_suite(
-            expectations=suite.expectations, batch_request=batch_request
+            expectations=suite.expectation_configurations, batch_request=batch_request
         )
         self.add_footer(batch_request=batch_request)
 

--- a/great_expectations/validator/v1_validator.py
+++ b/great_expectations/validator/v1_validator.py
@@ -60,7 +60,9 @@ class Validator:
         self, expectation_suite: ExpectationSuite
     ) -> ExpectationSuiteValidationResult:
         """Run an expectation suite against the batch config"""
-        results = self._validate_expectation_configs(expectation_suite.expectations)
+        results = self._validate_expectation_configs(
+            expectation_suite.expectation_configurations
+        )
         statistics = calc_validation_statistics(results)
 
         # TODO: This was copy/pasted from Validator, but many fields were removed

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1398,7 +1398,7 @@ class Validator:
         """
 
         expectation_suite = copy.deepcopy(self.expectation_suite)
-        expectations = expectation_suite.expectations
+        expectations = expectation_suite.expectation_configurations
 
         discards: defaultdict[str, int] = defaultdict(int)
 
@@ -1461,7 +1461,7 @@ class Validator:
         ):  # Only add this if we added one of the settings above.
             settings_message += " settings filtered."
 
-        expectation_suite.expectations = expectations
+        expectation_suite.expectation_configurations = expectations
         if not suppress_logging:
             logger.info(message + settings_message)
         return expectation_suite

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1652,7 +1652,7 @@ class Validator:
             # Group expectations by column
             columns: dict[Any, list[ExpectationConfiguration]] = {}
 
-            for expectation in expectation_suite.expectations:
+            for expectation in expectation_suite.expectation_configurations:
                 expectation.process_evaluation_parameters(
                     evaluation_parameters=runtime_evaluation_parameters,
                     interactive_evaluation=self.interactive_evaluation,

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -3190,7 +3190,7 @@ def test_suite_new_profile_runs_notebook_no_jupyter(  # noqa: PLR0915
 
     expectation_configurations: List[ExpectationConfiguration] = []
     expectation_configuration: ExpectationConfiguration
-    for expectation_configuration in suite.expectations:
+    for expectation_configuration in suite.expectation_configurations:
         kwargs: dict = expectation_configuration.kwargs
         key: str
         value: Any
@@ -3416,7 +3416,7 @@ def test_suite_new_profile_runs_notebook_opens_jupyter(  # noqa: PLR0915
 
     expectation_configurations: List[ExpectationConfiguration] = []
     expectation_configuration: ExpectationConfiguration
-    for expectation_configuration in suite.expectations:
+    for expectation_configuration in suite.expectation_configurations:
         kwargs: dict = expectation_configuration.kwargs
         key: str
         value: Any

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -119,7 +119,9 @@ class TestInit:
         )
         assert suite.expectation_suite_name == fake_expectation_suite_name
         assert suite._data_context == dummy_data_context
-        assert suite.expectations == [expect_column_values_to_be_in_set_col_a_with_meta]
+        assert suite.expectation_configurations == [
+            expect_column_values_to_be_in_set_col_a_with_meta
+        ]
         assert suite.evaluation_parameters == test_evaluation_parameters
         assert suite.data_asset_type == test_data_asset_type
         assert suite.execution_engine_type == dummy_execution_engine_type
@@ -156,7 +158,7 @@ class TestInit:
             expect_column_values_to_be_in_set_col_a_with_meta,
         ]
         assert len(suite.expectations) == 2
-        assert suite.expectations == test_expected_expectations
+        assert suite.expectation_configurations == test_expected_expectations
 
     @pytest.mark.unit
     def test_expectation_suite_init_overrides_non_json_serializable_meta(
@@ -379,7 +381,7 @@ class TestIsEquivalentTo:
         self, suite_with_single_expectation: ExpectationSuite
     ):
         modified_suite = deepcopy(suite_with_single_expectation)
-        modified_suite.expectations[0]["kwargs"]["value_set"][0] = -1
+        modified_suite.expectation_configurations[0]["kwargs"]["value_set"][0] = -1
 
         modified_suite_dict: dict = expectationSuiteSchema.dump(modified_suite)
 
@@ -431,7 +433,7 @@ class TestIsEquivalentTo:
         """Only expectation equivalence is considered for suite equivalence. Marked as integration since this uses the ExpectationConfiguration.isEquivalentTo() under the hood."""
         different_and_not_equivalent_suite = deepcopy(suite_with_single_expectation)
         # Set different column in expectation kwargs
-        different_and_not_equivalent_suite.expectations[0].kwargs = {
+        different_and_not_equivalent_suite.expectation_configurations[0].kwargs = {
             "column": "b",
             "value_set": [1, 2, 3],
             "result_format": "BASIC",
@@ -451,8 +453,8 @@ class TestIsEquivalentTo:
         """Only expectation equivalence is considered for suite equivalence, and the same number of expectations in the suite is required for equivalence. Marked as integration since this uses the ExpectationConfiguration.isEquivalentTo() under the hood."""
         different_and_not_equivalent_suite = deepcopy(suite_with_single_expectation)
         # Add a copy of the existing expectation, using list .append() to bypass add_expectation logic to handle overwrite
-        different_and_not_equivalent_suite.expectations.append(
-            different_and_not_equivalent_suite.expectations[0]
+        different_and_not_equivalent_suite.expectation_configurations.append(
+            different_and_not_equivalent_suite.expectation_configurations[0]
         )
         assert len(suite_with_single_expectation.expectations) == 1
         assert len(different_and_not_equivalent_suite.expectations) == 2
@@ -650,7 +652,7 @@ def suite_with_table_and_column_expectations(
         meta={"notes": "This is an expectation suite."},
         data_context=context,
     )
-    assert suite.expectations == [
+    assert suite.expectation_configurations == [
         expect_column_values_to_be_in_set_col_a_with_meta,
         exp2,
         exp3,
@@ -728,9 +730,9 @@ def test_expectation_suite_copy(baseline_suite):
     assert (
         baseline_suite.data_asset_type != "blarg"
     )  # copy on primitive properties shouldn't propagate
-    suite_copy.expectations[0].meta["notes"] = "a different note"
+    suite_copy.expectation_configurations[0].meta["notes"] = "a different note"
     assert (
-        baseline_suite.expectations[0].meta["notes"] == "a different note"
+        baseline_suite.expectation_configurations[0].meta["notes"] == "a different note"
     )  # copy on deep attributes does propagate
 
 
@@ -742,9 +744,12 @@ def test_expectation_suite_deepcopy(baseline_suite):
     assert (
         baseline_suite.data_asset_type != "blarg"
     )  # copy on primitive properties shouldn't propagate
-    suite_deepcopy.expectations[0].meta["notes"] = "a different note"
+    suite_deepcopy.expectation_configurations[0].meta["notes"] = "a different note"
     # deepcopy on deep attributes does not propagate
-    assert baseline_suite.expectations[0].meta["notes"] == "This is an expectation."
+    assert (
+        baseline_suite.expectation_configurations[0].meta["notes"]
+        == "This is an expectation."
+    )
 
 
 @pytest.mark.unit

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -504,7 +504,7 @@ class TestEqDunder:
                     reason="Currently data_context is not considered in ExpectationSuite equality",
                 ),
             ),
-            pytest.param("expectations", []),
+            pytest.param("expectation_configurations", []),
             pytest.param(
                 "evaluation_parameters", {"different": "evaluation_parameters"}
             ),

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -225,7 +225,7 @@ def suite_with_table_and_column_expectations(
         meta={"notes": "This is an expectation suite."},
         data_context=context,
     )
-    assert suite.expectations == [
+    assert suite.expectation_configurations == [
         exp1,
         exp2,
         exp3,
@@ -259,7 +259,7 @@ def suite_with_column_pair_and_table_expectations(
         meta={"notes": "This is an expectation suite."},
         data_context=context,
     )
-    assert suite.expectations == [
+    assert suite.expectation_configurations == [
         column_pair_expectation,
         table_exp1,
         table_exp2,
@@ -442,11 +442,11 @@ def test_remove_expectation_without_necessary_args(single_expectation_suite):
 
 @pytest.mark.filesystem
 def test_patch_expectation_replace(exp5, exp6, domain_success_runtime_suite):
-    assert domain_success_runtime_suite.expectations[4] is exp5
+    assert domain_success_runtime_suite.expectation_configurations[4] is exp5
 
-    assert not domain_success_runtime_suite.expectations[4].isEquivalentTo(
-        exp6, match_type="success"
-    )
+    assert not domain_success_runtime_suite.expectation_configurations[
+        4
+    ].isEquivalentTo(exp6, match_type="success")
     domain_success_runtime_suite.patch_expectation(
         exp5,
         op="replace",
@@ -454,18 +454,18 @@ def test_patch_expectation_replace(exp5, exp6, domain_success_runtime_suite):
         value=[1, 2],
         match_type="runtime",
     )
-    assert domain_success_runtime_suite.expectations[4].isEquivalentTo(
+    assert domain_success_runtime_suite.expectation_configurations[4].isEquivalentTo(
         exp6, match_type="success"
     )
 
 
 @pytest.mark.filesystem
 def test_patch_expectation_add(exp5, exp7, domain_success_runtime_suite):
-    assert domain_success_runtime_suite.expectations[4] is exp5
+    assert domain_success_runtime_suite.expectation_configurations[4] is exp5
 
-    assert not domain_success_runtime_suite.expectations[4].isEquivalentTo(
-        exp7, match_type="success"
-    )
+    assert not domain_success_runtime_suite.expectation_configurations[
+        4
+    ].isEquivalentTo(exp7, match_type="success")
     domain_success_runtime_suite.patch_expectation(
         exp5,
         op="add",
@@ -473,18 +473,18 @@ def test_patch_expectation_add(exp5, exp7, domain_success_runtime_suite):
         value=4,
         match_type="runtime",
     )
-    assert domain_success_runtime_suite.expectations[4].isEquivalentTo(
+    assert domain_success_runtime_suite.expectation_configurations[4].isEquivalentTo(
         exp7, match_type="success"
     )
 
 
 @pytest.mark.filesystem
 def test_patch_expectation_remove(exp5, exp8, domain_success_runtime_suite):
-    assert domain_success_runtime_suite.expectations[4] is exp5
+    assert domain_success_runtime_suite.expectation_configurations[4] is exp5
 
-    assert not domain_success_runtime_suite.expectations[4].isEquivalentTo(
-        exp8, match_type="runtime"
-    )
+    assert not domain_success_runtime_suite.expectation_configurations[
+        4
+    ].isEquivalentTo(exp8, match_type="runtime")
     domain_success_runtime_suite.patch_expectation(
         exp5,
         op="remove",
@@ -492,7 +492,7 @@ def test_patch_expectation_remove(exp5, exp8, domain_success_runtime_suite):
         value=None,
         match_type="runtime",
     )
-    assert domain_success_runtime_suite.expectations[4].isEquivalentTo(
+    assert domain_success_runtime_suite.expectation_configurations[4].isEquivalentTo(
         exp8, match_type="runtime"
     )
 
@@ -625,11 +625,9 @@ def test_add_expectation_with_ge_cloud_id(
     """
     This test ensures that expectation does not lose ge_cloud_id attribute when updated
     """
-    expectation_ge_cloud_id = (
-        single_expectation_suite_with_expectation_ge_cloud_id.expectations[
-            0
-        ].ge_cloud_id
-    )
+    expectation_ge_cloud_id = single_expectation_suite_with_expectation_ge_cloud_id.expectation_configurations[
+        0
+    ].ge_cloud_id
     # updated expectation does not have ge_cloud_id
     updated_expectation = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -644,15 +642,23 @@ def test_add_expectation_with_ge_cloud_id(
         updated_expectation, overwrite_existing=True
     )
     assert (
-        single_expectation_suite_with_expectation_ge_cloud_id.expectations[
+        single_expectation_suite_with_expectation_ge_cloud_id.expectation_configurations[
             0
         ].ge_cloud_id
         == expectation_ge_cloud_id
     )
     # make sure expectation config was actually updated
-    assert single_expectation_suite_with_expectation_ge_cloud_id.expectations[0].kwargs[
+    assert single_expectation_suite_with_expectation_ge_cloud_id.expectation_configurations[
+        0
+    ].kwargs[
         "value_set"
-    ] == [11, 22, 33, 44, 55]
+    ] == [
+        11,
+        22,
+        33,
+        44,
+        55,
+    ]
 
     # ensure usage statistics are being emitted correctly
     assert mock_emit.call_count == 1
@@ -688,7 +694,7 @@ def test_remove_all_expectations_of_type(
 @pytest.mark.cloud
 def test_replace_expectation_replaces_expectation(ge_cloud_suite, ge_cloud_id, exp1):
     # The state of the first expectation before update
-    expectation_before_update = ge_cloud_suite.expectations[0]
+    expectation_before_update = ge_cloud_suite.expectation_configurations[0]
     assert expectation_before_update["kwargs"]["column"] == "a"
     assert expectation_before_update["kwargs"]["value_set"] == [1, 2, 3]
     assert expectation_before_update["meta"]["notes"] == "This is an expectation."
@@ -705,7 +711,7 @@ def test_replace_expectation_replaces_expectation(ge_cloud_suite, ge_cloud_id, e
     )
 
     # The state of the first expectation after update
-    expectation_after_update = ge_cloud_suite.expectations[0]
+    expectation_after_update = ge_cloud_suite.expectation_configurations[0]
     assert expectation_after_update["kwargs"]["column"] == "b"
     assert expectation_after_update["kwargs"]["value_set"] == [4, 5, 6]
     assert (

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -177,7 +177,7 @@ def test_expectation_meta():
     k = 0
     assert True is result.success
     suite = df.get_expectation_suite()
-    for expectation_config in suite.expectations:
+    for expectation_config in suite.expectation_configurations:
         if expectation_config.expectation_type == "expect_column_median_to_be_between":
             k += 1
             assert {"notes": "This expectation is for lolz."} == expectation_config.meta
@@ -737,19 +737,19 @@ def test_discard_failing_expectations():
     sub1 = df[:3]
 
     sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df[1:2]
     sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df[:-1]
     sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df[-1:]
     sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df[["A", "D"]]
     exp1 = [
@@ -770,7 +770,7 @@ def test_discard_failing_expectations():
     ]
     with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
         sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df[["A"]]
     exp1 = [
@@ -784,7 +784,7 @@ def test_discard_failing_expectations():
     ]
     with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
         sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df.iloc[:3, 1:4]
     exp1 = [
@@ -812,7 +812,7 @@ def test_discard_failing_expectations():
     ]
     with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
         sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
     sub1 = df.loc[0:, "A":"B"]
     exp1 = [
@@ -833,7 +833,7 @@ def test_discard_failing_expectations():
     ]
     with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
         sub1.discard_failing_expectations()
-    assert sub1.get_expectation_suite().expectations == exp1
+    assert sub1.get_expectation_suite().expectation_configurations == exp1
 
 
 @pytest.mark.unit

--- a/tests/data_asset/test_expectation_decorators.py
+++ b/tests/data_asset/test_expectation_decorators.py
@@ -42,7 +42,7 @@ def test_expectation_decorator_build_config():
     config = eds.get_expectation_suite()
     assert (
         ExpectationConfiguration(expectation_type="no_op_expectation", kwargs={})
-        == config.expectations[0]
+        == config.expectation_configurations[0]
     )
 
     assert (
@@ -50,7 +50,7 @@ def test_expectation_decorator_build_config():
             expectation_type="no_op_value_expectation",
             kwargs={"value": "a"},
         )
-        == config.expectations[1]
+        == config.expectation_configurations[1]
     )
 
 
@@ -77,7 +77,9 @@ def test_expectation_decorator_meta():
 
     assert (
         ExpectationValidationResult(
-            success=True, meta=metadata, expectation_config=config.expectations[0]
+            success=True,
+            meta=metadata,
+            expectation_config=config.expectation_configurations[0],
         )
         == out
     )
@@ -88,7 +90,7 @@ def test_expectation_decorator_meta():
             kwargs={"value": "a"},
             meta=metadata,
         )
-        == config.expectations[0]
+        == config.expectation_configurations[0]
     )
 
 

--- a/tests/data_asset/test_filedata_asset.py
+++ b/tests/data_asset/test_filedata_asset.py
@@ -61,7 +61,7 @@ def test_expectation_suite_filedata_asset():
             expectation_type="expect_file_line_regex_match_count_to_equal",
             kwargs={"expected_count": 3, "regex": ",\\S", "skip": 1},
         )
-    ] == complete_config.expectations
+    ] == complete_config.expectation_configurations
 
     # Include result format kwargs
     complete_config2 = f_dat.get_expectation_suite(
@@ -86,7 +86,7 @@ def test_expectation_suite_filedata_asset():
                 "skip": 1,
             },
         ),
-    ] == complete_config2.expectations
+    ] == complete_config2.expectation_configurations
 
     # Discard Failing Expectations
     complete_config3 = f_dat.get_expectation_suite(
@@ -103,7 +103,7 @@ def test_expectation_suite_filedata_asset():
                 "skip": 1,
             },
         )
-    ] == complete_config3.expectations
+    ] == complete_config3.expectation_configurations
 
 
 @pytest.mark.filesystem

--- a/tests/data_asset/test_parameter_substitution.py
+++ b/tests/data_asset/test_parameter_substitution.py
@@ -139,7 +139,7 @@ def test_parameter_substitution(single_expectation_custom_data_asset):
     # Ensure our value has been substituted during evaluation, and set properly in the suite
     assert result.result["details"]["expectation_argument"] == "upstream_dag_value"
     assert suite.evaluation_parameters == {"upstream_dag_key": "upstream_dag_value"}
-    assert suite.expectations[0].kwargs == {
+    assert suite.expectation_configurations[0].kwargs == {
         "expectation_argument": {"$PARAMETER": "upstream_dag_key"}
     }
 
@@ -163,7 +163,7 @@ def test_parameter_substitution_with_validator(validator_with_titanic_1911_asset
     # Ensure our value has been substituted during evaluation, and set properly in the suite
     assert result.result["details"]["expectation_argument"] == "upstream_dag_value"
     assert suite.evaluation_parameters == {"upstream_dag_key": "upstream_dag_value"}
-    assert suite.expectations[0].kwargs == {
+    assert suite.expectation_configurations[0].kwargs == {
         "expectation_argument": {"$PARAMETER": "upstream_dag_key"}
     }
 
@@ -182,7 +182,7 @@ def test_exploratory_parameter_substitution(single_expectation_custom_data_asset
     # Ensure our value has been substituted during evaluation, and NOT stored in the suite
     assert result.result["details"]["expectation_argument"] == "temporary_value"
     assert suite.evaluation_parameters == {}
-    assert suite.expectations[0].kwargs == {
+    assert suite.expectation_configurations[0].kwargs == {
         "expectation_argument": {"$PARAMETER": "upstream_dag_key"}
     }
 
@@ -218,7 +218,7 @@ def test_exploratory_parameter_substitution_with_validator(
     # Ensure our value has been substituted during evaluation, and NOT stored in the suite
     assert result.result["details"]["expectation_argument"] == "temporary_value"
     assert suite.evaluation_parameters == {}
-    assert suite.expectations[0].kwargs == {
+    assert suite.expectation_configurations[0].kwargs == {
         "expectation_argument": {"$PARAMETER": "upstream_dag_key"}
     }
 

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -676,7 +676,9 @@ def test_get_expectation_suite_include_rendered_content_prescriptive(
         )
     )
     assert (
-        expectation_suite_exclude_rendered_content.expectations[0].rendered_content
+        expectation_suite_exclude_rendered_content.expectation_configurations[
+            0
+        ].rendered_content
         is None
     )
 
@@ -712,6 +714,8 @@ def test_get_expectation_suite_include_rendered_content_prescriptive(
         )
     )
     assert (
-        expectation_suite_include_rendered_content.expectations[0].rendered_content
+        expectation_suite_include_rendered_content.expectation_configurations[
+            0
+        ].rendered_content
         == expected_expectation_configuration_prescriptive_rendered_content
     )

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -50,12 +50,12 @@ def test_cloud_backed_data_context_add_or_update_expectation_suite_include_rende
         expectation_suite: ExpectationSuite = context.add_or_update_expectation_suite(
             "test_suite"
         )
-    expectation_suite.expectations.append(
+    expectation_suite.expectation_configurations.append(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_equal", kwargs={"value": 10}
         )
     )
-    assert expectation_suite.expectations[0].rendered_content is None
+    assert expectation_suite.expectation_configurations[0].rendered_content is None
 
     with mock.patch(
         "great_expectations.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend.list_keys"

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -198,7 +198,7 @@ def test_save_expectation_suite(data_context_parameterized_expectation_suite):
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    expectation_suite.expectations.append(
+    expectation_suite.expectation_configurations.append(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_equal", kwargs={"value": 10}
         )
@@ -211,7 +211,10 @@ def test_save_expectation_suite(data_context_parameterized_expectation_suite):
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    assert expectation_suite.expectations == expectation_suite_saved.expectations
+    assert (
+        expectation_suite.expectation_configurations
+        == expectation_suite_saved.expectation_configurations
+    )
 
 
 @pytest.mark.filesystem
@@ -223,12 +226,12 @@ def test_save_expectation_suite_include_rendered_content(
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    expectation_suite.expectations.append(
+    expectation_suite.expectation_configurations.append(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_equal", kwargs={"value": 10}
         )
     )
-    for expectation in expectation_suite.expectations:
+    for expectation in expectation_suite.expectation_configurations:
         assert expectation.rendered_content is None
     data_context_parameterized_expectation_suite.save_expectation_suite(
         expectation_suite,
@@ -239,7 +242,7 @@ def test_save_expectation_suite_include_rendered_content(
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    for expectation in expectation_suite_saved.expectations:
+    for expectation in expectation_suite_saved.expectation_configurations:
         for rendered_content_block in expectation.rendered_content:
             assert isinstance(
                 rendered_content_block,
@@ -256,12 +259,12 @@ def test_get_expectation_suite_include_rendered_content(
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    expectation_suite.expectations.append(
+    expectation_suite.expectation_configurations.append(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_equal", kwargs={"value": 10}
         )
     )
-    for expectation in expectation_suite.expectations:
+    for expectation in expectation_suite.expectation_configurations:
         assert expectation.rendered_content is None
     data_context_parameterized_expectation_suite.save_expectation_suite(
         expectation_suite,
@@ -271,7 +274,7 @@ def test_get_expectation_suite_include_rendered_content(
             "this_data_asset_config_does_not_exist.default"
         )
     )
-    for expectation in expectation_suite.expectations:
+    for expectation in expectation_suite.expectation_configurations:
         assert expectation.rendered_content is None
 
     expectation_suite_retrieved: ExpectationSuite = (
@@ -281,7 +284,7 @@ def test_get_expectation_suite_include_rendered_content(
         )
     )
 
-    for expectation in expectation_suite_retrieved.expectations:
+    for expectation in expectation_suite_retrieved.expectation_configurations:
         for rendered_content_block in expectation.rendered_content:
             assert isinstance(
                 rendered_content_block,
@@ -2874,7 +2877,7 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
     )
     assert not any(
         expectation_configuration.rendered_content
-        for expectation_configuration in expectation_suite.expectations
+        for expectation_configuration in expectation_suite.expectation_configurations
     )
 
     # Once we include_rendered_content, we get rendered_content on each ExpectationConfiguration in the ExpectationSuite.
@@ -2882,7 +2885,7 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
     expectation_suite = context.get_expectation_suite(
         expectation_suite_name=expectation_suite_name
     )
-    for expectation_configuration in expectation_suite.expectations:
+    for expectation_configuration in expectation_suite.expectation_configurations:
         assert all(
             isinstance(rendered_content_block, RenderedAtomicContent)
             for rendered_content_block in expectation_configuration.rendered_content
@@ -2950,7 +2953,7 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
     ]
 
     actual_rendered_content: List[RenderedAtomicContent] = []
-    for expectation_configuration in expectation_suite.expectations:
+    for expectation_configuration in expectation_suite.expectation_configurations:
         actual_rendered_content.extend(expectation_configuration.rendered_content)
 
     assert actual_rendered_content == expected_rendered_content
@@ -3000,10 +3003,12 @@ def test_unrendered_and_failed_prescriptive_renderer_behavior(
         ),
     ]
 
-    expectation_suite.expectations[0].rendered_content = legacy_rendered_content
+    expectation_suite.expectation_configurations[
+        0
+    ].rendered_content = legacy_rendered_content
 
     actual_rendered_content: List[RenderedAtomicContent] = []
-    for expectation_configuration in expectation_suite.expectations:
+    for expectation_configuration in expectation_suite.expectation_configurations:
         actual_rendered_content.extend(expectation_configuration.rendered_content)
 
     assert actual_rendered_content == legacy_rendered_content

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -624,7 +624,7 @@ def test_update_expectation_suite_success(
 
     assert context.expectations_store.save_count == 1
 
-    suite.expectations = [
+    suite.expectation_configurations = [
         ExpectationConfiguration(
             expectation_type="expect_column_values_to_be_in_set",
             kwargs={"column": "x", "value_set": [1, 2, 4]},
@@ -632,7 +632,7 @@ def test_update_expectation_suite_success(
     ]
     updated_suite = context.update_expectation_suite(suite)
 
-    assert updated_suite.expectations == suite.expectations
+    assert updated_suite.expectation_configurations == suite.expectation_configurations
     assert context.expectations_store.save_count == 2
 
 
@@ -705,7 +705,7 @@ def test_add_or_update_expectation_suite_adds_successfully(
     suite = context.add_or_update_expectation_suite(**kwargs)
 
     assert suite.expectation_suite_name == expectation_suite_name
-    assert suite.expectations == expectations
+    assert suite.expectation_configurations == expectations
     assert suite.meta == meta
     assert context.expectations_store.save_count == 1
 
@@ -752,7 +752,7 @@ def test_add_or_update_expectation_suite_updates_successfully(
         expectation_suite_name=suite_name, expectations=new_expectations
     )
 
-    assert suite.expectations == new_expectations
+    assert suite.expectation_configurations == new_expectations
     assert context.expectations_store.save_count == 2
 
 

--- a/tests/integration/docusaurus/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
+++ b/tests/integration/docusaurus/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
@@ -107,10 +107,10 @@ suite.add_expectation(expectation_configuration=expectation_configuration_4)
 
 # Does the ExpectationSuite contain what we expect
 assert len(suite.expectations) == 4
-assert suite.expectations[0] == expectation_configuration_1
-assert suite.expectations[1] == expectation_configuration_2
-assert suite.expectations[2] == expectation_configuration_3
-assert suite.expectations[3] == expectation_configuration_4
+assert suite.expectation_configurations[0] == expectation_configuration_1
+assert suite.expectation_configurations[1] == expectation_configuration_2
+assert suite.expectation_configurations[2] == expectation_configuration_3
+assert suite.expectation_configurations[3] == expectation_configuration_4
 
 # <snippet name="tests/integration/docusaurus/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py save_expectation_suite">
 context.save_expectation_suite(expectation_suite=suite)

--- a/tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite.py
+++ b/tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite.py
@@ -97,11 +97,11 @@ my_suite.add_expectation(updated_config)
 # </snippet>
 
 assert len(my_suite.expectations) == 2
-assert my_suite.expectations[0] == ExpectationConfiguration(
+assert my_suite.expectation_configurations[0] == ExpectationConfiguration(
     expectation_type="expect_column_values_to_not_be_null",
     kwargs={"column": "pickup_datetime"},
 )
-assert my_suite.expectations[1] == updated_config
+assert my_suite.expectation_configurations[1] == updated_config
 
 
 # <snippet name="tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite find_configuration">
@@ -132,7 +132,7 @@ my_suite.show_expectations_by_expectation_type()
 # </snippet>
 
 assert len(my_suite.expectations) == 1
-assert my_suite.expectations[0] == ExpectationConfiguration(
+assert my_suite.expectation_configurations[0] == ExpectationConfiguration(
     expectation_type="expect_column_values_to_not_be_null",
     kwargs={"column": "pickup_datetime"},
 )

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -285,7 +285,9 @@ def test_alice_profiler_user_workflow_single_batch(
 
     assert (
         result.expectation_configurations
-        == alice_columnar_table_single_batch["expected_expectation_suite"].expectations
+        == alice_columnar_table_single_batch[
+            "expected_expectation_suite"
+        ].expectation_configurations
     )
 
     assert mock_emit.call_count == 43
@@ -688,7 +690,10 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
                 "estimation_histogram", None
             )
 
-    assert result.expectation_configurations == fixture_expectation_suite.expectations
+    assert (
+        result.expectation_configurations
+        == fixture_expectation_suite.expectation_configurations
+    )
 
     profiled_fully_qualified_parameter_names_by_domain: Dict[
         Domain, List[str]

--- a/tests/profile/conftest.py
+++ b/tests/profile/conftest.py
@@ -74,9 +74,13 @@ def get_set_of_columns_and_expectations_from_suite(
         A tuple containing a set of columns and a set of expectations found in a suite
     """
     columns: Set[str] = {
-        i.kwargs.get("column") for i in suite.expectations if i.kwargs.get("column")
+        i.kwargs.get("column")
+        for i in suite.expectation_configurations
+        if i.kwargs.get("column")
     }
-    expectations: Set[str] = {i.expectation_type for i in suite.expectations}
+    expectations: Set[str] = {
+        i.expectation_type for i in suite.expectation_configurations
+    }
 
     return columns, expectations
 

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -36,9 +36,10 @@ def test_ColumnsExistProfiler():
 
     assert len(expectations_config.expectations) == 1
     assert (
-        expectations_config.expectations[0].expectation_type == "expect_column_to_exist"
+        expectations_config.expectation_configurations[0].expectation_type
+        == "expect_column_to_exist"
     )
-    assert expectations_config.expectations[0].kwargs["column"] == "x"
+    assert expectations_config.expectation_configurations[0].kwargs["column"] == "x"
 
 
 @mock.patch(
@@ -50,7 +51,12 @@ def test_BasicDatasetProfiler(mock_emit):
         {"x": [1, 2, 3]},
     )
     assert (
-        len(toy_dataset.get_expectation_suite(suppress_warnings=True).expectations) == 0
+        len(
+            toy_dataset.get_expectation_suite(
+                suppress_warnings=True
+            ).expectation_configurations
+        )
+        == 0
     )
 
     expectations_config, evr_config = BasicDatasetProfiler.profile(toy_dataset)
@@ -72,7 +78,7 @@ def test_BasicDatasetProfiler(mock_emit):
     assert "To add additional notes" in expectations_config.meta["notes"]["content"][0]
 
     added_expectations = set()
-    for exp in expectations_config.expectations:
+    for exp in expectations_config.expectation_configurations:
         added_expectations.add(exp.expectation_type)
         assert "BasicDatasetProfiler" in exp.meta
         assert "confidence" in exp.meta["BasicDatasetProfiler"]
@@ -169,7 +175,7 @@ def test_BasicDatasetProfiler_with_context(filesystem_csv_data_context):
     assert (
         expectation_suite.meta["BasicDatasetProfiler"]["batch_kwargs"] == batch_kwargs
     )
-    for exp in expectation_suite.expectations:
+    for exp in expectation_suite.expectation_configurations:
         assert "BasicDatasetProfiler" in exp.meta
         assert "confidence" in exp.meta["BasicDatasetProfiler"]
 
@@ -202,7 +208,7 @@ def test_context_profiler(filesystem_csv_data_context):
     expected_suite_name = "rad_datasource.subdir_reader.f1.BasicDatasetProfiler"
     profiled_expectations = context.get_expectation_suite(expected_suite_name)
 
-    for exp in profiled_expectations.expectations:
+    for exp in profiled_expectations.expectation_configurations:
         assert "BasicDatasetProfiler" in exp.meta
         assert "confidence" in exp.meta["BasicDatasetProfiler"]
 

--- a/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
+++ b/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
@@ -273,7 +273,9 @@ def test_build_suite_no_config(titanic_dataset, possible_expectations_set):
     """
     profiler = UserConfigurableProfiler(titanic_dataset)
     suite = profiler.build_suite()
-    expectations_from_suite = {i.expectation_type for i in suite.expectations}
+    expectations_from_suite = {
+        i.expectation_type for i in suite.expectation_configurations
+    }
 
     assert expectations_from_suite.issubset(possible_expectations_set)
     assert len(suite.expectations) == 48
@@ -349,7 +351,7 @@ def test_build_suite_with_semantic_types_dict(
 
     value_set_expectations = [
         i
-        for i in suite.expectations
+        for i in suite.expectation_configurations
         if i.expectation_type == "expect_column_values_to_be_in_set"
     ]
     value_set_columns = {i.kwargs.get("column") for i in value_set_expectations}
@@ -491,7 +493,7 @@ def test_nullity_expectations_mostly_tolerance(
     )
     suite = profiler.build_suite()
 
-    for i in suite.expectations:
+    for i in suite.expectation_configurations:
         assert i["kwargs"]["mostly"] == 0.66
 
 

--- a/tests/profile/test_user_configurable_profiler_v3_batch_request.py
+++ b/tests/profile/test_user_configurable_profiler_v3_batch_request.py
@@ -482,7 +482,9 @@ def test_build_suite_no_config(
     """
     profiler = UserConfigurableProfiler(titanic_validator)
     suite = profiler.build_suite()
-    expectations_from_suite = {i.expectation_type for i in suite.expectations}
+    expectations_from_suite = {
+        i.expectation_type for i in suite.expectation_configurations
+    }
 
     assert expectations_from_suite.issubset(possible_expectations_set)
     assert len(suite.expectations) == 48
@@ -676,7 +678,7 @@ def test_build_suite_with_semantic_types_dict(
 
     value_set_expectations = [
         i
-        for i in suite.expectations
+        for i in suite.expectation_configurations
         if i.expectation_type == "expect_column_values_to_be_in_set"
     ]
     value_set_columns = {i.kwargs.get("column") for i in value_set_expectations}
@@ -879,7 +881,7 @@ def test_nullity_expectations_mostly_tolerance(
     )
     suite = profiler.build_suite()
 
-    for i in suite.expectations:
+    for i in suite.expectation_configurations:
         assert i["kwargs"]["mostly"] == 0.66
 
 

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -578,7 +578,7 @@ def test_render_without_batch_kwargs_uses_batch_kwargs_in_citations(
 
 
 def test_render_with_no_column_cells(critical_suite_with_citations, empty_data_context):
-    critical_suite_with_citations.expectations = []
+    critical_suite_with_citations.expectation_configurations = []
     obs = SuiteEditNotebookRenderer.from_data_context(empty_data_context).render(
         critical_suite_with_citations
     )

--- a/tests/render/renderer/v3/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_edit_notebook_renderer.py
@@ -500,7 +500,7 @@ def warning_suite(empty_data_context) -> ExpectationSuite:
 def test_render_with_no_column_cells_without_batch_request(
     critical_suite_with_citations, empty_data_context
 ):
-    critical_suite_with_citations.expectations = []
+    critical_suite_with_citations.expectation_configurations = []
     obs: dict = SuiteEditNotebookRenderer.from_data_context(
         data_context=empty_data_context
     ).render(suite=critical_suite_with_citations)

--- a/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
@@ -389,7 +389,7 @@ def test_notebook_execution_onboarding_data_assistant_pandas_backend(
 
     expectation_configurations: List[ExpectationConfiguration] = []
     expectation_configuration: ExpectationConfiguration
-    for expectation_configuration in suite.expectations:
+    for expectation_configuration in suite.expectation_configurations:
         kwargs: dict = expectation_configuration.kwargs
         key: str
         value: Any

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -113,7 +113,7 @@ def test_render_expectation_suite_column_section_renderer(titanic_expectations):
     # Group expectations by column
     exp_groups = {}
     # print(json.dumps(titanic_expectations, indent=2))
-    for exp in titanic_expectations.expectations:
+    for exp in titanic_expectations.expectation_configurations:
         try:
             column = exp.kwargs["column"]
             if column not in exp_groups:

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -190,7 +190,7 @@ def test_render_expectation_suite_column_section_renderer(
 ):
     # Group expectations by column
     exp_groups = {}
-    for exp in titanic_profiled_expectations_1.expectations:
+    for exp in titanic_profiled_expectations_1.expectation_configurations:
         try:
             column = exp.kwargs["column"]
             if column not in exp_groups:

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1773,7 +1773,7 @@ def test_volume_data_assistant_get_metrics_and_expectations_using_explicit_insta
 
     assert (
         data_assistant_result.expectation_configurations
-        == expected_expectation_suite.expectations
+        == expected_expectation_suite.expectation_configurations
     )
 
     assert sorted(
@@ -1844,7 +1844,7 @@ def test_volume_data_assistant_get_metrics_and_expectations_using_implicit_invoc
 
     assert (
         data_assistant_result.expectation_configurations
-        == expected_expectation_suite.expectations
+        == expected_expectation_suite.expectation_configurations
     )
 
     data_assistant_result_profiler_config_as_json_dict: dict = (
@@ -1962,9 +1962,9 @@ def test_volume_data_assistant_get_metrics_and_expectations_using_implicit_invoc
 
     expectation_configuration: ExpectationConfiguration
 
-    expected_expectation_suite.expectations = [
+    expected_expectation_suite.expectation_configurations = [
         expectation_configuration
-        for expectation_configuration in expected_expectation_suite.expectations
+        for expectation_configuration in expected_expectation_suite.expectation_configurations
         if not (
             expectation_configuration.kwargs
             and expectation_configuration.kwargs.get("column") in exclude_column_names
@@ -1979,7 +1979,7 @@ def test_volume_data_assistant_get_metrics_and_expectations_using_implicit_invoc
 
     assert (
         data_assistant_result.expectation_configurations
-        == expected_expectation_suite.expectations
+        == expected_expectation_suite.expectation_configurations
     )
 
     data_assistant_result_profiler_config_as_json_dict: dict = (

--- a/tests/rule_based_profiler/test_user_workflow_fixtures.py
+++ b/tests/rule_based_profiler/test_user_workflow_fixtures.py
@@ -20,7 +20,9 @@ def test_alice_fixture_generation(
     )
     assert (
         len(
-            alice_columnar_table_single_batch["expected_expectation_suite"].expectations
+            alice_columnar_table_single_batch[
+                "expected_expectation_suite"
+            ].expectation_configurations
         )
         == 22
     )
@@ -43,7 +45,7 @@ def test_bobby_fixture_generation(
         len(
             bobby_columnar_table_multi_batch["test_configuration_quantiles_estimator"][
                 "expected_expectation_suite"
-            ].expectations
+            ].expectation_configurations
         )
         == 39
     )

--- a/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
+++ b/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
@@ -16,6 +16,7 @@
         {
             "expectation_type": "expect_column_unique_value_count_to_be_between",
             "kwargs": {
+                "column": "default",
                 "min_value": {
                     "$PARAMETER": "urn:great_expectations:validations:source_patient_data.default:expect_table_row_count_to_equal.result.observed_value"
                 }


### PR DESCRIPTION
This PR refactors `ExpectationSuite.expectations` to `ExpectationSuite.expectation_configurations` in preparation to make it a private attribute of the class.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
