### PR TITLE
[DOCS] Return Support Section to GX Cloud Docs

### DIFF
--- a/docs/docusaurus/docs/cloud/about_gx.md
+++ b/docs/docusaurus/docs/cloud/about_gx.md
@@ -134,3 +134,11 @@ The following browsers are supported by GX Cloud:
 ### Browser session duration
 
 A session is the period of time that you’re signed in to your GX Cloud account from a browser. If you close the browser, your session ends, and you're signed out. You'll need to sign in again to access GX Cloud.
+
+## Get support
+
+Use the following resources when you have questions or encounter issues with GX Cloud:
+
+- [GX Cloud support on Discourse](https://discourse.greatexpectations.io/c/cloud-support/17)
+
+- [Discuss your issue with GX community members on Slack](https://greatexpectationstalk.slack.com/archives/C051D941XAL)


### PR DESCRIPTION
A small PR to return the support content to the GX Cloud documentation. This content was removed inadvertently in a previous PR.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated