### PR TITLE
[MAINTENANCE] Delete Checkpoint by name in a Cloud context

### DIFF
--- a/tests/integration/cloud/end_to_end/conftest.py
+++ b/tests/integration/cloud/end_to_end/conftest.py
@@ -131,12 +131,9 @@ def checkpoint(
     assert (
         len(checkpoint.validations) == 1
     ), "Checkpoint was not updated in the previous method call."
-    yield checkpoint
-    # PP-691: this is a bug
-    # you should only have to pass name
+
     context.delete_checkpoint(
-        # name=checkpoint_name,
-        id=checkpoint.ge_cloud_id,
+        name=checkpoint_name,
     )
     with pytest.raises(gx_exceptions.DataContextError):
         context.get_checkpoint(name=checkpoint_name)

--- a/tests/integration/cloud/end_to_end/conftest.py
+++ b/tests/integration/cloud/end_to_end/conftest.py
@@ -131,7 +131,7 @@ def checkpoint(
     assert (
         len(checkpoint.validations) == 1
     ), "Checkpoint was not updated in the previous method call."
-
+    yield checkpoint
     context.delete_checkpoint(
         name=checkpoint_name,
     )


### PR DESCRIPTION
Update Cloud context E2E test to delete a Checkpoint by name `context.delete_checkpoint(name=<Checkpoint_name>)`
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
