### PR TITLE
[MAINTENANCE] Add context to `BatchConfig`, and fetch assets by name

### DIFF
--- a/great_expectations/core/batch_config.py
+++ b/great_expectations/core/batch_config.py
@@ -1,11 +1,14 @@
 from typing import Optional
 
 from great_expectations.compatibility import pydantic
+from great_expectations.data_context.data_context.abstract_data_context import (
+    AbstractDataContext,
+)
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,
 )
-from great_expectations.datasource.fluent.interfaces import DataAsset
+from great_expectations.datasource.fluent.interfaces import DataAsset, Datasource
 
 
 class BatchConfig(pydantic.BaseModel):
@@ -15,7 +18,20 @@ class BatchConfig(pydantic.BaseModel):
     TODO: Add splitters and sorters?
     """
 
-    data_asset: DataAsset
+    class Config:
+        arbitrary_types_allowed = True
+
+    context: AbstractDataContext
+    datasource_name: str
+    data_asset_name: str
+
+    @property
+    def data_asset(self) -> DataAsset:
+        """Get the DataAsset referenced by this BatchConfig."""
+        datasource = self.context.get_datasource(self.datasource_name)
+        assert isinstance(datasource, Datasource)
+
+        return datasource.get_asset(self.data_asset_name)
 
     def build_batch_request(
         self, batch_request_options: Optional[BatchRequestOptions] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3247,12 +3247,21 @@ def sqlite_connection_string() -> str:
 
 
 @pytest.fixture
+def fds_data_context_datasource_name() -> str:
+    return "sqlite_datasource"
+
+
+@pytest.fixture
 def fds_data_context(
-    sa, empty_data_context: AbstractDataContext, sqlite_connection_string: str
+    sa,
+    fds_data_context_datasource_name: str,
+    empty_data_context: AbstractDataContext,
+    sqlite_connection_string: str,
 ) -> AbstractDataContext:
     context = empty_data_context
     datasource = context.sources.add_sqlite(
-        name="sqlite_datasource", connection_string=sqlite_connection_string
+        name=fds_data_context_datasource_name,
+        connection_string=sqlite_connection_string,
     )
 
     datasource.add_query_asset(

--- a/tests/core/test_batch_config.py
+++ b/tests/core/test_batch_config.py
@@ -6,9 +6,53 @@ from unittest.mock import Mock
 import pytest
 
 from great_expectations.core.batch_config import BatchConfig
+from great_expectations.data_context.data_context.abstract_data_context import (
+    AbstractDataContext,
+)
 from great_expectations.datasource.fluent.batch_request import BatchRequestOptions
 from great_expectations.datasource.fluent.interfaces import DataAsset
+from great_expectations.datasource.fluent.sql_datasource import TableAsset
+from great_expectations.datasource.fluent.sqlite_datasource import SqliteDatasource
 
+
+@pytest.fixture
+def mock_asset_name() -> str:
+    return "foo"
+
+
+@pytest.fixture
+def mock_asset(
+    mock_asset_name: str,
+) -> TableAsset:
+    mock_data_asset = Mock(spec=TableAsset)
+    mock_data_asset.name = mock_asset_name
+    return mock_data_asset
+
+
+@pytest.fixture
+def data_context(
+    fds_data_context: AbstractDataContext,
+    fds_data_context_datasource_name: str,
+    mock_asset: TableAsset,
+) -> AbstractDataContext:
+    datasource = fds_data_context.get_datasource(fds_data_context_datasource_name)
+    assert isinstance(datasource, SqliteDatasource)
+    datasource.assets.append(mock_asset)
+    return fds_data_context
+
+@pytest.mark.unit
+def test_data_asset(
+    data_context: AbstractDataContext,
+    fds_data_context_datasource_name: str,
+    mock_asset_name: str,
+    mock_asset: DataAsset,
+):
+    batch_config = BatchConfig(
+        context=data_context,
+        datasource_name=fds_data_context_datasource_name,
+        data_asset_name=mock_asset_name,
+    )
+    assert batch_config.data_asset == mock_asset
 
 @pytest.mark.parametrize(
     "batch_request_options",
@@ -18,12 +62,20 @@ from great_expectations.datasource.fluent.interfaces import DataAsset
     ],
 )
 @pytest.mark.unit
-def test_build_batch_request(batch_request_options: Optional[BatchRequestOptions]):
-    batch_config = BatchConfig(data_asset=Mock(spec=DataAsset))
+def test_build_batch_request(
+    batch_request_options: Optional[BatchRequestOptions],
+    data_context: AbstractDataContext,
+    fds_data_context_datasource_name: str,
+    mock_asset_name: str,
+):
+    batch_config = BatchConfig(
+        context=data_context,
+        datasource_name=fds_data_context_datasource_name,
+        data_asset_name=mock_asset_name,
+    )
 
     batch_config.build_batch_request(batch_request_options=batch_request_options)
 
     mock_build_batch_request = batch_config.data_asset.build_batch_request
     assert isinstance(mock_build_batch_request, Mock)
-
     mock_build_batch_request.assert_called_once_with(options=batch_request_options)

--- a/tests/core/test_batch_config.py
+++ b/tests/core/test_batch_config.py
@@ -40,6 +40,7 @@ def data_context(
     datasource.assets.append(mock_asset)
     return fds_data_context
 
+
 @pytest.mark.unit
 def test_data_asset(
     data_context: AbstractDataContext,
@@ -53,6 +54,7 @@ def test_data_asset(
         data_asset_name=mock_asset_name,
     )
     assert batch_config.data_asset == mock_asset
+
 
 @pytest.mark.parametrize(
     "batch_request_options",

--- a/tests/validator/test_v1_validator.py
+++ b/tests/validator/test_v1_validator.py
@@ -6,7 +6,6 @@ from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
-from great_expectations.datasource.fluent.sqlite_datasource import SqliteDatasource
 from great_expectations.expectations.core.expect_column_values_to_be_between import (
     ExpectColumnValuesToBeBetween,
 )
@@ -55,22 +54,26 @@ def expectation_suite(
 
 
 @pytest.fixture
-def batch_config(fds_data_context: AbstractDataContext) -> BatchConfig:
-    datasource = fds_data_context.get_datasource("sqlite_datasource")
-    assert isinstance(datasource, SqliteDatasource)
+def batch_config(
+    fds_data_context: AbstractDataContext,
+    fds_data_context_datasource_name: str,
+) -> BatchConfig:
     return BatchConfig(
-        data_asset=datasource.get_asset("trip_asset"),
+        context=fds_data_context,
+        datasource_name=fds_data_context_datasource_name,
+        data_asset_name="trip_asset",
     )
 
 
 @pytest.fixture
 def batch_config_with_event_type_splitter(
     fds_data_context: AbstractDataContext,
+    fds_data_context_datasource_name: str,
 ) -> BatchConfig:
-    datasource = fds_data_context.get_datasource("sqlite_datasource")
-    assert isinstance(datasource, SqliteDatasource)
     return BatchConfig(
-        data_asset=datasource.get_asset("trip_asset_split_by_event_type"),
+        context=fds_data_context,
+        datasource_name=fds_data_context_datasource_name,
+        data_asset_name="trip_asset_split_by_event_type",
     )
 
 


### PR DESCRIPTION
After discussing it with the team, we should not be storing the `DataAsset` directly on the `BatchConfig`. Instead, we should have a reference to the context, and fetch the asset based on datasource and asset names. We can expose the asset as a property for nicer ergonomics.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
