### PR TITLE
[DOCS] Minor Edits to Available Expectation Types

### DIFF
--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -18,21 +18,21 @@ To learn more about Expectations, see [Expectation](../../terms/expectation.md).
 
 The following table lists the available GX Cloud Expectation types.
 
-| Expectation type                         | Description                                               | 
-|------------------------------------------|------------------------------------------------------------------------|
-| `expect_column_max_to_be_between`        | Expect the column maximum to be between a minimum and a maximum value. For more information, see [expect_column_max_to_be_between](https://greatexpectations.io/expectations/expect_column_max_to_be_between).  | 
-| `expect_column_mean_to_be_between`       | Expect the column mean to be between a minimum and a maximum value (inclusive). For more information, see [expect_column_mean_to_be_between](https://greatexpectations.io/expectations/expect_column_mean_to_be_between). | 
-| `expect_column_median_to_be_between`     | Expect the column median to be between a minimum and a maximum value. For more information, see [expect_column_median_to_be_between](https://greatexpectations.io/expectations/expect_column_median_to_be_between). | 
-| `expect_column_min_to_be_between`        | Expect the column minimum to be between a minimum value and a maximum value. For more information, see  [expect_column_min_to_be_between](https://greatexpectations.io/expectations/expect_column_min_to_be_between).| 
-| `expect_column_values_to_be_in_set`      | Expect each column value to be in a given set. For more information, see [expect_column_values_to_be_in_set](https://greatexpectations.io/expectations/expect_column_values_to_be_in_set).| 
-| `expect_column_values_to_be_in_type_list`| Expect a column to contain values from a specified type list. For more information, see [expect_column_values_to_be_in_type_list](https://greatexpectations.io/expectations/expect_column_values_to_be_in_type_list).|
-| `expect_column_values_to_be_null`        | Expect the column values to be null. For more information, see [expect_column_values_to_be_null](https://greatexpectations.io/expectations/expect_column_values_to_be_null).|
-| `expect_column_values_to_be_of_type`     | Expect a column to contain values of a specified data type. For more information, see [expect_column_values_to_be_of_type](https://greatexpectations.io/expectations/expect_column_values_to_be_of_type).|
-| `expect_column_values_to_be_unique`      | Expect each column value to be unique. For more information, see [expect_column_values_to_be_unique](https://greatexpectations.io/expectations/expect_column_values_to_be_unique).|
-| `expect_column_values_to_not_be_null`    | Expect the column values to not be null. For more information, see [expect_column_values_to_not_be_null](https://greatexpectations.io/expectations/expect_column_values_to_not_be_null).|
-| `expect_table_columns_to_match_ordered_list` | Expect the columns to exactly match a specified list. For more information, see [expect_table_columns_to_match_ordered_list](https://greatexpectations.io/expectations/expect_table_columns_to_match_ordered_list).|
-| `expect_table_row_count_to_be_between`   | Expect the number of rows to be between two values. For more information, see [expect_table_row_count_to_be_between](https://greatexpectations.io/expectations/expect_table_row_count_to_be_between).|
-| `expect_table_row_count_to_equal`        | Expect the number of rows to equal a value. For more information, see [expect_table_row_count_to_equal](https://greatexpectations.io/expectations/expect_table_row_count_to_equal). |                                          
+| Expectation                              | Description                                                                    | 
+|------------------------------------------|--------------------------------------------------------------------------------|
+| `expect_column_max_to_be_between`        | Expect the column maximum to be between a minimum and a maximum value.         | 
+| `expect_column_mean_to_be_between`       | Expect the column mean to be between a minimum and a maximum value (inclusive).| 
+| `expect_column_median_to_be_between`     | Expect the column median to be between a minimum and a maximum value.          | 
+| `expect_column_min_to_be_between`        | Expect the column minimum to be between a minimum value and a maximum value.   | 
+| `expect_column_values_to_be_in_set`      | Expect each column value to be in a given set.                                 | 
+| `expect_column_values_to_be_in_type_list`| Expect a column to contain values from a specified type list.                  |
+| `expect_column_values_to_be_null`        | Expect the column values to be null.                                           |
+| `expect_column_values_to_be_of_type`     | Expect a column to contain values of a specified data type.                    |
+| `expect_column_values_to_be_unique`      | Expect each column value to be unique.                                         |
+| `expect_column_values_to_not_be_null`    | Expect the column values to not be null.                                       |
+| `expect_table_columns_to_match_ordered_list` | Expect the columns to exactly match a specified list.                      |
+| `expect_table_row_count_to_be_between`   | Expect the number of rows to be between two values.                            |
+| `expect_table_row_count_to_equal`        | Expect the number of rows to equal a value.                                    |                                          
 
 ## Add an Expectation
 

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -14,9 +14,9 @@ To learn more about Expectations, see [Expectation](../../terms/expectation.md).
 
 - You have a [Data Asset](/docs/cloud/data_assets/manage_data_assets#create-a-data-asset).
 
-## Available Expectation types
+## Available Expectations
 
-The following table lists the available GX Cloud Expectation types.
+The following table lists the available GX Cloud Expectations.
 
 | Expectation                              | Description                                                                    | 
 |------------------------------------------|--------------------------------------------------------------------------------|

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -76,7 +76,7 @@ Currently, the GX Cloud user interface is configured for Snowflake and this proc
 
 ## Secure your GX API Data Source connection strings
 
-You must obfuscate your sensitive Data Source credentials in your connection string when you use the GX API and not GX Cloud, to connect to Data Sources. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
+When you use the GX API and not GX Cloud to connect to Data Sources, you must obfuscate your sensitive Data Source credentials in your connection string. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
 
 1. Store your credential value as an environment variable by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the command to your `~/.bashrc` or `~/.zshrc` file. For example:
 

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -76,7 +76,7 @@ Currently, the GX Cloud user interface is configured for Snowflake and this proc
 
 ## Secure your GX API Data Source connection strings
 
-You must obfuscate your sensitive Data Source credentials in your connection string when you use the GX API, not GX Cloud, to create Data Sources. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
+You must obfuscate your sensitive Data Source credentials in your connection string when you use the GX API and not GX Cloud, to connect to Data Sources. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
 
 1. Store your credential value as an environment variable by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the command to your `~/.bashrc` or `~/.zshrc` file. For example:
 
@@ -93,6 +93,7 @@ You must obfuscate your sensitive Data Source credentials in your connection str
     Environment variable names must be enclosed by curly braces and be preceded by a dollar sign. For example: `${GX_CLOUD_SNOWFLAKE_PASSWORD}`. Do not use interpolation to add credential values to connection strings.
 
 3. Use the environment variable to supply the credential value when you run the GX Agent. For example:
+
     ```bash title="Terminal input"
     docker run --rm -e GX_CLOUD_SNOWFLAKE_PASSWORD="<snowflake_password>" -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
     ```

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -133,8 +133,8 @@ module.exports = {
           items: [
             {
               type: 'link',
-              label: 'Available Expectation types',
-              href: '/docs/cloud/expectations/manage_expectations#available-expectation-types',
+              label: 'Available Expectations',
+              href: '/docs/cloud/expectations/manage_expectations#available-expectations',
             },
             {
               type: 'link',

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -75,7 +75,7 @@ module.exports = {
             },
             {
               type: 'link',
-              label: 'Securely manage GX API Data Source connection strings',
+              label: 'Secure your GX API Data Source connection strings',
               href: '/docs/cloud/set_up_gx_cloud#secure-your-gx-api-data-source-connection-strings',
             },
           ]


### PR DESCRIPTION
In [this Slack conversation](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1701104355981359), @joshzzheng requested minor changes to the topic Available Expectation types. These changes included removing links to the Expectations Gallery and the word **type** from the column heading. This PR implements these changes and minor changes to content added by a member of the DevRel team.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] _Appropriate_ tests and docs have been updated