### PR TITLE
[BUGFIX] Patch breaking docs tests as a result of Expectation constructor changes

### DIFF
--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
@@ -337,12 +337,34 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
 
 if __name__ == "__main__":
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py diagnostics">
-    ExpectColumnMaxToBeBetweenCustom().print_diagnostic_checklist()
+    ExpectColumnMaxToBeBetweenCustom(
+        configuration=ExpectationConfiguration(
+            expectation_type="expect_column_max_to_be_between_custom",
+            kwargs={
+                "column": "x",
+                "min_value": 0,
+                "max_value": 10,
+                "strict_min": True,
+                "strict_max": False,
+            },
+        )
+    ).print_diagnostic_checklist()
 #     </snippet>
 
 # Note to users: code below this line is only for integration testing -- ignore!
 
-diagnostics = ExpectColumnMaxToBeBetweenCustom().run_diagnostics()
+diagnostics = ExpectColumnMaxToBeBetweenCustom(
+    configuration=ExpectationConfiguration(
+        expectation_type="expect_column_max_to_be_between_custom",
+        kwargs={
+            "column": "x",
+            "min_value": 0,
+            "max_value": 10,
+            "strict_min": True,
+            "strict_max": False,
+        },
+    )
+).run_diagnostics()
 
 for check in diagnostics["tests"]:
     assert check["test_passed"] is True

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
@@ -1,3 +1,4 @@
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.expectations.set_based_column_map_expectation import (
     SetBasedColumnMapExpectation,
 )
@@ -123,12 +124,22 @@ class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
 
 if __name__ == "__main__":
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py diagnostics">
-    ExpectColumnValuesToBeInSolfegeScaleSet().print_diagnostic_checklist()
+    ExpectColumnValuesToBeInSolfegeScaleSet(
+        configuration=ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_in_solfege_scale_set",
+            kwargs={"column": "lowercase_solfege_scale"},
+        )
+    ).print_diagnostic_checklist()
 #     </snippet>
 
 # Note to users: code below this line is only for integration testing -- ignore!
 
-diagnostics = ExpectColumnValuesToBeInSolfegeScaleSet().run_diagnostics()
+diagnostics = ExpectColumnValuesToBeInSolfegeScaleSet(
+    configuration=ExpectationConfiguration(
+        expectation_type="expect_column_values_to_be_in_solfege_scale_set",
+        kwargs={"column": "lowercase_solfege_scale"},
+    )
+).run_diagnostics()
 
 for check in diagnostics["tests"]:
     assert check["test_passed"] is True

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py
@@ -1,3 +1,4 @@
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.expectations.regex_based_column_map_expectation import (
     RegexBasedColumnMapExpectation,
 )
@@ -109,12 +110,22 @@ class ExpectColumnValuesToOnlyContainVowels(RegexBasedColumnMapExpectation):
 
 if __name__ == "__main__":
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py diagnostics">
-    ExpectColumnValuesToOnlyContainVowels().print_diagnostic_checklist()
+    ExpectColumnValuesToOnlyContainVowels(
+        configuration=ExpectationConfiguration(
+            expectation_type="expect_column_values_to_only_contain_vowels",
+            kwargs={"column": "only_vowels"},
+        )
+    ).print_diagnostic_checklist()
 #     </snippet>
 
 # Note to users: code below this line is only for integration testing -- ignore!
 
-diagnostics = ExpectColumnValuesToOnlyContainVowels().run_diagnostics()
+diagnostics = ExpectColumnValuesToOnlyContainVowels(
+    configuration=ExpectationConfiguration(
+        expectation_type="expect_column_values_to_only_contain_vowels",
+        kwargs={"column": "only_vowels"},
+    )
+).run_diagnostics()
 
 for check in diagnostics["tests"]:
     assert check["test_passed"] is True

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
@@ -130,11 +130,21 @@ class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
 
 if __name__ == "__main__":
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py print_diagnostic_checklist">
-    ExpectMulticolumnValuesToBeMultiplesOfThree().print_diagnostic_checklist()
+    ExpectMulticolumnValuesToBeMultiplesOfThree(
+        configuration=ExpectationConfiguration(
+            expectation_type="expect_multicolumn_values_to_be_multiples_of_three",
+            kwargs={"column_list": ["col_a", "col_b", "col_c"]},
+        )
+    ).print_diagnostic_checklist()
     # </snippet>
 # Note to users: code below this line is only for integration testing -- ignore!
 
-diagnostics = ExpectMulticolumnValuesToBeMultiplesOfThree().run_diagnostics()
+diagnostics = ExpectMulticolumnValuesToBeMultiplesOfThree(
+    configuration=ExpectationConfiguration(
+        expectation_type="expect_multicolumn_values_to_be_multiples_of_three",
+        kwargs={"column_list": ["col_a", "col_b", "col_c"]},
+    )
+).run_diagnostics()
 
 for check in diagnostics["tests"]:
     assert check["test_passed"] is True


### PR DESCRIPTION
Now that `configuration` is required within the Expectation constructor, we need to patch some calls made in our tests. We should probably make these diagnostic methods classmethod moving forward but I'll defer that effort to a later ticket. 


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
