### PR TITLE
[MAINTENANCE] Allow arbitrary kwargs in Expectation constructor

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1491,7 +1491,7 @@ class ExpectationConfiguration(SerializableDictDot):
     ):
         expectation_impl: Type[Expectation] = self._get_expectation_impl()
         # noinspection PyCallingNonCallable
-        return expectation_impl(self).metrics_validate(
+        return expectation_impl(**self.kwargs).metrics_validate(
             metrics=metrics,
             runtime_configuration=runtime_configuration,
             execution_engine=execution_engine,

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1477,7 +1477,7 @@ class ExpectationConfiguration(SerializableDictDot):
         """
         expectation_impl: Type[Expectation] = self._get_expectation_impl()
         # noinspection PyCallingNonCallable
-        return expectation_impl(**self.kwargs).validate(
+        return expectation_impl(**self.kwargs).validate_(
             validator=validator,
             runtime_configuration=runtime_configuration,
         )

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1477,7 +1477,7 @@ class ExpectationConfiguration(SerializableDictDot):
         """
         expectation_impl: Type[Expectation] = self._get_expectation_impl()
         # noinspection PyCallingNonCallable
-        return expectation_impl(self).validate(
+        return expectation_impl(**self.kwargs).validate(
             validator=validator,
             runtime_configuration=runtime_configuration,
         )

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -754,7 +754,9 @@ class ExpectationSuite(SerializableDictDot):
     ):
         try:
             class_ = get_expectation_impl(expectation_configuration.expectation_type)
-            _ = class_(expectation_configuration)  # Implicitly validates in constructor
+            _ = class_(
+                **expectation_configuration.kwargs
+            )  # Implicitly validates in constructor
         except (
             gx_exceptions.ExpectationNotFoundError,
             gx_exceptions.InvalidExpectationConfigurationError,

--- a/great_expectations/data_context/data_context/context_factory.py
+++ b/great_expectations/data_context/data_context/context_factory.py
@@ -245,6 +245,13 @@ def get_context(  # noqa: PLR0913
         "cloud": CloudDataContext,
         None: AbstractDataContext,
     }
+
+    if mode == "ephemeral":
+        return _get_ephemeral_context(
+            project_config=project_config,
+            runtime_environment=runtime_environment,
+        )
+
     context = _get_context(**kwargs)
 
     expected_type = expected_ctx_types[mode]

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional
+from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Tuple
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.expectation_configuration import parse_result_format
@@ -90,7 +90,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
     }
 
     map_metric: ClassVar[str] = "column_values.nonnull"
-    args_keys: ClassVar[tuple[str, ...]] = ("column",)
+    args_keys: ClassVar[Tuple[str, ...]] = ("column",)
 
     @override
     def validate_configuration(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -10,7 +10,7 @@ import sys
 import time
 import traceback
 import warnings
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from copy import deepcopy
 from inspect import isabstract
@@ -37,6 +37,8 @@ from dateutil.parser import parse
 from typing_extensions import ParamSpec
 
 from great_expectations import __version__ as ge_version
+from great_expectations.compatibility import pydantic
+from great_expectations.compatibility.pydantic import ModelMetaclass
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import (
     deprecated_method_or_class,
@@ -265,7 +267,7 @@ def param_method(param_name: str) -> Callable:
 
 
 # noinspection PyMethodParameters
-class MetaExpectation(ABCMeta):
+class MetaExpectation(ModelMetaclass):
     """MetaExpectation registers Expectations as they are defined, adding them to the Expectation registry.
 
     Any class inheriting from Expectation will be registered based on the value of the "expectation_type" class
@@ -297,7 +299,7 @@ class MetaExpectation(ABCMeta):
 
 
 @public_api
-class Expectation(metaclass=MetaExpectation):
+class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     """Base class for all Expectations.
 
     Expectation classes *must* have the following attributes set:
@@ -329,7 +331,11 @@ class Expectation(metaclass=MetaExpectation):
         2. Data Docs rendering methods decorated with the @renderer decorator. See the
     """
 
-    version: ClassVar = ge_version
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "allow"
+
+    version: ClassVar[str] = ge_version
     domain_keys: ClassVar[Tuple[str, ...]] = ()
     success_keys: ClassVar[Tuple[str, ...]] = ()
     runtime_keys: ClassVar[Tuple[str, ...]] = (
@@ -338,7 +344,7 @@ class Expectation(metaclass=MetaExpectation):
         "result_format",
     )
     default_kwarg_values: ClassVar[
-        dict[str, bool | str | float | RuleBasedProfilerConfig | None]
+        dict[str, Union[bool, str, float, RuleBasedProfilerConfig, None]]
     ] = {
         "include_config": True,
         "catch_exceptions": False,
@@ -350,9 +356,7 @@ class Expectation(metaclass=MetaExpectation):
     examples: ClassVar[List[dict]] = []
 
     def __init__(self, **kwargs) -> None:
-        # Promote ExpectationConfiguration fields to Expectation
-        for k, v in kwargs.items():
-            setattr(self, k, v)
+        super().__init__(**kwargs)
 
         # Everything below is purely to maintain current validation logic
         expectation_type = camel_to_snake(self.__class__.__name__)
@@ -1249,6 +1253,7 @@ class Expectation(metaclass=MetaExpectation):
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 
+    # Renamed from validate due to collision with Pydantic method of the same name
     @public_api
     def validate_(  # noqa: PLR0913
         self,
@@ -2354,7 +2359,7 @@ class BatchExpectation(Expectation, ABC):
         "condition_parser",
     )
     metric_dependencies: ClassVar[Tuple[str, ...]] = ()
-    domain_type: ClassVar = MetricDomainTypes.TABLE
+    domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.TABLE
     args_keys: ClassVar[Tuple[str, ...]] = ()
 
     @override
@@ -2752,14 +2757,14 @@ class ColumnMapExpectation(BatchExpectation, ABC):
     """
 
     map_metric: ClassVar[Optional[str]] = None
-    domain_keys: ClassVar[tuple[str, ...]] = (
+    domain_keys: ClassVar[Tuple[str, ...]] = (
         "batch_id",
         "table",
         "column",
         "row_condition",
         "condition_parser",
     )
-    domain_type: ClassVar = MetricDomainTypes.COLUMN
+    domain_type: ClassVar[MetricDomainTypes] = MetricDomainTypes.COLUMN
     success_keys: ClassVar[Tuple[str, ...]] = ("mostly",)
     default_kwarg_values = {
         "row_condition": None,
@@ -3033,7 +3038,7 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
             kwargs from the Expectation Configuration.
     """
 
-    map_metric = None
+    map_metric: ClassVar[Optional[str]] = None
     domain_keys = (
         "batch_id",
         "table",
@@ -3305,7 +3310,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
             kwargs from the Expectation Configuration.
     """
 
-    map_metric = None
+    map_metric: ClassVar[Optional[str]] = None
     domain_keys = (
         "batch_id",
         "table",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -350,11 +350,15 @@ class Expectation(metaclass=MetaExpectation):
     examples: ClassVar[List[dict]] = []
 
     def __init__(self, **kwargs) -> None:
+        # Promote ExpectationConfiguration fields to Expectation
         self.meta = kwargs.pop("meta", None)
         self.success_on_last_run = kwargs.pop("success_on_last_run", None)
         self.expectation_context = kwargs.pop("expectation_context", None)
         self.rendered_content = kwargs.pop("rendered_content", None)
+        for k, v in kwargs:
+            setattr(self, k, v)
 
+        # Everything below is purely to maintain current validation logic
         expectation_type = camel_to_snake(self.__class__.__name__)
         configuration = ExpectationConfiguration(
             expectation_type=expectation_type,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1250,7 +1250,7 @@ class Expectation(metaclass=MetaExpectation):
             raise InvalidExpectationConfigurationError(str(e))
 
     @public_api
-    def validate(  # noqa: PLR0913
+    def validate_(  # noqa: PLR0913
         self,
         validator: Validator,
         configuration: Optional[ExpectationConfiguration] = None,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -351,10 +351,6 @@ class Expectation(metaclass=MetaExpectation):
 
     def __init__(self, **kwargs) -> None:
         # Promote ExpectationConfiguration fields to Expectation
-        self.meta = kwargs.pop("meta", None)
-        self.success_on_last_run = kwargs.pop("success_on_last_run", None)
-        self.expectation_context = kwargs.pop("expectation_context", None)
-        self.rendered_content = kwargs.pop("rendered_content", None)
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -362,10 +358,6 @@ class Expectation(metaclass=MetaExpectation):
         expectation_type = camel_to_snake(self.__class__.__name__)
         configuration = ExpectationConfiguration(
             expectation_type=expectation_type,
-            meta=self.meta,
-            success_on_last_run=self.success_on_last_run,
-            expectation_context=self.expectation_context,
-            rendered_content=self.rendered_content,
             kwargs=kwargs,
         )
         self.validate_configuration(configuration)

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -355,7 +355,7 @@ class Expectation(metaclass=MetaExpectation):
         self.success_on_last_run = kwargs.pop("success_on_last_run", None)
         self.expectation_context = kwargs.pop("expectation_context", None)
         self.rendered_content = kwargs.pop("rendered_content", None)
-        for k, v in kwargs:
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
         # Everything below is purely to maintain current validation logic

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -349,9 +349,23 @@ class Expectation(metaclass=MetaExpectation):
     expectation_type: ClassVar[str]
     examples: ClassVar[List[dict]] = []
 
-    def __init__(self, configuration: ExpectationConfiguration) -> None:
-        self._configuration = configuration
+    def __init__(self, **kwargs) -> None:
+        self.meta = kwargs.pop("meta", None)
+        self.success_on_last_run = kwargs.pop("success_on_last_run", None)
+        self.expectation_context = kwargs.pop("expectation_context", None)
+        self.rendered_content = kwargs.pop("rendered_content", None)
+
+        expectation_type = camel_to_snake(self.__class__.__name__)
+        configuration = ExpectationConfiguration(
+            expectation_type=expectation_type,
+            meta=self.meta,
+            success_on_last_run=self.success_on_last_run,
+            expectation_context=self.expectation_context,
+            rendered_content=self.rendered_content,
+            kwargs=kwargs,
+        )
         self.validate_configuration(configuration)
+        self._configuration = configuration
 
     @classmethod
     def is_abstract(cls) -> bool:

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -341,7 +341,9 @@ def get_metric_kwargs(
         }
         if configuration:
             expectation_impl = get_expectation_impl(configuration.expectation_type)
-            configuration_kwargs = expectation_impl(configuration).get_runtime_kwargs(
+            configuration_kwargs = expectation_impl(
+                **configuration.kwargs
+            ).get_runtime_kwargs(
                 configuration=configuration, runtime_configuration=runtime_configuration
             )
             if len(metric_kwargs["metric_domain_keys"]) > 0:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -543,7 +543,7 @@ class Validator:
                 )
 
             try:
-                expectation = expectation_impl(configuration)
+                expectation = expectation_impl(**configuration.kwargs)
                 """Given an implementation and a configuration for any Expectation, returns its validation result"""
 
                 if not self.interactive_evaluation and not self._active_validation:
@@ -1124,7 +1124,7 @@ class Validator:
 
             expectation_impl = get_expectation_impl(evaluated_config.expectation_type)
             validation_dependencies: ValidationDependencies = expectation_impl(
-                evaluated_config
+                **evaluated_config.kwargs
             ).get_validation_dependencies(
                 configuration=evaluated_config,
                 execution_engine=self._execution_engine,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -551,7 +551,7 @@ class Validator:
                         expectation_config=copy.deepcopy(expectation.configuration)
                     )
                 else:
-                    validation_result = expectation.validate(
+                    validation_result = expectation.validate_(
                         validator=self,
                         evaluation_parameters=self._expectation_suite.evaluation_parameters,
                         data_context=self._data_context,

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -160,7 +160,7 @@ def _expecation_configuration_to_validation_result_pandas(
             batch,
         ],
     )
-    result = expectation.validate(validator)
+    result = expectation.validate_(validator)
     return result
 
 
@@ -236,7 +236,7 @@ def _expecation_configuration_to_validation_result_sql(
             batch,
         ],
     )
-    result = expectation.validate(validator)
+    result = expectation.validate_(validator)
     return result
 
 
@@ -795,7 +795,7 @@ def test_include_unexpected_rows_without_explicit_result_format_raises_error(
         ],
     )
     with pytest.raises(ValueError):
-        expectation.validate(validator)
+        expectation.validate_(validator)
 
 
 # Spark
@@ -834,7 +834,7 @@ def test_spark_single_column_complete_result_format(
             batch,
         ],
     )
-    result = expectation.validate(validator)
+    result = expectation.validate_(validator)
     assert convert_to_json_serializable(result.result) == {
         "element_count": 6,
         "missing_count": 0,
@@ -894,7 +894,7 @@ def test_spark_single_column_complete_result_format_with_id_pk(
 
     # result_format configuration at ExpectationConfiguration-level will emit warning
     with pytest.warns(UserWarning):
-        result = expectation.validate(validator)
+        result = expectation.validate_(validator)
 
     assert convert_to_json_serializable(result.result) == {
         "element_count": 6,
@@ -962,7 +962,7 @@ def test_spark_single_column_summary_result_format(
             batch,
         ],
     )
-    result = expectation.validate(validator)
+    result = expectation.validate_(validator)
     assert convert_to_json_serializable(result.result) == {
         "element_count": 6,
         "missing_count": 0,
@@ -1015,7 +1015,7 @@ def test_spark_single_column_basic_result_format(
             batch,
         ],
     )
-    result = expectation.validate(validator)
+    result = expectation.validate_(validator)
     assert convert_to_json_serializable(result.result) == {
         "element_count": 6,
         "missing_count": 0,

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -140,7 +140,7 @@ def _expecation_configuration_to_validation_result_pandas(
         expectation_configuration (ExpectationConfiguration): configuration that is being tested
 
     """
-    expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
+    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="pandas_datasource",
         data_connector_name="runtime_data_connector",
@@ -176,7 +176,7 @@ def _expecation_configuration_to_validation_result_sql(
         expectation_configuration (ExpectationConfiguration): configuration that is being tested
 
     """
-    expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
+    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     sqlite_path = file_relative_path(__file__, "../../test_sets/metrics_test.db")
     connection_string = f"sqlite:///{sqlite_path}"
     engine = SqlAlchemyExecutionEngine(
@@ -774,7 +774,7 @@ def test_include_unexpected_rows_without_explicit_result_format_raises_error(
         },
     )
 
-    expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
+    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="pandas_datasource",
         data_connector_name="runtime_data_connector",

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -87,7 +87,7 @@ def fake_expectation_config(
 )
 def test_multicolumn_expectation_has_default_mostly(fake_expectation_cls, config):
     try:
-        fake_expectation = fake_expectation_cls(config)
+        fake_expectation = fake_expectation_cls(**config.kwargs)
     except Exception:
         assert (
             False
@@ -134,12 +134,7 @@ def test_multicolumn_expectation_has_default_mostly(fake_expectation_cls, config
     ),
 )
 def test_expectation_succeeds_with_valid_mostly(fake_expectation_cls, config):
-    try:
-        fake_expectation = fake_expectation_cls(config)
-    except Exception:
-        assert (
-            False
-        ), "Validate configuration threw an error when testing default mostly value"
+    fake_expectation = fake_expectation_cls(**config.kwargs)
     assert (
         fake_expectation.get_success_kwargs().get("mostly") == config.kwargs["mostly"]
     ), "Default mostly success ratio is not 1"
@@ -174,7 +169,7 @@ def test_multicolumn_expectation_validation_errors_with_bad_mostly(
     fake_expectation_cls, config
 ):
     with pytest.raises(InvalidExpectationConfigurationError):
-        fake_expectation_cls(config)
+        fake_expectation_cls(**config)
 
 
 @pytest.mark.unit

--- a/tests/expectations/test_generate_diagnostic_checklist.py
+++ b/tests/expectations/test_generate_diagnostic_checklist.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from great_expectations.core.expectation_diagnostics.supporting_types import Maturity
@@ -17,9 +15,7 @@ pytestmark = pytest.mark.unit
     "This is broken because Expectation._get_execution_engine_diagnostics is broken"
 )
 def test_print_diagnostic_checklist__first_iteration():
-    output_message = ExpectColumnValuesToEqualThree(
-        configuration=mock.MagicMock()
-    ).print_diagnostic_checklist()
+    output_message = ExpectColumnValuesToEqualThree().print_diagnostic_checklist()
 
     assert (
         output_message
@@ -34,9 +30,9 @@ Completeness checklist for ExpectColumnValuesToEqualThree:
 
 
 def test_print_diagnostic_checklist__second_iteration():
-    output_message = ExpectColumnValuesToEqualThree__SecondIteration(
-        configuration=mock.MagicMock()
-    ).print_diagnostic_checklist()
+    output_message = (
+        ExpectColumnValuesToEqualThree__SecondIteration().print_diagnostic_checklist()
+    )
     print(output_message)
 
     assert (
@@ -61,9 +57,9 @@ Completeness checklist for ExpectColumnValuesToEqualThree__SecondIteration ({Mat
 
 
 def test_print_diagnostic_checklist__third_iteration():
-    output_message = ExpectColumnValuesToEqualThree__ThirdIteration(
-        configuration=mock.MagicMock()
-    ).print_diagnostic_checklist()
+    output_message = (
+        ExpectColumnValuesToEqualThree__ThirdIteration().print_diagnostic_checklist()
+    )
     print(output_message)
 
     assert (

--- a/tests/expectations/test_run_diagnostics.py
+++ b/tests/expectations/test_run_diagnostics.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 import pytest
 
@@ -20,7 +19,7 @@ from tests.expectations.fixtures.expect_column_values_to_equal_three import (
 
 @pytest.mark.unit
 def test_expectation_self_check():
-    my_expectation = ExpectColumnValuesToEqualThree(configuration=mock.MagicMock())
+    my_expectation = ExpectColumnValuesToEqualThree()
     expectation_diagnostic = my_expectation.run_diagnostics()
     print(json.dumps(expectation_diagnostic.to_dict(), indent=2))
 
@@ -214,9 +213,7 @@ def test_expectation_self_check():
 
 @pytest.mark.unit
 def test_include_in_gallery_flag():
-    my_expectation = ExpectColumnValuesToEqualThree__SecondIteration(
-        configuration=mock.MagicMock()
-    )
+    my_expectation = ExpectColumnValuesToEqualThree__SecondIteration()
     report_object = my_expectation.run_diagnostics()
     # print(json.dumps(report_object["examples"], indent=2))
 
@@ -523,9 +520,9 @@ def test_expectation_is_abstract():
 
 @pytest.mark.unit
 def test_run_diagnostics_on_an_expectation_with_errors_in_its_tests():
-    expectation_diagnostics = ExpectColumnValuesToEqualThree__BrokenIteration(
-        configuration=mock.MagicMock()
-    ).run_diagnostics()
+    expectation_diagnostics = (
+        ExpectColumnValuesToEqualThree__BrokenIteration().run_diagnostics()
+    )
     # print(json.dumps(expectation_diagnostics.to_dict(), indent=2))
 
     tests = expectation_diagnostics["tests"]

--- a/tests/expectations/test_run_diagnostics_supporting_methods.py
+++ b/tests/expectations/test_run_diagnostics_supporting_methods.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from great_expectations.core.expectation_diagnostics.expectation_test_data_cases import (
@@ -23,9 +21,9 @@ from tests.expectations.fixtures.expect_column_values_to_equal_three import (
 
 @pytest.mark.unit
 def test__get_augmented_library_metadata_on_a_class_with_no_library_metadata_object():
-    augmented_library_metadata = ExpectColumnValuesToEqualThree(
-        configuration=mock.MagicMock()
-    )._get_augmented_library_metadata()
+    augmented_library_metadata = (
+        ExpectColumnValuesToEqualThree()._get_augmented_library_metadata()
+    )
     assert augmented_library_metadata == AugmentedLibraryMetadata(
         maturity="CONCEPT_ONLY",
         tags=[],
@@ -40,9 +38,9 @@ def test__get_augmented_library_metadata_on_a_class_with_no_library_metadata_obj
 
 @pytest.mark.unit
 def test__get_augmented_library_metadata_on_a_class_with_a_basic_library_metadata_object():
-    augmented_library_metadata = ExpectColumnValuesToEqualThree__SecondIteration(
-        configuration=mock.MagicMock()
-    )._get_augmented_library_metadata()
+    augmented_library_metadata = (
+        ExpectColumnValuesToEqualThree__SecondIteration()._get_augmented_library_metadata()
+    )
     assert augmented_library_metadata == AugmentedLibraryMetadata(
         maturity="EXPERIMENTAL",
         tags=["tag", "other_tag"],
@@ -59,17 +57,12 @@ def test__get_augmented_library_metadata_on_a_class_with_a_basic_library_metadat
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_no_examples():
-    assert (
-        ExpectColumnValuesToEqualThree(configuration=mock.MagicMock())._get_examples()
-        == []
-    )
+    assert ExpectColumnValuesToEqualThree()._get_examples() == []
 
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_some_examples():
-    examples = ExpectColumnValuesToEqualThree__SecondIteration(
-        configuration=mock.MagicMock()
-    )._get_examples()
+    examples = ExpectColumnValuesToEqualThree__SecondIteration()._get_examples()
     assert len(examples) == 1
 
     first_example = examples[0]
@@ -82,9 +75,9 @@ def test__get_examples_from_a_class_with_some_examples():
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_return_only_gallery_examples_equals_false():
-    examples = ExpectColumnValuesToEqualThree__SecondIteration(
-        configuration=mock.MagicMock()
-    )._get_examples(return_only_gallery_examples=False)
+    examples = ExpectColumnValuesToEqualThree__SecondIteration()._get_examples(
+        return_only_gallery_examples=False
+    )
     assert len(examples) == 1
 
     first_example = examples[0]
@@ -106,12 +99,12 @@ def test__get_description_diagnostics():
         It has more to it.
         """
 
-        def validate_configuration(self, configuration) -> None:
+        def validate_configuration(self, configuration=None) -> None:
             pass
 
-    description_diagnostics = ExpectColumnValuesToBeAwesome(
-        configuration=mock.MagicMock()
-    )._get_description_diagnostics()
+    description_diagnostics = (
+        ExpectColumnValuesToBeAwesome()._get_description_diagnostics()
+    )
     assert description_diagnostics == ExpectationDescriptionDiagnostics(
         camel_name="ExpectColumnValuesToBeAwesome",
         snake_name="expect_column_values_to_be_awesome",
@@ -127,9 +120,11 @@ def test__get_description_diagnostics():
 @pytest.mark.unit
 def test__get_metric_diagnostics_list_on_a_class_without_metrics():
     _config = None
-    metric_diagnostics_list = ExpectColumnValuesToEqualThree(
-        configuration=mock.MagicMock()
-    )._get_metric_diagnostics_list(expectation_config=_config)
+    metric_diagnostics_list = (
+        ExpectColumnValuesToEqualThree()._get_metric_diagnostics_list(
+            expectation_config=_config
+        )
+    )
     assert len(metric_diagnostics_list) == 0
     ExpectationMetricDiagnostics(
         name="column_values.something",
@@ -140,9 +135,11 @@ def test__get_metric_diagnostics_list_on_a_class_without_metrics():
 @pytest.mark.unit
 def test__get_metric_diagnostics_list_on_a_class_with_metrics():
     _config = None
-    metric_diagnostics_list = ExpectColumnValuesToEqualThree__ThirdIteration(
-        configuration=mock.MagicMock()
-    )._get_metric_diagnostics_list(expectation_config=_config)
+    metric_diagnostics_list = (
+        ExpectColumnValuesToEqualThree__ThirdIteration()._get_metric_diagnostics_list(
+            expectation_config=_config
+        )
+    )
     assert len(metric_diagnostics_list) == 0
     ExpectationMetricDiagnostics(
         name="column_values.something",

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -106,7 +106,7 @@ def expect_column_value_z_scores_to_be_less_than_expectation_validation_graph():
     graph = ValidationGraph(execution_engine=execution_engine)
     validation_dependencies: ValidationDependencies = (
         ExpectColumnValueZScoresToBeLessThan(
-            expectation_configuration
+            **expectation_configuration.kwargs
         ).get_validation_dependencies(expectation_configuration, execution_engine)
     )
 

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -1258,7 +1258,7 @@ def _context_to_validator_and_expectation_sql(
         },
     )
     expectation: ExpectColumnValuesToBeInSet = ExpectColumnValuesToBeInSet(
-        expectation_configuration
+        **expectation_configuration.kwargs
     )
 
     batch_request = BatchRequest(

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -1312,7 +1312,7 @@ def test_validator_result_format_config_from_expectation(
         context=data_context_with_connection_to_metrics_db,
     )
     with pytest.warns(UserWarning) as config_warning:
-        _: ExpectationValidationResult = expectation.validate(
+        _: ExpectationValidationResult = expectation.validate_(
             validator=validator, runtime_configuration=runtime_configuration
         )
 


### PR DESCRIPTION



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
