### PR TITLE
[BUGFIX] Add missing result format to test

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_excludes.py
+++ b/docs/sphinx_api_docs_source/public_api_excludes.py
@@ -739,4 +739,14 @@ DEFAULT_EXCLUDES: list[IncludeExcludeDefinition] = [
             "great_expectations/experimental/metric_repository/column_descriptive_metrics_metric_retriever.py"
         ),
     ),
+    IncludeExcludeDefinition(
+        reason="Not yet part of the public API",
+        name="ResultFormat",
+        filepath=pathlib.Path("great_expectations/validator/v1_validator.py"),
+    ),
+    IncludeExcludeDefinition(
+        reason="Not yet part of the public API",
+        name="ResultFormat",
+        filepath=pathlib.Path("great_expectations/core/result_format.py"),
+    ),
 ]

--- a/tests/integration/docusaurus/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py
+++ b/tests/integration/docusaurus/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py
@@ -2,6 +2,7 @@ import pathlib
 
 # <snippet name="tests/integration/docusaurus/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get_context">
 import great_expectations as gx
+from great_expectations.core.result_format import ResultFormat
 
 context = gx.get_context()
 # </snippet>
@@ -65,7 +66,8 @@ expected_validation_result = {
         "kwargs": {
             "value": {
                 "$PARAMETER": "urn:great_expectations:validations:upstream_expectation_suite:expect_table_row_count_to_be_between.result.observed_value"
-            }
+            },
+            "result_format": ResultFormat.BASIC,
         },
         "expectation_type": "expect_table_row_count_to_equal",
         "meta": {},


### PR DESCRIPTION
Result format was added as a default for expectations but this test was not updated.


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
