### PR TITLE
[MAINTENANCE] Remove runtime overrides from Expectation methods

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_discrete_entropy_to_be_between.py
@@ -279,7 +279,7 @@ class ExpectColumnDiscreteEntropyToBeBetween(ColumnAggregateExpectation):
         Returns:
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         self.validate_metric_value_between_configuration(configuration=configuration)
 
     @classmethod

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_pair_values_to_have_difference_of_custom_percentage.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_pair_values_to_have_difference_of_custom_percentage.py
@@ -113,7 +113,7 @@ class ExpectColumnPairValuesToHaveDifferenceOfCustomPercentage(
         Returns:
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
-        super().validate_configuration(configuration)
+        super().validate_configuration()
 
         mostly = configuration.kwargs["mostly"]
         percentage = configuration.kwargs["percentage"]

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_in_set_spark_optimized.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_in_set_spark_optimized.py
@@ -96,7 +96,7 @@ class ExpectColumnValuesToBeInSetSparkOptimized(ColumnAggregateExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
         value_set = configuration.kwargs.get("value_set") or self._get_default_value(
             "value_set"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_match_powers_of_base.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_match_powers_of_base.py
@@ -216,7 +216,7 @@ class ExpectColumnValuesToMatchPowersOfBase(ColumnMapExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         base_integer = configuration.kwargs["base_integer"]

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_in_months.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_in_months.py
@@ -187,7 +187,7 @@ class ExpectMulticolumnDatetimeDifferenceInMonths(MulticolumnMapExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         start_datetime = configuration.kwargs["start_datetime"]

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_to_be_less_than_two_months.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_datetime_difference_to_be_less_than_two_months.py
@@ -173,7 +173,7 @@ class ExpectMulticolumnDatetimeDifferenceToBeLessThanTwoMonths(
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         start_datetime = configuration.kwargs["start_datetime"]

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_values_to_be_equal.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_multicolumn_values_to_be_equal.py
@@ -216,7 +216,7 @@ class ExpectMulticolumnValuesToBeEqual(MulticolumnMapExpectation):
             `InvalidExpectationConfigurationError`: The configuration does \
                 not contain the values required by the Expectation."
         """
-        super().validate_configuration(configuration)
+        super().validate_configuration()
 
         try:
             assert "column_list" in configuration.kwargs, "column_list is required"

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_be_both_filled_or_null.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_be_both_filled_or_null.py
@@ -67,7 +67,7 @@ class ExpectQueriedColumnPairValuesToBeBothFilledOrNull(QueryExpectation):
         Returns:
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         template_dict = configuration.kwargs.get("template_dict")

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_pair_values_to_have_diff.py
@@ -46,7 +46,7 @@ class ExpectQueriedColumnPairValuesToHaveDiff(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         diff = configuration["kwargs"].get("diff")
         mostly = configuration["kwargs"].get("mostly")
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -51,7 +51,7 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
         value = configuration["kwargs"].get("value")
         threshold = configuration["kwargs"].get("threshold")

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
@@ -106,7 +106,7 @@ class ExpectQueriedCustomQueryToReturnNumRows(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         value = configuration["kwargs"].get("value")
 
         try:

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_slowly_changing_table_to_have_no_gaps.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_slowly_changing_table_to_have_no_gaps.py
@@ -217,7 +217,7 @@ class ExpectQueriedSlowlyChangingTableToHaveNoGaps(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration]
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         threshold = configuration["kwargs"].get("threshold")
         if not threshold:
             threshold = self._get_default_value("threshold")

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_table_row_count_to_be.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_table_row_count_to_be.py
@@ -46,7 +46,7 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         value = configuration["kwargs"].get("value")
 
         try:

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_query_count_with_filter_to_meet_threshold.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_query_count_with_filter_to_meet_threshold.py
@@ -43,7 +43,7 @@ class ExpectQueryCountWithFilterToMeetThreshold(QueryExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration]
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
         threshold = configuration["kwargs"].get("threshold")
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_table_checksum_to_equal_other_table.py
@@ -470,7 +470,7 @@ class ExpectTableChecksumToEqualOtherTable(BatchExpectation):
                 ), "ignore_columns input is not valid. Please provide comma seperated columns list"
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         return True
 
     @classmethod

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
@@ -217,7 +217,7 @@ class ExpectTableBinaryLabelModelBias(BatchExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         #        columns = configuration.kwargs.get("important_columns")
@@ -244,7 +244,7 @@ class ExpectTableBinaryLabelModelBias(BatchExpectation):
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
-        super().validate_configuration(configuration)
+        super().validate_configuration()
 
     def _validate(
         self,

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
@@ -149,7 +149,7 @@ class ExpectTableLinearFeatureImportancesToBe(BatchExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         n_features = configuration.kwargs.get("n_features")
@@ -177,7 +177,7 @@ class ExpectTableLinearFeatureImportancesToBe(BatchExpectation):
             assert isinstance(y_column, str), "y_column must be a string column name"
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
-        super().validate_configuration(configuration)
+        super().validate_configuration()
 
     def _validate(
         self,

--- a/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_pair_values_lat_lng_matches_geohash.py
+++ b/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_pair_values_lat_lng_matches_geohash.py
@@ -112,7 +112,7 @@ class ExpectColumnPairValuesLatLngMatchesGeohash(ColumnPairMapExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration]
     ) -> None:
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
         try:
             assert (

--- a/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_geometry_distance_to_address_to_be_between.py
+++ b/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_geometry_distance_to_address_to_be_between.py
@@ -271,7 +271,7 @@ class ExpectColumnValuesGeometryDistanceToAddressToBeBetween(ColumnMapExpectatio
             True if the configuration has been validated successfully. Otherwise, raises an exception
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         configuration = configuration or self.configuration
 
         min_val = None

--- a/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_reverse_geocoded_lat_lon_to_contain.py
+++ b/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_reverse_geocoded_lat_lon_to_contain.py
@@ -85,7 +85,7 @@ class ExpectColumnValuesReverseGeocodedLatLonToContain(ColumnMapExpectation):
         """
 
         # Setting up a configuration
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         if configuration is None:
             configuration = cls.configuration
 

--- a/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_to_be_lat_lon_coordinates_in_range_of_given_point.py
+++ b/contrib/great_expectations_geospatial_expectations/great_expectations_geospatial_expectations/expectations/expect_column_values_to_be_lat_lon_coordinates_in_range_of_given_point.py
@@ -234,7 +234,7 @@ class ExpectColumnValuesToBeLatLonCoordinatesInRangeOfGivenPoint(ColumnMapExpect
         """
 
         # Setting up a configuration
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         if configuration is None:
             configuration = cls.configuration
 

--- a/contrib/great_expectations_zipcode_expectations/great_expectations_zipcode_expectations/expectations/expect_column_values_to_be_valid_india_zip.py
+++ b/contrib/great_expectations_zipcode_expectations/great_expectations_zipcode_expectations/expectations/expect_column_values_to_be_valid_india_zip.py
@@ -103,7 +103,7 @@ class ExpectColumnValuesToBeValidIndiaZip(ColumnMapExpectation):
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         if configuration is None:
             configuration = self.configuration
 

--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
@@ -560,7 +560,7 @@ Beginning in version 0.13, we have introduced a new API focused on enabling Modu
               max_val = None
 
               # Setting up a configuration
-              super().validate_configuration()
+              super().validate_configuration(configuration)
               if configuration is None:
                   configuration = self.configuration
 

--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
@@ -560,7 +560,7 @@ Beginning in version 0.13, we have introduced a new API focused on enabling Modu
               max_val = None
 
               # Setting up a configuration
-              super().validate_configuration(configuration)
+              super().validate_configuration()
               if configuration is None:
                   configuration = self.configuration
 

--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
@@ -43,7 +43,7 @@ Additional Notes
 .. code-block:: python
 
     def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
-        super().validate_configuration(configuration)
+        super().validate_configuration()
         assert "min_value" not in configuration.kwargs, "min_value cannot be altered"
         assert "max_value" not in configuration.kwargs, "max_value cannot be altered"
         assert "strict_min" not in configuration.kwargs, "strict_min cannot be altered"

--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
@@ -43,7 +43,7 @@ Additional Notes
 .. code-block:: python
 
     def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
-        super().validate_configuration()
+        super().validate_configuration(configuration)
         assert "min_value" not in configuration.kwargs, "min_value cannot be altered"
         assert "max_value" not in configuration.kwargs, "max_value cannot be altered"
         assert "strict_min" not in configuration.kwargs, "strict_min cannot be altered"

--- a/examples/expectations/batch_expectation_template.py
+++ b/examples/expectations/batch_expectation_template.py
@@ -100,7 +100,6 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: dict = None,
         execution_engine: ExecutionEngine = None,

--- a/examples/expectations/batch_expectation_template.py
+++ b/examples/expectations/batch_expectation_template.py
@@ -97,34 +97,6 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
     # This dictionary contains default values for any parameters that should have default values.
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,

--- a/examples/expectations/column_aggregate_expectation_template.py
+++ b/examples/expectations/column_aggregate_expectation_template.py
@@ -64,7 +64,6 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: dict = None,
         execution_engine: ExecutionEngine = None,

--- a/examples/expectations/column_aggregate_expectation_template.py
+++ b/examples/expectations/column_aggregate_expectation_template.py
@@ -61,34 +61,6 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
     # This dictionary contains default values for any parameters that should have default values.
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,

--- a/examples/expectations/column_map_expectation_template.py
+++ b/examples/expectations/column_map_expectation_template.py
@@ -61,34 +61,6 @@ class ExpectColumnValuesToMatchSomeCriteria(ColumnMapExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This object contains metadata for display in the public Gallery
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery

--- a/examples/expectations/column_pair_map_expectation_template.py
+++ b/examples/expectations/column_pair_map_expectation_template.py
@@ -70,34 +70,6 @@ class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This object contains metadata for display in the public Gallery
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery

--- a/examples/expectations/multicolumn_map_expectation_template.py
+++ b/examples/expectations/multicolumn_map_expectation_template.py
@@ -73,34 +73,6 @@ class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This object contains metadata for display in the public Gallery
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery

--- a/examples/expectations/query_expectation_template.py
+++ b/examples/expectations/query_expectation_template.py
@@ -42,7 +42,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: dict,
         runtime_configuration: dict = None,
         execution_engine: ExecutionEngine = None,

--- a/examples/expectations/query_expectation_template.py
+++ b/examples/expectations/query_expectation_template.py
@@ -39,33 +39,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
         "query": query,  # Passing the above `query` attribute here as a default kwarg allows for the Expectation to be run with the defaul query, or have that query overridden by passing a `query` kwarg into the expectation
     }
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     def _validate(
         self,

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -322,14 +322,13 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         observed_value_counts = metrics.get("column.value_counts")
         observed_value_set = set(observed_value_counts.index)
-        value_set = self.get_success_kwargs(configuration).get("value_set") or []
+        value_set = self.get_success_kwargs().get("value_set") or []
 
         parsed_value_set = value_set
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -190,13 +190,12 @@ class ExpectColumnDistinctValuesToContainSet(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         observed_value_counts = metrics.get("column.value_counts")
-        value_set = self.get_success_kwargs(configuration).get("value_set")
+        value_set = self.get_success_kwargs().get("value_set")
 
         parsed_value_set = value_set
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -219,14 +219,13 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         observed_value_counts = metrics.get("column.value_counts")
         observed_value_set = set(observed_value_counts.index)
-        value_set = self.get_success_kwargs(configuration).get("value_set")
+        value_set = self.get_success_kwargs().get("value_set")
 
         parsed_value_set = value_set
 

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -370,11 +370,11 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnAggregateExpectation):
 
     def _validate(  # noqa: C901, PLR0912, PLR0915
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         bucketize_data = configuration.kwargs.get(
             "bucketize_data", self._get_default_value("bucketize_data")
         )

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -262,11 +262,11 @@ class ExpectColumnMaxToBeBetween(ColumnAggregateExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.max",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -305,11 +305,11 @@ class ExpectColumnMeanToBeBetween(ColumnAggregateExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.mean",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -232,11 +232,11 @@ class ExpectColumnMedianToBeBetween(ColumnAggregateExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.median",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -262,11 +262,11 @@ class ExpectColumnMinToBeBetween(ColumnAggregateExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.min",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -206,11 +206,12 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         most_common_value = metrics.get("column.most_common_value")
         value_set = configuration.kwargs.get("value_set") or []
         expected_value_set = set(value_set)

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -282,11 +282,11 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.unique_proportion",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -600,11 +600,12 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         quantile_vals = metrics.get("column.quantile_values")
         quantile_ranges = configuration.kwargs.get("quantile_ranges")
         quantiles = quantile_ranges["quantiles"]

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -231,11 +231,11 @@ class ExpectColumnStdevToBeBetween(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.standard_deviation",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -232,11 +232,11 @@ class ExpectColumnSumToBeBetween(ColumnAggregateExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.sum",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -168,7 +168,6 @@ class ExpectColumnToExist(BatchExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -281,11 +281,11 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="column.distinct_values.count",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -1,11 +1,11 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from great_expectations.core import (
     ExpectationConfiguration,
     ExpectationValidationResult,
 )
-from great_expectations.core._docs_decorators import public_api
-from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.core.evaluation_parameters import EvaluationParameterDict
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
     render_evaluation_parameter_string,
@@ -88,6 +88,11 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
         [expect_column_value_lengths_to_equal](https://greatexpectations.io/expectations/expect_column_value_lengths_to_equal)
     """
 
+    min_value: Union[float, EvaluationParameterDict, datetime, None] = None
+    max_value: Union[float, EvaluationParameterDict, datetime, None] = None
+    strict_min: bool = False
+    strict_max: bool = False
+
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {
         "maturity": "production",
@@ -123,58 +128,6 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
         "min_value",
         "max_value",
     )
-
-    @public_api
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """Validates the configuration of an Expectation.
-
-        For `expect_column_value_lengths_to_be_between` it is required that the `configuration.kwargs` contain
-        `min_value` and/or `max_value`; both cannot be None.  Both `min_value` and `max_value` may be either an integer
-        or a `dict`; if a `dict`, it must include `$PARAMETER` as a key.
-
-         The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
-         superclass hierarchy.
-
-        Args:
-            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
-                from the configuration attribute of the Expectation instance.
-
-        Raises:
-            InvalidExpectationConfigurationError: The configuration does not contain the values required by the
-                Expectation.
-        """
-        super().validate_configuration(configuration)
-
-        configuration = configuration or self.configuration
-
-        try:
-            assert (
-                configuration.kwargs.get("min_value") is not None
-                or configuration.kwargs.get("max_value") is not None
-            ), "min_value and max_value cannot both be None"
-            if configuration.kwargs.get("min_value"):
-                assert (
-                    isinstance(configuration.kwargs["min_value"], dict)
-                    or float(configuration.kwargs.get("min_value")).is_integer()
-                ), "min_value and max_value must be integers"
-                if isinstance(configuration.kwargs.get("min_value"), dict):
-                    assert "$PARAMETER" in configuration.kwargs.get(
-                        "min_value"
-                    ), 'Evaluation Parameter dict for min_value kwarg must have "$PARAMETER" key.'
-
-            if configuration.kwargs.get("max_value"):
-                assert (
-                    isinstance(configuration.kwargs["max_value"], dict)
-                    or float(configuration.kwargs.get("max_value")).is_integer()
-                ), "min_value and max_value must be integers"
-                if isinstance(configuration.kwargs.get("max_value"), dict):
-                    assert "$PARAMETER" in configuration.kwargs.get(
-                        "max_value"
-                    ), 'Evaluation Parameter dict for max_value kwarg must have "$PARAMETER" key.'
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
 
     @classmethod
     def _prescriptive_template(  # noqa: PLR0912

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -500,11 +500,12 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         column_name = configuration.kwargs.get("column")
         expected_types_list = configuration.kwargs.get("type_list")
         actual_column_types_list = metrics.get("table.column_types")

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -212,11 +212,12 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         result_format = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration
         )

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -455,11 +455,12 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         column_name = configuration.kwargs.get("column")
         expected_type = configuration.kwargs.get("type_")
         actual_column_types_list = metrics.get("table.column_types")

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -8,7 +8,6 @@ from great_expectations.core.evaluation_parameters import (
 )
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
-    InvalidExpectationConfigurationError,
 )
 from great_expectations.render.components import (
     LegacyRendererType,
@@ -116,40 +115,6 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
         "column",
         "like_pattern_list",
     )
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """Validates the configuration for the Expectation.
-
-        For `expect_column_values_to_match_like_pattern`
-        we require that the `configuraton.kwargs` contain a `like_pattern_list` key that is either a `list` or `dict`.
-
-        Args:
-            configuration: The ExpectationConfiguration to be validated.
-
-        Raises:
-            InvalidExpectationConfigurationError: The configuraton does not contain the values required by the Expectation
-        """
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-        try:
-            assert (
-                "like_pattern_list" in configuration.kwargs
-            ), "Must provide like_pattern_list"
-            assert isinstance(
-                configuration.kwargs.get("like_pattern_list"), (list, dict)
-            ), "like_pattern_list must be a list"
-            assert isinstance(configuration.kwargs.get("like_pattern_list"), dict) or (
-                len(configuration.kwargs.get("like_pattern_list")) > 0
-            ), "At least one like_pattern must be supplied in the like_pattern_list."
-            if isinstance(configuration.kwargs.get("like_pattern_list"), dict):
-                assert "$PARAMETER" in configuration.kwargs.get(
-                    "like_pattern_list"
-                ), 'Evaluation Parameter dict for like_pattern_list kwarg must have "$PARAMETER" key.'
-
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -264,10 +264,8 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
-        configuration = self.configuration
-
         result_format = self.get_result_format(
-            configuration=configuration, runtime_configuration=runtime_configuration
+            runtime_configuration=runtime_configuration
         )
         mostly = self.get_success_kwargs().get("mostly")
         total_count = metrics.get("table.row_count")

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -260,11 +260,12 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         result_format = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration
         )

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -189,11 +189,11 @@ class ExpectTableColumnCountToBeBetween(BatchExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="table.column_count",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -118,11 +118,12 @@ class ExpectTableColumnCountToEqual(BatchExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
+
         expected_column_count = configuration.kwargs.get("value")
         actual_column_count = metrics.get("table.column_count")
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -159,13 +159,12 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         # Obtaining columns and ordered list for sake of comparison
-        expected_column_list = self.get_success_kwargs(configuration).get("column_list")
+        expected_column_list = self.get_success_kwargs().get("column_list")
         actual_column_list = metrics.get("table.columns")
 
         if expected_column_list is None or list(actual_column_list) == list(

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -179,19 +179,18 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         # Obtaining columns and ordered list for sake of comparison
-        expected_column_set = self.get_success_kwargs(configuration).get("column_set")
+        expected_column_set = self.get_success_kwargs().get("column_set")
         expected_column_set = (
             set(expected_column_set) if expected_column_set is not None else set()
         )
         actual_column_list = metrics.get("table.columns")
         actual_column_set = set(actual_column_list)
-        exact_match = self.get_success_kwargs(configuration).get("exact_match")
+        exact_match = self.get_success_kwargs().get("exact_match")
 
         if (
             (expected_column_set is None) and (exact_match is not True)

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -202,6 +202,7 @@ class ExpectTableRowCountToBeBetween(BatchExpectation):
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
+        configuration = self.configuration
         return self._validate_metric_value_between(
             metric_name="table.row_count",
             configuration=configuration,

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -135,7 +135,6 @@ class ExpectTableRowCountToEqual(BatchExpectation):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -198,7 +198,6 @@ class ExpectTableRowCountToEqualOtherTable(BatchExpectation):
 
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2305,7 +2305,6 @@ class BatchExpectation(Expectation, ABC):
     ) -> ValidationDependencies:
         validation_dependencies: ValidationDependencies = (
             super().get_validation_dependencies(
-                configuration=configuration,
                 execution_engine=execution_engine,
                 runtime_configuration=runtime_configuration,
             )

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2707,13 +2707,12 @@ class ColumnMapExpectation(BatchExpectation, ABC):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format: str | dict[str, Any] = self.get_result_format(
-            configuration=configuration, runtime_configuration=runtime_configuration
+            runtime_configuration=runtime_configuration
         )
 
         include_unexpected_rows: bool
@@ -2965,16 +2964,13 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format: Union[
             Dict[str, Union[int, str, bool, List[str], None]], str
-        ] = self.get_result_format(
-            configuration=configuration, runtime_configuration=runtime_configuration
-        )
+        ] = self.get_result_format(runtime_configuration=runtime_configuration)
 
         unexpected_index_column_names = None
         if isinstance(result_format, dict):
@@ -3223,13 +3219,12 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
     @override
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format = self.get_result_format(
-            configuration=configuration, runtime_configuration=runtime_configuration
+            runtime_configuration=runtime_configuration
         )
         unexpected_index_column_names = None
         if isinstance(result_format, dict):

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2107,7 +2107,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             return []
 
         validation_dependencies: ValidationDependencies = (
-            self.get_validation_dependencies(configuration=expectation_config)
+            self.get_validation_dependencies()
         )
 
         metric_name: str

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1048,13 +1048,11 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     def metrics_validate(
         self,
         metrics: dict,
-        configuration: Optional[ExpectationConfiguration] = None,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         **kwargs: dict,
     ) -> ExpectationValidationResult:
-        if not configuration:
-            configuration = self.configuration
+        configuration = self.configuration
 
         if runtime_configuration is None:
             runtime_configuration = {}
@@ -1176,17 +1174,14 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         return domain_kwargs
 
     @public_api
-    def get_success_kwargs(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> Dict[str, Any]:
+    def get_success_kwargs(self) -> Dict[str, Any]:
         """Retrieve the success kwargs.
 
         Args:
             configuration: The `ExpectationConfiguration` that contains the kwargs. If no configuration arg is provided,
                 the success kwargs from the configuration attribute of the Expectation instance will be returned.
         """
-        if not configuration:
-            configuration = self.configuration
+        configuration = self.configuration
 
         domain_kwargs: Dict[str, Optional[str]] = self.get_domain_kwargs(
             configuration=configuration
@@ -1200,11 +1195,9 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
 
     def get_runtime_kwargs(
         self,
-        configuration: Optional[ExpectationConfiguration] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> dict:
-        if not configuration:
-            configuration = self.configuration
+        configuration = self.configuration
 
         configuration = deepcopy(configuration)
 
@@ -1244,9 +1237,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         return result_format
 
     @public_api
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
+    def validate_configuration(self) -> None:
         pass  # no-op
 
     # Renamed from validate due to collision with Pydantic method of the same name
@@ -1254,7 +1245,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     def validate_(  # noqa: PLR0913
         self,
         validator: Validator,
-        configuration: Optional[ExpectationConfiguration] = None,
         evaluation_parameters: Optional[dict] = None,
         interactive_evaluation: bool = True,
         data_context: Optional[AbstractDataContext] = None,
@@ -1275,8 +1265,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         Returns:
             An ExpectationValidationResult object
         """
-        if not configuration:
-            configuration = deepcopy(self.configuration)
+        configuration = deepcopy(self.configuration)
 
         # issue warnings if necessary
         self._warn_if_result_format_config_in_runtime_configuration(
@@ -2463,9 +2452,7 @@ class QueryExpectation(BatchExpectation, ABC):
     )
 
     @override
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
+    def validate_configuration(self) -> None:
         """Raises an exception if the configuration is not viable for an expectation.
 
         Args:
@@ -2475,9 +2462,8 @@ class QueryExpectation(BatchExpectation, ABC):
               InvalidExpectationConfigurationError: If no `query` is specified
               UserWarning: If query is not parameterized, and/or row_condition is passed.
         """
-        super().validate_configuration(configuration=configuration)
-        if not configuration:
-            configuration = self.configuration
+        super().validate_configuration()
+        configuration = self.configuration
 
         query: Optional[Any] = configuration.kwargs.get(
             "query"

--- a/great_expectations/expectations/regex_based_column_map_expectation.py
+++ b/great_expectations/expectations/regex_based_column_map_expectation.py
@@ -7,9 +7,6 @@ from great_expectations.core import (
     ExpectationValidationResult,
 )
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.exceptions.exceptions import (
-    InvalidExpectationConfigurationError,
-)
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
@@ -122,6 +119,8 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
         map_metric (str): The name of an ephemeral metric, as returned by `register_metric(...)`.
     """
 
+    regex: str
+
     @staticmethod
     def register_metric(
         regex_camel_name: str,
@@ -150,36 +149,6 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
         )
 
         return map_metric
-
-    @public_api
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """Raise an exception if the configuration is not viable for an expectation.
-
-        Args:
-            configuration: An ExpectationConfiguration
-
-        Raises:
-            InvalidExpectationConfigurationError: If no `regex` or `column` specified, or if `mostly` parameter
-                incorrectly defined.
-        """
-        super().validate_configuration(configuration)
-        try:
-            assert (
-                getattr(self, "regex", None) is not None
-            ), "regex is required for RegexBasedColumnMap Expectations"
-            assert (
-                "column" in configuration.kwargs
-            ), "'column' parameter is required for column map expectations"
-            if "mostly" in configuration.kwargs:
-                mostly = configuration.kwargs["mostly"]
-                assert isinstance(
-                    mostly, (int, float)
-                ), "'mostly' parameter must be an integer or float"
-                assert 0 <= mostly <= 1, "'mostly' parameter must be between 0 and 1"
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
 
     # question, descriptive, prescriptive, diagnostic
     @classmethod

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -368,9 +368,7 @@ def get_metric_kwargs(
             expectation_impl = get_expectation_impl(configuration.expectation_type)
             configuration_kwargs = expectation_impl(
                 **configuration.kwargs
-            ).get_runtime_kwargs(
-                configuration=configuration, runtime_configuration=runtime_configuration
-            )
+            ).get_runtime_kwargs(runtime_configuration=runtime_configuration)
             if len(metric_kwargs["metric_domain_keys"]) > 0:
                 metric_domain_kwargs = IDDict(
                     {

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1129,7 +1129,6 @@ class Validator:
             validation_dependencies: ValidationDependencies = expectation_impl(
                 **evaluated_config.kwargs
             ).get_validation_dependencies(
-                configuration=evaluated_config,
                 execution_engine=self._execution_engine,
                 runtime_configuration=runtime_configuration,
             )

--- a/tests/data_asset/test_parameter_substitution.py
+++ b/tests/data_asset/test_parameter_substitution.py
@@ -46,12 +46,11 @@ def validator_with_titanic_1911_asset(
 
         def _validate(
             self,
-            configuration: ExpectationConfiguration,
             metrics: Dict,
             runtime_configuration: dict = None,
             execution_engine: ExecutionEngine = None,
         ):
-            expectation_argument = configuration.kwargs.get("expectation_argument")
+            expectation_argument = self.configuration.kwargs.get("expectation_argument")
             return {
                 "success": True,
                 "result": {"details": {"expectation_argument": expectation_argument}},

--- a/tests/expectations/core/test_expect_column_mean_to_be_positive.py
+++ b/tests/expectations/core/test_expect_column_mean_to_be_positive.py
@@ -18,8 +18,9 @@ class ExpectColumnMeanToBePositive(ExpectColumnMeanToBeBetween):
 
     # </snippet>
     # <snippet name="tests/expectations/core/test_expect_column_mean_to_be_positive.py validate_config">
-    def validate_configuration(self, configuration):
-        super().validate_configuration(configuration)
+    def validate_configuration(self):
+        super().validate_configuration()
+        configuration = self.configuration
         assert "min_value" not in configuration.kwargs, "min_value cannot be altered"
         assert "max_value" not in configuration.kwargs, "max_value cannot be altered"
         assert "strict_min" not in configuration.kwargs, "strict_min cannot be altered"

--- a/tests/expectations/fixtures/expect_column_values_to_equal_three.py
+++ b/tests/expectations/fixtures/expect_column_values_to_equal_three.py
@@ -37,7 +37,7 @@ class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
     success_keys = ("mostly",)
     # default_kwarg_values = ColumnMapExpectation.default_kwarg_values
 
-    def validate_configuration(self, configuration) -> None:
+    def validate_configuration(self) -> None:
         pass  # no-op to make test setup easier
 
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
@@ -177,14 +177,13 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py validate">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: dict | None = None,
         execution_engine: ExecutionEngine | None = None,
     ):
         unique_columns = metrics.get("table.columns.unique")
         batch_columns = metrics.get("table.columns")
-        strict = configuration.kwargs.get("strict")
+        strict = self.configuration.kwargs.get("strict")
 
         duplicate_columns = unique_columns.symmetric_difference(batch_columns)
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
@@ -151,22 +151,17 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
     # This dictionary contains default values for any parameters that should have default values.
     default_kwarg_values = {"strict": True}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
+    def validate_configuration(self) -> None:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.
 
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
         Returns:
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
+        super().validate_configuration()
+        configuration = self.configuration
 
         strict = configuration.kwargs.get("strict")
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
@@ -211,7 +211,6 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py _validate">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: ExecutionEngine = None,
@@ -220,10 +219,10 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
         column_max = metrics["column.custom_max"]
 
         # Obtaining components needed for validation
-        min_value = self.get_success_kwargs(configuration).get("min_value")
-        strict_min = self.get_success_kwargs(configuration).get("strict_min")
-        max_value = self.get_success_kwargs(configuration).get("max_value")
-        strict_max = self.get_success_kwargs(configuration).get("strict_max")
+        min_value = self.get_success_kwargs().get("min_value")
+        strict_min = self.get_success_kwargs().get("strict_min")
+        max_value = self.get_success_kwargs().get("max_value")
+        strict_max = self.get_success_kwargs().get("strict_max")
 
         # Checking if mean lies between thresholds
         if min_value is not None:

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
@@ -152,22 +152,18 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
     }
 
     # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py validate_config">
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
+    def validate_configuration(self) -> None:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
+
         Returns:
             None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
 
         # Setting up a configuration
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
+        super().validate_configuration()
+        configuration = self.configuration
         # </snippet>
 
         # <snippet name="tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py validate_config_params">

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
@@ -1,9 +1,7 @@
 # ruff: noqa: E711
-from typing import Optional
 
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
 )
@@ -115,11 +113,9 @@ class ExpectColumnPairValuesToHaveADifferenceOfThree(ColumnPairMapExpectation):
         "column_B",
     )
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
+    def validate_configuration(self) -> None:
+        super().validate_configuration()
+        configuration = self.configuration
         try:
             assert (
                 "column_A" in configuration.kwargs

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
@@ -1,7 +1,4 @@
-from typing import Optional
-
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
 )
@@ -104,11 +101,9 @@ class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
     }
     args_keys = ("column_list",)
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
+    def validate_configuration(self) -> None:
+        super().validate_configuration()
+        configuration = self.configuration
 
         try:
             assert "column_list" in configuration.kwargs, "column_list must be provided"

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -6,7 +6,6 @@ For detailed information on QueryExpectations, please see:
 
 from typing import Union
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
@@ -81,12 +80,13 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
     # <snippet name="expect_queried_column_value_frequency_to_meet_threshold.py _validate function signature">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: dict,
         runtime_configuration: dict | None = None,
         execution_engine: ExecutionEngine | None = None,
     ) -> Union[ExpectationValidationResult, dict]:
         # </snippet>
+        configuration = self.configuration
+
         metrics = convert_to_json_serializable(data=metrics)
         query_result = metrics.get("query.column")
         query_result = dict([element.values() for element in query_result])

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -4,7 +4,7 @@ For detailed information on QueryExpectations, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations
 """
 
-from typing import Optional, Union
+from typing import Union
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.util import convert_to_json_serializable
@@ -56,10 +56,9 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
         "query": query,
     }
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        super().validate_configuration(configuration)
+    def validate_configuration(self) -> None:
+        super().validate_configuration()
+        configuration = self.configuration
         value = configuration["kwargs"].get("value")
         threshold = configuration["kwargs"].get("threshold")
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
@@ -5,7 +5,7 @@ For detailed information on QueryExpectations, please see:
 """
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Union
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.util import convert_to_json_serializable
@@ -51,10 +51,9 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
         "query": query,
     }
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        super().validate_configuration(configuration)
+    def validate_configuration(self) -> None:
+        super().validate_configuration()
+        configuration = self.configuration
         value = configuration["kwargs"].get("value")
 
         try:

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import Union
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
@@ -68,7 +67,6 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
     # <snippet name="expect_queried_table_row_count_to_be.py _validate function signature">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: dict,
         runtime_configuration: dict | None = None,
         execution_engine: ExecutionEngine | None = None,
@@ -76,7 +74,7 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
         # </snippet>
         metrics = convert_to_json_serializable(data=metrics)
         query_result = list(metrics.get("query.table")[0].values())[0]
-        value = configuration["kwargs"].get("value")
+        value = self.configuration["kwargs"].get("value")
 
         success = query_result == value
 

--- a/tests/integration/docusaurus/expectations/examples/batch_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/batch_expectation_template.py
@@ -110,34 +110,6 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
     # This dictionary contains default values for any parameters that should have default values.
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     # <snippet name="tests/integration/docusaurus/expectations/examples/batch_expectation_template.py validate">
     def _validate(

--- a/tests/integration/docusaurus/expectations/examples/batch_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/batch_expectation_template.py
@@ -114,7 +114,6 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
     # <snippet name="tests/integration/docusaurus/expectations/examples/batch_expectation_template.py validate">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: ExecutionEngine = None,

--- a/tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py
@@ -71,34 +71,6 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
     # This dictionary contains default values for any parameters that should have default values.
     default_kwarg_values = {}
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     # <snippet name="tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py validate">
     def _validate(

--- a/tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py
@@ -6,7 +6,6 @@ For detailed instructions on how to use it, please see:
 
 from typing import Dict, Optional
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
@@ -75,7 +74,6 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
     # <snippet name="tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py validate">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: Dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: ExecutionEngine = None,

--- a/tests/integration/docusaurus/expectations/examples/column_map_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/column_map_expectation_template.py
@@ -4,9 +4,7 @@ For detailed instructions on how to use it, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations
 """
 
-from typing import Optional
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
 )
@@ -72,34 +70,6 @@ class ExpectColumnValuesToMatchSomeCriteria(ColumnMapExpectation):
 
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
     # <snippet name="tests/integration/docusaurus/expectations/examples/column_map_expectation_template.py library_metadata">

--- a/tests/integration/docusaurus/expectations/examples/column_pair_map_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/column_pair_map_expectation_template.py
@@ -4,9 +4,7 @@ For detailed instructions on how to use it, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_pair_map_expectations
 """
 
-from typing import Optional
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
 )
@@ -79,34 +77,6 @@ class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
 
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
     # <snippet name="tests/integration/docusaurus/expectations/examples/column_pair_map_expectation_template.py library_metadata">

--- a/tests/integration/docusaurus/expectations/examples/multicolumn_map_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/multicolumn_map_expectation_template.py
@@ -4,9 +4,7 @@ For detailed instructions on how to use it, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_multicolumn_map_expectations
 """
 
-from typing import Optional
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
 )
@@ -82,34 +80,6 @@ class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
 
     # This dictionary contains default values for any parameters that should have default values
     default_kwarg_values = {}
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
     # <snippet name="tests/integration/docusaurus/expectations/examples/multicolumn_map_expectation_template.py library_metadata">

--- a/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
@@ -49,33 +49,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
         "query": query,  # Passing the above `query` attribute here as a default kwarg allows for the Expectation to be run with the defaul query, or have that query overridden by passing a `query` kwarg into the expectation
     }
 
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
-
-        Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
-        """
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-
-        # # Check other things in configuration.kwargs and raise Exceptions if needed
-        # try:
-        #     assert (
-        #         ...
-        #     ), "message"
-        #     assert (
-        #         ...
-        #     ), "message"
-        # except AssertionError as e:
-        #     raise InvalidExpectationConfigurationError(str(e))
-
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
     # <snippet name="tests/integration/docusaurus/expectations/examples/query_expectation_template.py _validate">
     def _validate(

--- a/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
+++ b/tests/integration/docusaurus/expectations/examples/query_expectation_template.py
@@ -6,7 +6,6 @@ For detailed instructions on how to use it, please see:
 
 from typing import Optional, Union
 
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     ExpectationValidationResult,
@@ -53,7 +52,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
     # <snippet name="tests/integration/docusaurus/expectations/examples/query_expectation_template.py _validate">
     def _validate(
         self,
-        configuration: ExpectationConfiguration,
         metrics: dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: ExecutionEngine = None,


### PR DESCRIPTION
No need to pass explicit config if we already have one in instance state

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
