### PR TITLE
[DOCS] Add Statement to Update Expectation Suite Name in Existing Code

### DIFF
--- a/docs/docusaurus/docs/cloud/expectation_suites/manage_expectation_suites.md
+++ b/docs/docusaurus/docs/cloud/expectation_suites/manage_expectation_suites.md
@@ -62,6 +62,8 @@ If you have specific business requirements, or you want to examine specific data
 
 3. Edit the Expectation Suite name and then click **Save**.
 
+4. Optional. Update the Expectation Suite name in all code that included the previous Expectation Suite name.
+
 ## Delete an Expectation Suite
 
 1. In GX Cloud, delete all Checkpoints associated with the Expectation Suite. See [Delete a Checkpoint](/docs/cloud/checkpoints/manage_checkpoints#delete-a-checkpoint). 


### PR DESCRIPTION
In [this Slack](https://greatexpectationslabs.slack.com/archives/C03AEDCEE12/p1700677555340239) conversation, @jcampbell indicated that users should be informed that the Expectation Suite name will need to be updated in all existing code when the Expectation Suite name is edited.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated