### PR TITLE
[DOCS] Document Create New/Add to Existing Expectation Suite Functionality on GX Cloud Data Assets Page

### DIFF
--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -120,7 +120,7 @@ The following table lists the available Data Asset metrics.
 
 6. Select an Expectation type. See [Available Expectation types](/docs/cloud/expectations/manage_expectations#available-expectation-types).
 
-7. Select a column in the **Create Expectation** pane and then complete the optional fields.
+7. Complete the fields in the **Create Expectation** pane.
 
 8. Click **Save** to add the Expectation, or click **Save & Add More** to add additional Expectations.
 

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -98,7 +98,7 @@ The following table lists the available Data Asset metrics.
 | **Median**                                 | For numeric columns, the value in the middle of a data set.<br/> 50% of the data within the Data Asset has a value smaller or equal to the median, and 50% of the data within the Data Asset has a value that is higher or equal to the median.  |
 | **Null %**                                | The percentage of missing values in a column.             |
 
-## Add an Expectation to Data Asset Metrics
+## Add an Expectation to a Data Asset column
 
 1. In GX Cloud, click **Data Assets** and then select a Data Asset in the **Data Assets** list.
 

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -98,6 +98,32 @@ The following table lists the available Data Asset metrics.
 | **Median**                                 | For numeric columns, the value in the middle of a data set.<br/> 50% of the data within the Data Asset has a value smaller or equal to the median, and 50% of the data within the Data Asset has a value that is higher or equal to the median.  |
 | **Null %**                                | The percentage of missing values in a column.             |
 
+## Add an Expectation to Data Asset Metrics
+
+1. In GX Cloud, click **Data Assets** and then select a Data Asset in the **Data Assets** list.
+
+2. Click the **Overview** tab.
+
+3. Select one of the following options: 
+
+    - If you have not previously generated Data Asset metrics, click **Fetch Metrics**. 
+
+    - If you previously generated Data Asset metrics, click **Refresh** to refresh the metrics.
+
+4. Scroll to the end of the Data Asset Metrics list and click **Create Expectation**.
+
+5. Select one of the following options:
+
+    - To add an Expectation to a new Expectation Suite, click the **Create new Expectation Suite** tab and then enter a name for the Expectation.
+
+    - To add an Expectation to an existing Expectation Suite, click the **Add to existing Expectation Suite** tab and then select an existing Expectation Suite.
+
+6. Select an Expectation type. See [Available Expectation types](/docs/cloud/expectations/manage_expectations#available-expectation-types).
+
+7. Select a column and then complete the optional fields.
+
+8. Click **Save** to add the Expectation, or click **Save & Add More** to add additional Expectations.
+
 
 ## Add a Data Asset to an Existing Data Source
 

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -114,13 +114,13 @@ The following table lists the available Data Asset metrics.
 
 5. Select one of the following options:
 
-    - To add an Expectation to a new Expectation Suite, click the **Create new Expectation Suite** tab and then enter a name for the Expectation.
+    - To add an Expectation to a new Expectation Suite, click the **Create new Expectation Suite** tab and then enter a name for the new Expectation Suite.
 
     - To add an Expectation to an existing Expectation Suite, click the **Add to existing Expectation Suite** tab and then select an existing Expectation Suite.
 
 6. Select an Expectation type. See [Available Expectation types](/docs/cloud/expectations/manage_expectations#available-expectation-types).
 
-7. Select a column and then complete the optional fields.
+7. Select a column in the **Create Expectation** pane and then complete the optional fields.
 
 8. Click **Save** to add the Expectation, or click **Save & Add More** to add additional Expectations.
 

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -14,6 +14,26 @@ To learn more about Expectations, see [Expectation](../../terms/expectation.md).
 
 - You have a [Data Asset](/docs/cloud/data_assets/manage_data_assets#create-a-data-asset).
 
+## Available Expectation types
+
+The following table lists the available GX Cloud Expectation types.
+
+| Expectation type                         | Description                                               | 
+|------------------------------------------|------------------------------------------------------------------------|
+| `expect_column_max_to_be_between`        | Expect the column maximum to be between a minimum and a maximum value. For more information, see [expect_column_max_to_be_between](https://greatexpectations.io/expectations/expect_column_max_to_be_between).  | 
+| `expect_column_mean_to_be_between`       | Expect the column mean to be between a minimum and a maximum value (inclusive). For more information, see [expect_column_mean_to_be_between](https://greatexpectations.io/expectations/expect_column_mean_to_be_between). | 
+| `expect_column_median_to_be_between`     | Expect the column median to be between a minimum and a maximum value. For more information, see [expect_column_median_to_be_between](https://greatexpectations.io/expectations/expect_column_median_to_be_between). | 
+| `expect_column_min_to_be_between`        | Expect the column minimum to be between a minimum value and a maximum value. For more information, see  [expect_column_min_to_be_between](https://greatexpectations.io/expectations/expect_column_min_to_be_between).| 
+| `expect_column_values_to_be_in_set`      | Expect each column value to be in a given set. For more information, see [expect_column_values_to_be_in_set](https://greatexpectations.io/expectations/expect_column_values_to_be_in_set).| 
+| `expect_column_values_to_be_in_type_list`| Expect a column to contain values from a specified type list. For more information, see [expect_column_values_to_be_in_type_list](https://greatexpectations.io/expectations/expect_column_values_to_be_in_type_list).|
+| `expect_column_values_to_be_null`        | Expect the column values to be null. For more information, see [expect_column_values_to_be_null](https://greatexpectations.io/expectations/expect_column_values_to_be_null).|
+| `expect_column_values_to_be_of_type`     | Expect a column to contain values of a specified data type. For more information, see [expect_column_values_to_be_of_type](https://greatexpectations.io/expectations/expect_column_values_to_be_of_type).|
+| `expect_column_values_to_be_unique`      | Expect each column value to be unique. For more information, see [expect_column_values_to_be_unique](https://greatexpectations.io/expectations/expect_column_values_to_be_unique).|
+| `expect_column_values_to_not_be_null`    | Expect the column values to not be null. For more information, see [expect_column_values_to_not_be_null](https://greatexpectations.io/expectations/expect_column_values_to_not_be_null).|
+| `expect_table_columns_to_match_ordered_list` | Expect the columns to exactly match a specified list. For more information, see [expect_table_columns_to_match_ordered_list](https://greatexpectations.io/expectations/expect_table_columns_to_match_ordered_list).|
+| `expect_table_row_count_to_be_between`   | Expect the number of rows to be between two values. For more information, see [expect_table_row_count_to_be_between](https://greatexpectations.io/expectations/expect_table_row_count_to_be_between).|
+| `expect_table_row_count_to_equal`        | Expect the number of rows to equal a value. For more information, see [expect_table_row_count_to_equal](https://greatexpectations.io/expectations/expect_table_row_count_to_equal). |                                          
+
 ## Add an Expectation
 
 1. In GX Cloud, click **Data Assets**.
@@ -24,33 +44,7 @@ To learn more about Expectations, see [Expectation](../../terms/expectation.md).
 
 4. Click **New Expectation**.
 
-5. Select one of the following Expectation types:
-
-    - [expect_column_max_to_be_between](https://greatexpectations.io/expectations/expect_column_max_to_be_between) - Expect the column maximum to be between a minimum and a maximum value.
-
-    - [expect_column_mean_to_be_between](https://greatexpectations.io/expectations/expect_column_mean_to_be_between) - Expect the column mean to be between a minimum and a maximum value (inclusive).
-
-    - [expect_column_median_to_be_between](https://greatexpectations.io/expectations/expect_column_median_to_be_between) - Expect the column median to be between a minimum and a maximum value.
-
-    - [expect_column_min_to_be_between](https://greatexpectations.io/expectations/expect_column_min_to_be_between) - Expect the column minimum to be between a minimum value and a maximum value.
-
-    - [expect_column_values_to_be_in_set](https://greatexpectations.io/expectations/expect_column_values_to_be_in_set) - Expect each column value to be in a given set.
-
-    - [expect_column_values_to_be_in_type_list](https://greatexpectations.io/expectations/expect_column_values_to_be_in_type_list) - Expect a column to contain values from a specified type list.
-
-    - [expect_column_values_to_be_null](https://greatexpectations.io/expectations/expect_column_values_to_be_null) - Expect the column values to be null.
-
-    - [expect_column_values_to_be_of_type](https://greatexpectations.io/expectations/expect_column_values_to_be_of_type) - Expect a column to contain values of a specified data type.
-
-    - [expect_column_values_to_be_unique](https://greatexpectations.io/expectations/expect_column_values_to_be_unique) - Expect each column value to be unique.
-
-    - [expect_column_values_to_not_be_null](https://greatexpectations.io/expectations/expect_column_values_to_not_be_null) - Expect the column values to not be null.
-
-    - [expect_table_columns_to_match_ordered_list](https://greatexpectations.io/expectations/expect_table_columns_to_match_ordered_list) - Expect the columns to exactly match a specified list.
-
-    - [expect_table_row_count_to_be_between](https://greatexpectations.io/expectations/expect_table_row_count_to_be_between) - Expect the number of rows to be between two values.
-
-    - [expect_table_row_count_to_equal](https://greatexpectations.io/expectations/expect_table_row_count_to_equal) - Expect the number of rows to equal a value.
+5. Select an Expectation type. See [Available Expectation types](#available-expectation-types).
 
     If you prefer to work in a code editor, or you want to configure an Expectation from the [Expectations Gallery](https://greatexpectations.io/expectations/) that isn't listed, click the **JSON Editor** tab and define your Expectation parameters in the code pane.
 

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -48,7 +48,7 @@ The following table lists the available GX Cloud Expectation types.
 
     If you prefer to work in a code editor, or you want to configure an Expectation from the [Expectations Gallery](https://greatexpectations.io/expectations/) that isn't listed, click the **JSON Editor** tab and define your Expectation parameters in the code pane.
 
-6. Enter the column name in the **Create Expectation** pane and then complete the optional fields.
+6. Complete the fields in the **Create Expectation** pane.
 
 7. Click **Save**.
 

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -48,7 +48,7 @@ The following table lists the available GX Cloud Expectation types.
 
     If you prefer to work in a code editor, or you want to configure an Expectation from the [Expectations Gallery](https://greatexpectations.io/expectations/) that isn't listed, click the **JSON Editor** tab and define your Expectation parameters in the code pane.
 
-6. Enter the column name and then complete the optional fields.
+6. Enter the column name in the **Create Expectation** pane and then complete the optional fields.
 
 7. Click **Save**.
 

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -101,6 +101,11 @@ module.exports = {
             },
             {
               type: 'link',
+              label: 'Add an Expectation to a Data Asset column',
+              href: '/docs/cloud/data_assets/manage_data_assets#add-an-expectation-to-a-data-asset-column',
+            },
+            {
+              type: 'link',
               label: 'Add a Data Asset to an Existing Data Source',
               href: '/docs/cloud/data_assets/manage_data_assets#add-a-data-asset-to-an-existing-data-source',
             },
@@ -121,6 +126,11 @@ module.exports = {
           label: 'Manage Expectations',
           link: { type: 'doc', id: 'cloud/expectations/manage_expectations' },
           items: [
+            {
+              type: 'link',
+              label: 'Available Expectation types',
+              href: '/docs/cloud/expectations/manage_expectations#available-expectation-types',
+            },
             {
               type: 'link',
               label: 'Add an Expectation',


### PR DESCRIPTION
[DOC-615](https://greatexpectations.atlassian.net/browse/DOC-615) requests the addition of content to the GX Cloud docs that describes how to add a new Expectation to a Data Asset column after generating metrics. This PR implements this update.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated

[DOC-615]: https://greatexpectations.atlassian.net/browse/DOC-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ