### PR TITLE
[MAINTENANCE] Explicitly register metrics on GX init

### DIFF
--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -4,7 +4,10 @@ from ._version import get_versions  # isort:skip
 __version__ = get_versions()["version"]  # isort:skip
 
 from great_expectations.data_context.migrator.cloud_migrator import CloudMigrator
-from great_expectations.expectations.registry import register_core_expectations
+from great_expectations.expectations.registry import (
+    register_core_expectations,
+    register_core_metrics,
+)
 
 del get_versions  # isort:skip
 
@@ -16,6 +19,7 @@ from great_expectations.data_context import get_context
 # Both of the following import paths will trigger this file, causing the registration to occur:
 #   import great_expectations as gx
 #   from great_expectations.core import ExpectationSuite, ExpectationConfiguration
+register_core_metrics()
 register_core_expectations()
 
 rtd_url_ge_version = __version__.replace(".", "_")

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -188,7 +188,7 @@ def register_core_metrics() -> None:
     after_count = len(_registered_metrics)
 
     if before_count == after_count:
-        logger.debug("Already registered core mtrics; no updates to registry")
+        logger.debug("Already registered core metrics; no updates to registry")
     else:
         logger.debug(f"Registered {after_count-before_count} core metrics")
 

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -168,6 +168,31 @@ def register_expectation(expectation: Type[Expectation]) -> None:
     _registered_expectations[expectation_type] = expectation
 
 
+def register_core_metrics() -> None:
+    """As Metric registration is the responsibility of MetaMetricProvider.__new__,
+    simply importing a given class will ensure that it is added to the Metric
+    registry.
+
+    We use this to grab metrics by name within our workflows.
+
+    Without this function, we need to hope that core Metrics are imported somewhere
+    in our import graph - if not, our registry will be empty and we'll see
+    MetricResolutionErrors.
+    """
+    before_count = len(_registered_metrics)
+
+    # Implicitly calls MetaMetricProvider.__new__ as Metrics are loaded from metrics.__init__.py
+    # As __new__ calls upon register_metric this import builds our core registry
+    from great_expectations.expectations import metrics  # noqa: F401
+
+    after_count = len(_registered_metrics)
+
+    if before_count == after_count:
+        logger.debug("Already registered core mtrics; no updates to registry")
+    else:
+        logger.debug(f"Registered {after_count-before_count} core metrics")
+
+
 def register_core_expectations() -> None:
     """As Expectation registration is the responsibility of MetaExpectation.__new__,
     simply importing a given class will ensure that it is added to the Expectation


### PR DESCRIPTION
Metrics are a dependency of workflows and require a populated global registry - we currently hope for an import that'll result in a populated registry but we should explictly load it. 

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
