### PR TITLE
[MAINTENANCE] Remove `catch_exceptions` on Expectations

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_confidence_for_data_label_to_be_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_confidence_for_data_label_to_be_greater_than_or_equal_to_threshold.py
@@ -171,7 +171,6 @@ class ExpectColumnValuesConfidenceForDataLabelToBeGreaterThanOrEqualToThreshold(
         "threshold": None,
         "data_label": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # This object contains metadata for display in the public Gallery

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_confidence_for_data_label_to_be_less_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_confidence_for_data_label_to_be_less_than_or_equal_to_threshold.py
@@ -171,7 +171,6 @@ class ExpectColumnValuesConfidenceForDataLabelToBeLessThanOrEqualToThreshold(
         "threshold": None,
         "data_label": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # This object contains metadata for display in the public Gallery

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_equal_to_or_greater_than_profile_min.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_equal_to_or_greater_than_profile_min.py
@@ -153,7 +153,6 @@ class ExpectColumnValuesToBeEqualToOrGreaterThanProfileMin(ColumnMapExpectation)
     default_kwarg_values = {
         "profile": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # This object contains metadata for display in the public Gallery

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_equal_to_or_less_than_profile_max.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_equal_to_or_less_than_profile_max.py
@@ -154,7 +154,6 @@ class ExpectColumnValuesToBeEqualToOrLessThanProfileMax(ColumnMapExpectation):
     default_kwarg_values = {
         "profile": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # This object contains metadata for display in the public Gallery

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_probabilistically_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_column_values_to_be_probabilistically_greater_than_or_equal_to_threshold.py
@@ -151,7 +151,6 @@ class ExpectColumnValuesToBeProbabilisticallyGreaterThanOrEqualToThreshold(
     default_kwarg_values = {
         "threshold": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # This object contains metadata for display in the public Gallery

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
@@ -228,7 +228,6 @@ class ExpectColumnDiscreteEntropyToBeBetween(ColumnAggregateExpectation):
                         "column": "empty_column",
                         "min_value": 0,
                         "max_value": 0,
-                        "catch_exceptions": False,
                     },
                     "out": {"success": True, "observed_value": 0.0},
                 }
@@ -262,7 +261,6 @@ class ExpectColumnDiscreteEntropyToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "base": 2,
     }
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_distinct_values_to_be_continuous.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_distinct_values_to_be_continuous.py
@@ -115,7 +115,6 @@ class ExpectColumnDistinctValuesToBeContinuous(ColumnAggregateExpectation):
         "row_condition": None,
         "condition_parser": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = ("column", "datetime_format")
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_distribution_to_match_benfords_law.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_distribution_to_match_benfords_law.py
@@ -257,7 +257,7 @@ class ExpectColumnDistributionToMatchBenfordsLaw(ColumnAggregateExpectation):
     #     "strict_max": None,
     #     "result_format": "BASIC",
     #
-    #     "catch_exceptions": False,
+    #
     # }
 
     # @classmethod

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
@@ -254,7 +254,6 @@ class ExpectColumnKurtosisToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # @classmethod

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_pair_values_to_have_difference_of_custom_percentage.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_pair_values_to_have_difference_of_custom_percentage.py
@@ -98,7 +98,6 @@ class ExpectColumnPairValuesToHaveDifferenceOfCustomPercentage(
         "percentage": 0.1,
         "mostly": 1.0,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     def validate_configuration(

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_skew_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_skew_to_be_between.py
@@ -320,7 +320,6 @@ class ExpectColumnSkewToBeBetween(ColumnAggregateExpectation):
         "strict_max": None,
         "abs": False,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # @classmethod

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_edtf_parseable.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_edtf_parseable.py
@@ -112,9 +112,6 @@ class ExpectColumnValuesToBeEdtfParseable(ColumnMapExpectation):
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
 
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_normally_distributed.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_normally_distributed.py
@@ -203,7 +203,6 @@ class ExpectColumnValuesToBeNormallyDistributed(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     # @classmethod

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
@@ -162,9 +162,6 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnAggregateExpectation)
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
 
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -193,7 +190,6 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnAggregateExpectation)
         "condition_parser": None,
         "strictly": False,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     def _validate_success_key(

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_match_xml_schema.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_match_xml_schema.py
@@ -97,9 +97,6 @@ class ExpectColumnValuesToMatchXmlSchema(ColumnMapExpectation):
         result_format (str or None): \
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_be_null_and_column_to_not_be_empty.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_be_null_and_column_to_not_be_empty.py
@@ -67,9 +67,6 @@ class ExpectColumnValuesToNotBeNullAndColumnToNotBeEmpty(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_character.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_character.py
@@ -60,9 +60,6 @@ class ExpectColumnValuesToNotContainCharacter(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_wasserstein_distance_to_be_less_than.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_wasserstein_distance_to_be_less_than.py
@@ -176,7 +176,6 @@ class ExpectColumnWassersteinDistanceToBeLessThan(ColumnAggregateExpectation):
         "raw_values": None,
         "partition": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
 
     examples = [

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_day_sum_to_be_close_to_equivalent_week_day_mean.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_day_sum_to_be_close_to_equivalent_week_day_mean.py
@@ -57,7 +57,6 @@ class ExpectDaySumToBeCloseToEquivalentWeekDayMean(QueryExpectation):
     # Default values
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "threshold": 0.25,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_in_months.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_in_months.py
@@ -169,7 +169,6 @@ class ExpectMulticolumnDatetimeDifferenceInMonths(MulticolumnMapExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "base": 2,
         "threshold": 0,
     }

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_to_be_less_than_two_months.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_to_be_less_than_two_months.py
@@ -156,7 +156,6 @@ class ExpectMulticolumnDatetimeDifferenceToBeLessThanTwoMonths(
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "base": 2,
     }
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_list_to_be_unique.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_list_to_be_unique.py
@@ -37,7 +37,6 @@ class ExpectQueriedColumnListToBeUnique(QueryExpectation):
         "condition_parser",
     )
     default_kwarg_values = {
-        "catch_exceptions": False,
         "meta": None,
         "query": query,
     }

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_be_both_filled_or_null.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_be_both_filled_or_null.py
@@ -49,7 +49,6 @@ class ExpectQueriedColumnPairValuesToBeBothFilledOrNull(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "query": query,
     }

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
@@ -33,7 +33,6 @@ class ExpectQueriedColumnPairValuesToHaveDiff(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "column_A": None,
         "column_B": None,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_be_unique_with_condition.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_be_unique_with_condition.py
@@ -38,7 +38,6 @@ class ExpectQueriedColumnToBeUniqueWithCondition(QueryExpectation):
     )
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "column": None,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_have_n_distinct_values_with_condition.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_have_n_distinct_values_with_condition.py
@@ -38,7 +38,6 @@ class ExpectQueriedColumnToHaveNDistinctValuesWithCondition(QueryExpectation):
     )
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "column": None,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -40,7 +40,6 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "column": None,
         "value": None,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_values_to_exist_in_second_table_column.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_values_to_exist_in_second_table_column.py
@@ -49,7 +49,6 @@ class ExpectQueriedColumnValuesToExistInSecondTableColumn(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "query": query,
     }

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
@@ -34,7 +34,6 @@ class ExpectQueriedCustomQueryToReturnNumRows(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "value": "dummy_value",
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_slowly_changing_table_to_have_no_gaps.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_slowly_changing_table_to_have_no_gaps.py
@@ -51,7 +51,6 @@ class ExpectQueriedSlowlyChangingTableToHaveNoGaps(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "threshold": 0,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_table_row_count_to_be.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_table_row_count_to_be.py
@@ -37,7 +37,6 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "value": None,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_query_count_with_filter_to_meet_threshold.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_query_count_with_filter_to_meet_threshold.py
@@ -35,7 +35,6 @@ class ExpectQueryCountWithFilterToMeetThreshold(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "query": query,
     }

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_query_to_have_no_duplicate_value_combinations.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_query_to_have_no_duplicate_value_combinations.py
@@ -33,7 +33,6 @@ class ExpectQueryToHaveNoDuplicateValueCombinations(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "columns": None,
         "query": query,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
@@ -278,9 +278,6 @@ class ExpectTableChecksumToEqualOtherTable(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -435,7 +432,6 @@ class ExpectTableChecksumToEqualOtherTable(BatchExpectation):
         "ignore_columns": "",
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
         "meta": None,
     }
 

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
@@ -198,7 +198,6 @@ class ExpectTableBinaryLabelModelBias(BatchExpectation):
         "result_format": "BASIC",
         "reference_group": None,
         "alpha": 0.05,
-        "catch_exceptions": False,
         "partial_success": False,
         "meta": None,
     }

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
@@ -131,7 +131,6 @@ class ExpectTableLinearFeatureImportancesToBe(BatchExpectation):
         "y_column": None,
         "threshold": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
     }
 

--- a/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_to_be_lat_lon_coordinates_in_range_of_given_point.py
+++ b/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_to_be_lat_lon_coordinates_in_range_of_given_point.py
@@ -201,9 +201,6 @@ class ExpectColumnValuesToBeLatLonCoordinatesInRangeOfGivenPoint(ColumnMapExpect
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_ascii.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_ascii.py
@@ -70,9 +70,6 @@ class ExpectColumnValuesToBeAscii(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_secure_passwords.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_secure_passwords.py
@@ -112,9 +112,6 @@ class ExpectColumnValuesToBeSecurePasswords(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_xml_parseable.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_xml_parseable.py
@@ -83,9 +83,6 @@ class ExpectColumnValuesToBeXmlParseable(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/docs/expectation_gallery/3-expectation-docstring-formatting.md
+++ b/docs/expectation_gallery/3-expectation-docstring-formatting.md
@@ -41,9 +41,6 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -112,9 +109,6 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/examples/expectations/query_expectation_template.py
+++ b/examples/expectations/query_expectation_template.py
@@ -34,7 +34,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "query": query,  # Passing the above `query` attribute here as a default kwarg allows for the Expectation to be run with the defaul query, or have that query overridden by passing a `query` kwarg into the expectation
     }

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -158,7 +158,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "column_index": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_table_columns_to_match_ordered_list": {
@@ -166,7 +165,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "success_kwargs": ("column_list",),
             "default_kwarg_values": {
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_table_columns_to_match_set": {
@@ -174,7 +172,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "success_kwargs": ("column_set", "exact_match"),
             "default_kwarg_values": {
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "exact_match": True,
             },
         },
@@ -185,7 +182,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "min_value": None,
                 "max_value": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_table_column_count_to_equal": {
@@ -193,7 +189,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "success_kwargs": ("value",),
             "default_kwarg_values": {
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_table_row_count_to_be_between": {
@@ -203,7 +198,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "min_value": None,
                 "max_value": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_table_row_count_to_equal": {
@@ -211,7 +205,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "success_kwargs": ("value",),
             "default_kwarg_values": {
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_unique": {
@@ -222,7 +215,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_not_be_null": {
@@ -233,7 +225,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_compound_columns_to_be_unique": {
@@ -244,7 +235,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "ignore_row_if": "all_values_are_missing",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_null": {
@@ -255,7 +245,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_of_type": {
@@ -266,7 +255,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_in_type_list": {
@@ -277,7 +265,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_in_set": {
@@ -289,7 +276,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "mostly": None,
                 "parse_strings_as_datetimes": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_not_be_in_set": {
@@ -301,7 +287,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "mostly": None,
                 "parse_strings_as_datetimes": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_between": {
@@ -326,7 +311,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "output_strftime_format": None,
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_increasing": {
@@ -339,7 +323,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "parse_strings_as_datetimes": None,
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_decreasing": {
@@ -352,7 +335,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "parse_strings_as_datetimes": None,
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_value_lengths_to_be_between": {
@@ -365,7 +347,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "max_value": None,
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_value_lengths_to_equal": {
@@ -376,7 +357,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_match_regex": {
@@ -387,7 +367,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_not_match_regex": {
@@ -398,7 +377,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_match_regex_list": {
@@ -410,7 +388,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "match_on": "any",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_not_match_regex_list": {
@@ -421,7 +398,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_match_strftime_format": {
@@ -432,7 +408,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_dateutil_parseable": {
@@ -443,7 +418,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_be_json_parseable": {
@@ -454,7 +428,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_values_to_match_json_schema": {
@@ -465,7 +438,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than": {
@@ -477,7 +449,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "p_value": 0.05,
                 "params": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_distinct_values_to_be_in_set": {
@@ -488,7 +459,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "parse_strings_as_datetimes": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_distinct_values_to_equal_set": {
@@ -499,7 +469,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "parse_strings_as_datetimes": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_distinct_values_to_contain_set": {
@@ -510,7 +479,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "parse_strings_as_datetimes": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_mean_to_be_between": {
@@ -524,7 +492,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "strict_min": False,
                 "strict_max": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_median_to_be_between": {
@@ -538,7 +505,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "strict_min": False,
                 "strict_max": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_quantile_values_to_be_between": {
@@ -549,7 +515,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "allow_relative_error": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_stdev_to_be_between": {
@@ -563,7 +528,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "strict_min": False,
                 "strict_max": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_unique_value_count_to_be_between": {
@@ -575,7 +539,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "min_value": None,
                 "max_value": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_proportion_of_unique_values_to_be_between": {
@@ -589,7 +552,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "strict_min": False,
                 "strict_max": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_most_common_value_to_be_in_set": {
@@ -600,7 +562,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "ties_okay": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_sum_to_be_between": {
@@ -614,7 +575,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "strict_min": False,
                 "strict_max": False,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_min_to_be_between": {
@@ -637,7 +597,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "parse_strings_as_datetimes": None,
                 "output_strftime_format": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_max_to_be_between": {
@@ -660,7 +619,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "parse_strings_as_datetimes": None,
                 "output_strftime_format": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_chisquare_test_p_value_to_be_greater_than": {
@@ -673,7 +631,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "p": 0.05,
                 "tail_weight_holdout": 0,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_bootstrapped_ks_test_p_value_to_be_greater_than": {
@@ -692,7 +649,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "bootstrap_samples": None,
                 "bootstrap_sample_size": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_kl_divergence_to_be_less_than": {
@@ -713,7 +669,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "internal_weight_holdout": 0,
                 "bucketize_data": True,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_pair_values_to_be_equal": {
@@ -729,7 +684,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "ignore_row_if": "both_values_are_missing",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_pair_values_A_to_be_greater_than_B": {
@@ -751,7 +705,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "parse_strings_as_datetimes": None,
                 "ignore_row_if": "both_values_are_missing",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_pair_values_to_be_in_set": {
@@ -768,7 +721,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "ignore_row_if": "both_values_are_missing",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_multicolumn_values_to_be_unique": {
@@ -779,7 +731,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "ignore_row_if": "all_values_are_missing",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_multicolumn_sum_to_equal": {
@@ -790,7 +741,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "ignore_row_if": "all_values_are_missing",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "_expect_column_values_to_be_of_type__aggregate": {
@@ -801,7 +751,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "_expect_column_values_to_be_of_type__map": {
@@ -812,7 +761,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "_expect_column_values_to_be_in_type_list__aggregate": {
@@ -823,7 +771,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "_expect_column_values_to_be_in_type_list__map": {
@@ -834,7 +781,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_column_value_z_scores_to_be_less_than": {
@@ -845,7 +791,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "condition_parser": "pandas",
                 "mostly": 1,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
             },
         },
         "expect_file_line_regex_match_count_to_be_between": {
@@ -863,7 +808,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "mostly": 1,
                 "nonnull_lines_regex": r"^\s*$",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
                 "_lines": None,
             },
@@ -877,7 +821,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "mostly": 1,
                 "nonnull_lines_regex": r"^\s*$",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
                 "_lines": None,
             },
@@ -888,7 +831,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "default_kwarg_values": {
                 "hash_alg": "md5",
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
             },
         },
@@ -899,7 +841,6 @@ class ExpectationConfiguration(SerializableDictDot):
                 "minsize": 0,
                 "maxsize": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
             },
         },
@@ -909,7 +850,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "default_kwarg_values": {
                 "filepath": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
             },
         },
@@ -919,7 +859,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "default_kwarg_values": {
                 "skip": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
             },
         },
@@ -929,7 +868,6 @@ class ExpectationConfiguration(SerializableDictDot):
             "default_kwarg_values": {
                 "schema": None,
                 "result_format": "BASIC",
-                "catch_exceptions": False,
                 "meta": None,
             },
         },

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -363,7 +363,6 @@ class DataAsset:
         self._expectation_suite.data_asset_type = self._data_asset_type
         self.default_expectation_args = {
             "include_config": True,
-            "catch_exceptions": False,
             "result_format": "BASIC",
         }
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -85,9 +85,6 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
         result_format (str or None): \
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -122,7 +119,6 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
     default_kwarg_values = {
         "value_set": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -43,9 +43,6 @@ class ExpectColumnDistinctValuesToContainSet(ColumnAggregateExpectation):
         result_format (str or None): \
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -80,7 +77,6 @@ class ExpectColumnDistinctValuesToContainSet(ColumnAggregateExpectation):
     default_kwarg_values = {
         "value_set": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -45,9 +45,6 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -86,7 +83,6 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnAggregateExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -114,9 +114,6 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -198,7 +195,6 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnAggregateExpectation):
         "bucketize_data": True,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -66,9 +66,6 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -120,7 +117,6 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = ("column", "min_value", "max_value", "strict_min", "strict_max")
 

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -59,9 +59,6 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
 
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -114,7 +111,6 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -56,9 +56,6 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -111,7 +108,6 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -60,9 +60,6 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -114,7 +111,6 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -50,9 +50,6 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -95,7 +92,6 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
         "ties_okay": None,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than.py
@@ -57,7 +57,6 @@ class ExpectColumnPairCramersPhiValueToBeLessThan(BatchExpectation):
         "n_bins_B": None,
         "threshold": 0.1,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_A",

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -44,9 +44,6 @@ class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without modification. \
             For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -90,7 +87,6 @@ class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):
         "condition_parser": None,  # we expect this to be explicitly set whenever a row_condition is passed
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_A",

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -43,9 +43,6 @@ class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without modification. \
             For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -87,7 +84,6 @@ class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):
         "mostly": 1.0,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_A",

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
@@ -65,9 +65,6 @@ class ExpectColumnPairValuesToBeInSet(ColumnPairMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without modification. \
             For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -106,7 +103,6 @@ class ExpectColumnPairValuesToBeInSet(ColumnPairMapExpectation):
         "condition_parser": None,  # we expect this to be explicitly set whenever a row_condition is passed
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
 
     args_keys = (

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -60,9 +60,6 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -114,7 +111,6 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -104,9 +104,6 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
 
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -153,7 +150,6 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
         "quantile_ranges": None,
         "result_format": "BASIC",
         "allow_relative_error": False,
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = (

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -55,9 +55,6 @@ class ExpectColumnStdevToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -108,7 +105,6 @@ class ExpectColumnStdevToBeBetween(ColumnAggregateExpectation):
         "max_value": None,
         "strict_max": False,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -56,9 +56,6 @@ class ExpectColumnSumToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -107,7 +104,6 @@ class ExpectColumnSumToBeBetween(ColumnAggregateExpectation):
         "strict_min": None,
         "strict_max": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -46,9 +46,6 @@ class ExpectColumnToExist(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -56,9 +56,6 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -106,7 +103,6 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
         "min_value": None,
         "max_value": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -65,9 +65,6 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -116,7 +113,6 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
         "strict_max": None,
         "mostly": 1,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -52,9 +52,6 @@ class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -89,7 +86,6 @@ class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -39,9 +39,6 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the Expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -78,6 +75,5 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column", "threshold")

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -59,9 +59,6 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -124,7 +121,6 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         "strict_min": False,
         "strict_max": False,  # tolerance=1e-9,
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = (

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -45,9 +45,6 @@ class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -52,9 +52,6 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -90,7 +87,6 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column",)
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -83,9 +83,6 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -91,9 +91,6 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -130,7 +127,6 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -55,9 +55,6 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -92,7 +89,6 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column",)
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -50,9 +50,6 @@ class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -57,9 +57,6 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -115,9 +115,6 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
 
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -152,7 +149,6 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         "type_": None,
         "mostly": 1,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -58,9 +58,6 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -53,9 +53,6 @@ class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -43,9 +43,6 @@ class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -53,9 +53,6 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -52,9 +52,6 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -54,9 +54,6 @@ class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -54,9 +54,6 @@ class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -74,9 +74,6 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -114,7 +111,6 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column",

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -62,9 +62,6 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -45,9 +45,6 @@ class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -49,9 +49,6 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -61,9 +61,6 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -48,9 +48,6 @@ class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -44,9 +44,6 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -82,7 +79,6 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
         "ignore_row_if": "all_values_are_missing",
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column_list",)
 

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -42,9 +42,6 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -81,7 +78,6 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         "ignore_row_if": "all_values_are_missing",
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_list",

--- a/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
@@ -56,9 +56,6 @@ class ExpectMulticolumnValuesToBeUnique(ColumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -99,7 +96,6 @@ class ExpectMulticolumnValuesToBeUnique(ColumnMapExpectation):
         "mostly": 1,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column_list",)
 

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -56,9 +56,6 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -93,7 +90,6 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
         "ignore_row_if": "all_values_are_missing",
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("column_list",)
 

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -49,9 +49,6 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -96,7 +93,6 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
         "max_value": None,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = (

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -37,9 +37,6 @@ class ExpectTableColumnCountToEqual(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -72,7 +69,6 @@ class ExpectTableColumnCountToEqual(BatchExpectation):
         "value": None,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = ("value",)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -38,9 +38,6 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -80,7 +77,6 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
         "column": None,
         "column_index": None,
         "include_config": True,
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = ("column_list",)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -43,9 +43,6 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -80,7 +77,6 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
         "column_set": None,
         "exact_match": True,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_set",

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -49,9 +49,6 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -96,7 +93,6 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         "min_value": None,
         "max_value": None,
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = (

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -42,9 +42,6 @@ class ExpectTableRowCountToEqual(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -77,7 +74,6 @@ class ExpectTableRowCountToEqual(BatchExpectation):
         "value": None,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
         "meta": None,
     }
     args_keys = ("value",)

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -49,9 +49,6 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
         include_config (boolean): \
             If True, then include the expectation config as part of the result object.
-        catch_exceptions (boolean or None): \
-            If True, then catch exceptions and include them as part of the result object. \
-            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
         meta (dict or None): \
             A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
@@ -85,7 +82,6 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
         "other_table_name": None,
         "result_format": "BASIC",
         "include_config": True,
-        "catch_exceptions": False,
     }
     args_keys = ("other_table_name",)
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -347,7 +347,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     default_kwarg_values: ClassVar[
         dict[str, Union[bool, str, float, RuleBasedProfilerConfig, None]]
     ] = {
-        "catch_exceptions": False,
         "result_format": ResultFormat.BASIC,
     }
     args_keys: ClassVar[Tuple[str, ...]] = ()
@@ -2466,7 +2465,6 @@ class QueryExpectation(BatchExpectation, ABC):
 
     default_kwarg_values: ClassVar[Dict] = {
         "result_format": ResultFormat.BASIC,
-        "catch_exceptions": False,
         "meta": None,
         "row_condition": None,
         "condition_parser": None,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -174,7 +174,6 @@ class Validator:
     """
 
     DEFAULT_RUNTIME_CONFIGURATION = {
-        "catch_exceptions": False,
         "result_format": "BASIC",
     }
     RUNTIME_KEYS = DEFAULT_RUNTIME_CONFIGURATION.keys()

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -202,7 +202,6 @@ def test_set_default_expectation_argument():
 
     assert {
         "include_config": True,
-        "catch_exceptions": False,
         "result_format": "BASIC",
     } == df.get_default_expectation_arguments()
 
@@ -210,7 +209,6 @@ def test_set_default_expectation_argument():
 
     assert {
         "include_config": True,
-        "catch_exceptions": False,
         "result_format": "SUMMARY",
     } == df.get_default_expectation_arguments()
 

--- a/tests/expectations/test_expectation_arguments.py
+++ b/tests/expectations/test_expectation_arguments.py
@@ -570,7 +570,6 @@ def test_result_format_configured_no_set_default_override(  # noqa: PLR0915
     assert result.to_json_dict() == {
         "expectation_config": {
             "kwargs": {
-                "catch_exceptions": False,
                 "result_format": {"result_format": "BOOLEAN_ONLY"},
                 "column": "Name",
                 "batch_id": "bd7b9290f981fde37aabd403e8a507ea",
@@ -606,7 +605,6 @@ def test_result_format_configured_no_set_default_override(  # noqa: PLR0915
             "expectation_type": "expect_column_values_to_not_be_null",
             "meta": {},
             "kwargs": {
-                "catch_exceptions": False,
                 "result_format": {
                     "result_format": "BOOLEAN_ONLY",
                     "include_unexpected_rows": False,
@@ -711,7 +709,6 @@ def test_result_format_configured_with_set_default_override(
         "result": {},
         "expectation_config": {
             "kwargs": {
-                "catch_exceptions": False,
                 "result_format": {"result_format": "SUMMARY"},
                 "column": "Name",
                 "batch_id": "bd7b9290f981fde37aabd403e8a507ea",

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
@@ -108,7 +108,6 @@ class ExpectColumnPairValuesToHaveADifferenceOfThree(ColumnPairMapExpectation):
         "condition_parser": None,  # we expect this to be explicitly set whenever a row_condition is passed
         "mostly": 1.0,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = (
         "column_A",

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
@@ -100,7 +100,6 @@ class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
         "condition_parser": None,  # we expect this to be explicitly set whenever a row_condition is passed
         "mostly": 1.0,
         "result_format": "BASIC",
-        "catch_exceptions": False,
     }
     args_keys = ("column_list",)
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -48,7 +48,6 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "column": None,
         "value": None,

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
@@ -45,7 +45,6 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
 
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "value": None,
         "query": query,

--- a/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
@@ -44,7 +44,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {
         "result_format": "BASIC",
-        "catch_exceptions": False,
         "meta": None,
         "query": query,  # Passing the above `query` attribute here as a default kwarg allows for the Expectation to be run with the defaul query, or have that query overridden by passing a `query` kwarg into the expectation
     }

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -929,7 +929,6 @@ def test_graph_validate_with_bad_config_catch_exceptions_false(
         ).graph_validate(
             configurations=[expectation_configuration],
             runtime_configuration={
-                "catch_exceptions": False,
                 "result_format": {"result_format": "BASIC"},
             },
         )


### PR DESCRIPTION
Remove unnecessary param

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
