### PR TITLE
[BUGFIX] Patch faulty `ExpectColumnValuesToBeTwoLetterCountryCode` tests

### DIFF
--- a/tests/expectations/core/test_expect_column_values_to_be_in_set.py
+++ b/tests/expectations/core/test_expect_column_values_to_be_in_set.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pandas as pd
 import pytest
 
@@ -11,6 +13,7 @@ from great_expectations.expectations.core.expect_column_values_to_be_in_set impo
 
 # <snippet name="tests/expectations/core/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def">
 class ExpectColumnValuesToBeTwoLetterCountryCode(ExpectColumnValuesToBeInSet):
+    value_set: List[str] = ["FR", "DE", "CH", "ES", "IT", "BE", "NL", "PL"]
     default_kwarg_values = {
         "value_set": ["FR", "DE", "CH", "ES", "IT", "BE", "NL", "PL"],
     }


### PR DESCRIPTION
I moved too fast and broke things - this resolves a test failure that snuck in.

We should resolve this issue of Pydantic args vs default_kwargs_values asap

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
