### PR TITLE
[MAINTENANCE] `add_or_update_checkpoint` with `expectation_suite_ge_cloud_id`

### DIFF
--- a/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
@@ -43,8 +43,8 @@ To learn more about Checkpoints, see [Checkpoint](../../terms/checkpoint.md).
         "name": checkpoint_name,
         "validations": [{
             "expectation_suite_name": expectation_suite.expectation_suite_name,
-             "expectation_suite_ge_cloud_id": expectation_suite.ge_cloud_id,
-             "batch_request": {
+            "expectation_suite_ge_cloud_id": expectation_suite.ge_cloud_id,
+            "batch_request": {
                 "datasource_name": "<data_source_name>",
                 "data_asset_name": "<data_asset_name>",
              },

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1624,6 +1624,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         validations: list[dict] | None = ...,
         profilers: list[dict] | None = ...,
         expectation_suite_id: str | None = ...,
+        expectation_suite_ge_cloud_id: str | None = ...,
         default_validation_id: str | None = ...,
         validator: Validator | None = ...,
         checkpoint: None = ...,
@@ -1652,6 +1653,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         validations: None = ...,
         profilers: None = ...,
         expectation_suite_id: None = ...,
+        expectation_suite_ge_cloud_id: None = ...,
         default_validation_id: None = ...,
         validator: Validator | None = ...,
         checkpoint: Checkpoint = ...,
@@ -1686,6 +1688,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         validations: list[CheckpointValidationConfig] | list[dict] | None = None,
         profilers: list[dict] | None = None,
         expectation_suite_id: str | None = None,
+        expectation_suite_ge_cloud_id: str | None = None,
         default_validation_id: str | None = None,
         validator: Validator | None = None,
         checkpoint: Checkpoint | None = None,
@@ -1708,6 +1711,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             validations: The validations to use in generating this checkpoint.
             profilers: The profilers to use in generating this checkpoint.
             expectation_suite_id: The expectation suite GE Cloud ID to use in generating this checkpoint.
+            expectation_suite_ge_cloud_id: An alias for `expectation_suite_id`.
             default_validation_id: The default validation ID to use in generating this checkpoint.
             validator: An existing validator used to generate a validations list.
             checkpoint: An existing checkpoint you wish to persist.
@@ -1715,6 +1719,10 @@ class AbstractDataContext(ConfigPeer, ABC):
         Returns:
             A new Checkpoint or an updated once (depending on whether or not it existed before this method call).
         """
+        expectation_suite_id = self._resolve_id_and_ge_cloud_id(
+            id=expectation_suite_id, ge_cloud_id=expectation_suite_ge_cloud_id
+        )
+
         checkpoint = self._resolve_add_checkpoint_args(
             name=name,
             id=id,
@@ -1939,7 +1947,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             run_time: The date/time of the run
             result_format: One of several supported formatting directives for expectation validation results
             ge_cloud_id: Great Expectations Cloud id for the checkpoint
-            expectation_suite_ge_cloud_id: Great Expectations Cloud id for the expectation suite
+            expectation_suite_ge_cloud_id: An alias for `expectation_suite_id`.
             id: Great Expectations Cloud id for the checkpoint (preferred over `ge_cloud_id`)
             expectation_suite_id: Great Expectations Cloud id for the expectation suite (preferred over `expectation_suite_ge_cloud_id`)
             **kwargs: Additional kwargs to pass to the validation operator


### PR DESCRIPTION
- `add_or_update_checkpoint` is missing `expectation_suite_ge_cloud_id` as an alternative to `expectation_suite_id` which makes it inconsistent with the other checkpoint methods, the [the documentation](https://docs.greatexpectations.io/docs/cloud/checkpoints/manage_checkpoints/#add-a-checkpoint), and the GX Cloud code snippet experience 