### PR TITLE
[MAINTENANCE] Make `ResultFormatConfig` a Pydantic model

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -61,7 +61,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def parse_result_format(result_format: Union[str, dict]) -> dict:
+def parse_result_format(
+    result_format: Union[str, dict, ResultFormatConfig]
+) -> ResultFormatConfig:
     """This is a simple helper utility that can be used to parse a string result_format into the dict format used
     internally by great_expectations. It is not necessary but allows shorthand for result_format in cases where
     there is no need to specify a custom partial_unexpected_count."""

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -28,6 +28,7 @@ from great_expectations.core.evaluation_parameters import (
     find_evaluation_parameter_dependencies,
 )
 from great_expectations.core.metric_domain_types import MetricDomainTypes
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.urn import ge_urn
 from great_expectations.core.util import (
     convert_to_json_serializable,
@@ -65,25 +66,22 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
     internally by great_expectations. It is not necessary but allows shorthand for result_format in cases where
     there is no need to specify a custom partial_unexpected_count."""
     if isinstance(result_format, str):
-        result_format = {
-            "result_format": result_format,
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        }
+        result_format = ResultFormatConfig(
+            result_format=result_format,
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        )
     else:
-        if (
-            "include_unexpected_rows" in result_format
-            and "result_format" not in result_format
-        ):
+        if result_format.include_unexpected_rows and not result_format.result_format:
             raise ValueError(
                 "When using `include_unexpected_rows`, `result_format` must be explicitly specified"
             )
 
-        if "partial_unexpected_count" not in result_format:
-            result_format["partial_unexpected_count"] = 20
+        if not result_format.partial_unexpected_count:
+            result_format.partial_unexpected_count = 20
 
-        if "include_unexpected_rows" not in result_format:
-            result_format["include_unexpected_rows"] = False
+        if not result_format.include_unexpected_rows:
+            result_format.include_unexpected_rows = False
 
     return result_format
 

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -71,6 +71,8 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
             partial_unexpected_count=20,
             include_unexpected_rows=False,
         )
+    elif isinstance(result_format, dict):
+        result_format = ResultFormatConfig(**result_format)
     else:
         if result_format.include_unexpected_rows and not result_format.result_format:
             raise ValueError(

--- a/great_expectations/core/result_format.py
+++ b/great_expectations/core/result_format.py
@@ -13,8 +13,8 @@ class ResultFormat(str, enum.Enum):
 
 class ResultFormatConfig(pydantic.BaseModel):
     result_format: ResultFormat
-    unexpected_index_column_names: Optional[List[str]] = None
+    exclude_unexpected_values: Optional[bool] = None
     include_unexpected_rows: Optional[bool] = None
     partial_unexpected_count: Optional[int] = None
     return_unexpected_index_query: Optional[bool] = None
-    exclude_unexpected_values: Optional[bool] = None
+    unexpected_index_column_names: Optional[List[str]] = None

--- a/great_expectations/core/result_format.py
+++ b/great_expectations/core/result_format.py
@@ -1,6 +1,7 @@
 import enum
+from typing import List, Optional
 
-from typing_extensions import TypedDict
+from great_expectations.compatibility import pydantic
 
 
 class ResultFormat(str, enum.Enum):
@@ -10,5 +11,8 @@ class ResultFormat(str, enum.Enum):
     SUMMARY = "SUMMARY"
 
 
-class ResultFormatDict(TypedDict):
+class ResultFormatConfig(pydantic.BaseModel):
     result_format: ResultFormat
+    unexpected_index_column_names: Optional[List[str]] = None
+    include_unexpected_rows: Optional[bool] = None
+    partial_unexpected_count: Optional[int] = None

--- a/great_expectations/core/result_format.py
+++ b/great_expectations/core/result_format.py
@@ -16,3 +16,4 @@ class ResultFormatConfig(pydantic.BaseModel):
     unexpected_index_column_names: Optional[List[str]] = None
     include_unexpected_rows: Optional[bool] = None
     partial_unexpected_count: Optional[int] = None
+    return_unexpected_index_query: Optional[bool] = None

--- a/great_expectations/core/result_format.py
+++ b/great_expectations/core/result_format.py
@@ -17,3 +17,4 @@ class ResultFormatConfig(pydantic.BaseModel):
     include_unexpected_rows: Optional[bool] = None
     partial_unexpected_count: Optional[int] = None
     return_unexpected_index_query: Optional[bool] = None
+    exclude_unexpected_values: Optional[bool] = None

--- a/great_expectations/data_asset/util.py
+++ b/great_expectations/data_asset/util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime
 import decimal
+import json
 import sys
 from functools import wraps
 from typing import Any
@@ -10,6 +11,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from great_expectations.compatibility import pydantic
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.types import SerializableDictDot, SerializableDotDict
 
@@ -195,6 +197,9 @@ def _recursively_convert_to_json_serializable(  # noqa: C901, PLR0911, PLR0912
 
     elif isinstance(test_obj, decimal.Decimal):
         return float(test_obj)
+
+    elif isinstance(test_obj, pydantic.BaseModel):
+        return json.loads(test_obj.json())
 
     else:
         raise TypeError(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -78,7 +78,7 @@ from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import (
     SummarizationMetricNameSuffixes,
 )
-from great_expectations.core.result_format import ResultFormat, ResultFormatDict
+from great_expectations.core.result_format import ResultFormat, ResultFormatConfig
 from great_expectations.exceptions import (
     GreatExpectationsError,
     InvalidExpectationConfigurationError,
@@ -323,7 +323,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     id: Union[str, None] = None
     meta: Union[dict, None] = None
     notes: Union[str, None] = None
-    result_format: Union[ResultFormat, ResultFormatDict] = ResultFormat.BASIC
+    result_format: Union[ResultFormat, ResultFormatConfig] = ResultFormat.BASIC
 
     catch_exceptions: bool = False
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -3358,7 +3358,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
         exclude_unexpected_values = False
     if unexpected_list is not None and not exclude_unexpected_values:
         return_obj["result"]["partial_unexpected_list"] = unexpected_list[
-            : result_format["partial_unexpected_count"]
+            : result_format.partial_unexpected_count
         ]
 
     if unexpected_index_column_names is not None:
@@ -3374,7 +3374,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
             "unexpected_percent_nonmissing"
         ] = unexpected_percent_nonmissing
 
-    if result_format["include_unexpected_rows"]:
+    if result_format.include_unexpected_rows:
         return_obj["result"].update(
             {
                 "unexpected_rows": unexpected_rows,
@@ -3405,7 +3405,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     {"value": key, "count": value}
                     for key, value in sorted(
                         Counter(immutable_unexpected_list).most_common(
-                            result_format["partial_unexpected_count"]
+                            result_format.partial_unexpected_count
                         ),
                         key=lambda x: (-x[1], x[0]),
                     )
@@ -3422,7 +3422,7 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 return_obj["result"].update(
                     {
                         "partial_unexpected_index_list": unexpected_index_list[
-                            : result_format["partial_unexpected_count"]
+                            : result_format.partial_unexpected_count
                         ],
                     }
                 )

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -3294,7 +3294,7 @@ class MulticolumnMapExpectation(BatchExpectation, ABC):
 
 
 def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
-    result_format: dict,
+    result_format: dict | ResultFormatConfig,
     success: bool,
     element_count: Optional[int] = None,
     nonnull_count: Optional[int] = None,
@@ -3315,6 +3315,9 @@ def _format_map_output(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     This function handles the logic for mapping those fields for column_map_expectations.
     """
+    if isinstance(result_format, dict):
+        result_format = ResultFormatConfig(**result_format)
+
     if element_count is None:
         element_count = 0
 

--- a/great_expectations/expectations/metrics/map_metric_provider/column_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_map_condition_auxilliary_methods.py
@@ -85,7 +85,7 @@ def _pandas_column_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return list(domain_values)
 
     return list(domain_values[: result_format["partial_unexpected_count"]])
@@ -154,7 +154,7 @@ def _pandas_column_map_series_and_domain_values(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return (
             list(domain_values),
             list(map_series),
@@ -227,7 +227,7 @@ def _pandas_column_map_condition_value_counts(
     if not value_counts:
         raise gx_exceptions.MetricComputationError("Unable to compute value counts")
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return value_counts
 
     return value_counts[result_format["partial_unexpected_count"]]
@@ -278,10 +278,10 @@ def _sqlalchemy_column_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] != "COMPLETE":
+    if result_format.result_format != "COMPLETE":
         query = query.limit(result_format["partial_unexpected_count"])
     elif (
-        result_format["result_format"] == "COMPLETE"
+        result_format.result_format == "COMPLETE"
         and execution_engine.engine.dialect.name.lower() == GXSqlDialect.BIGQUERY
     ):
         logger.warning(
@@ -380,7 +380,7 @@ def _spark_column_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         rows = filtered.select(
             F.col(column_name).alias(column_name)
         ).collect()  # note that without the explicit alias, spark will use only the final portion of a nested column as the column name
@@ -434,7 +434,7 @@ def _spark_column_map_condition_value_counts(
     result_format = metric_value_kwargs["result_format"]
 
     value_counts = filtered.groupBy(F.col(column_name).alias(column_name)).count()
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         rows = value_counts.collect()
     else:
         rows = value_counts.collect()[: result_format["partial_unexpected_count"]]

--- a/great_expectations/expectations/metrics/map_metric_provider/column_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_map_condition_auxilliary_methods.py
@@ -88,7 +88,7 @@ def _pandas_column_map_condition_values(
     if result_format.result_format == "COMPLETE":
         return list(domain_values)
 
-    return list(domain_values[: result_format["partial_unexpected_count"]])
+    return list(domain_values[: result_format.partial_unexpected_count])
 
 
 # TODO: <Alex>11/15/2022: Please DO_NOT_DELETE this method (even though it is not currently utilized).  Thanks.</Alex>
@@ -161,8 +161,8 @@ def _pandas_column_map_series_and_domain_values(
         )
 
     return (
-        list(domain_values[: result_format["partial_unexpected_count"]]),
-        list(map_series[: result_format["partial_unexpected_count"]]),
+        list(domain_values[: result_format.partial_unexpected_count]),
+        list(map_series[: result_format.partial_unexpected_count]),
     )
 
 
@@ -230,7 +230,7 @@ def _pandas_column_map_condition_value_counts(
     if result_format.result_format == "COMPLETE":
         return value_counts
 
-    return value_counts[result_format["partial_unexpected_count"]]
+    return value_counts[result_format.partial_unexpected_count]
 
 
 def _sqlalchemy_column_map_condition_values(
@@ -279,7 +279,7 @@ def _sqlalchemy_column_map_condition_values(
     result_format = metric_value_kwargs["result_format"]
 
     if result_format.result_format != "COMPLETE":
-        query = query.limit(result_format["partial_unexpected_count"])
+        query = query.limit(result_format.partial_unexpected_count)
     elif (
         result_format.result_format == "COMPLETE"
         and execution_engine.engine.dialect.name.lower() == GXSqlDialect.BIGQUERY
@@ -389,7 +389,7 @@ def _spark_column_map_condition_values(
             filtered.select(
                 F.col(column_name).alias(column_name)
             )  # note that without the explicit alias, spark will use only the final portion of a nested column as the column name
-            .limit(result_format["partial_unexpected_count"])
+            .limit(result_format.partial_unexpected_count)
             .collect()
         )
     return [row[column_name] for row in rows]
@@ -437,5 +437,5 @@ def _spark_column_map_condition_value_counts(
     if result_format.result_format == "COMPLETE":
         rows = value_counts.collect()
     else:
-        rows = value_counts.collect()[: result_format["partial_unexpected_count"]]
+        rows = value_counts.collect()[: result_format.partial_unexpected_count]
     return rows

--- a/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_condition_auxilliary_methods.py
@@ -91,7 +91,7 @@ def _pandas_column_pair_map_condition_values(
             domain_values[column_A_name].values, domain_values[column_B_name].values
         )
     ]
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return unexpected_list
 
     return unexpected_list[: result_format["partial_unexpected_count"]]
@@ -171,7 +171,7 @@ def _sqlalchemy_column_pair_map_condition_values(
         query = query.select_from(selectable)
 
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] != "COMPLETE":
+    if result_format.result_format != "COMPLETE":
         query = query.limit(result_format["partial_unexpected_count"])
 
     unexpected_list = [
@@ -248,7 +248,7 @@ def _spark_column_pair_map_condition_values(
     )
 
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         rows = filtered.select(
             [
                 F.col(column_A_name).alias(column_A_name),

--- a/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_condition_auxilliary_methods.py
@@ -94,7 +94,7 @@ def _pandas_column_pair_map_condition_values(
     if result_format.result_format == "COMPLETE":
         return unexpected_list
 
-    return unexpected_list[: result_format["partial_unexpected_count"]]
+    return unexpected_list[: result_format.partial_unexpected_count]
 
 
 def _pandas_column_pair_map_condition_filtered_row_count(
@@ -172,7 +172,7 @@ def _sqlalchemy_column_pair_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
     if result_format.result_format != "COMPLETE":
-        query = query.limit(result_format["partial_unexpected_count"])
+        query = query.limit(result_format.partial_unexpected_count)
 
     unexpected_list = [
         (val.unexpected_values_A, val.unexpected_values_B)
@@ -263,7 +263,7 @@ def _spark_column_pair_map_condition_values(
                     F.col(column_B_name).alias(column_B_name),
                 ]
             )
-            .limit(result_format["partial_unexpected_count"])
+            .limit(result_format.partial_unexpected_count)
             .collect()
         )
 

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -136,7 +136,7 @@ def _pandas_map_condition_index(
         metrics=metrics,
         expectation_domain_column_list=domain_column_name_list,
     )
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return unexpected_index_list
     return unexpected_index_list[: result_format["partial_unexpected_count"]]
 
@@ -159,9 +159,9 @@ def _pandas_map_condition_query(
     result_format: dict = metric_value_kwargs["result_format"]
 
     # We will not return map_condition_query if return_unexpected_index_query = False
-    return_unexpected_index_query: Optional[bool] = result_format.get(
-        "return_unexpected_index_query"
-    )
+    return_unexpected_index_query: Optional[
+        bool
+    ] = result_format.return_unexpected_index_query
     if return_unexpected_index_query is False:
         return None
 
@@ -250,7 +250,7 @@ def _pandas_map_condition_rows(
 
     df = df[boolean_mapped_unexpected_values]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return df
 
     return df.iloc[: result_format["partial_unexpected_count"]]
@@ -403,7 +403,7 @@ def _sqlalchemy_map_condition_rows(
         query = query.select_from(selectable)
 
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] != "COMPLETE":
+    if result_format.result_format != "COMPLETE":
         query = query.limit(result_format["partial_unexpected_count"])
     try:
         return execution_engine.execute_query(query).fetchall()
@@ -437,9 +437,9 @@ def _sqlalchemy_map_condition_query(
 
     result_format: dict = metric_value_kwargs["result_format"]
     # We will not return map_condition_query if return_unexpected_index_query = False
-    return_unexpected_index_query: Optional[bool] = result_format.get(
-        "return_unexpected_index_query"
-    )
+    return_unexpected_index_query: Optional[
+        bool
+    ] = result_format.return_unexpected_index_query
     if return_unexpected_index_query is False:
         return None
 
@@ -466,9 +466,9 @@ def _sqlalchemy_map_condition_query(
     column_selector: List[sa.Column] = []
 
     all_table_columns: List[str] = metrics.get("table.columns", [])
-    unexpected_index_column_names: List[str] | None = result_format.get(
-        "unexpected_index_column_names"
-    )
+    unexpected_index_column_names: List[
+        str
+    ] | None = result_format.unexpected_index_column_names
     if unexpected_index_column_names:
         for column_name in unexpected_index_column_names:
             if column_name not in all_table_columns:
@@ -552,9 +552,9 @@ def _sqlalchemy_map_condition_index(
     domain_kwargs: dict = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
     all_table_columns: List[str] = metrics.get("table.columns", [])
 
-    unexpected_index_column_names: List[str] = result_format.get(
-        "unexpected_index_column_names", []
-    )
+    unexpected_index_column_names = result_format.unexpected_index_column_names
+    if unexpected_index_column_names is None:
+        unexpected_index_column_names = []
 
     column_selector: List[sa.Column] = []
     for column_name in unexpected_index_column_names:
@@ -591,9 +591,9 @@ def _sqlalchemy_map_condition_index(
         final_query
     ).fetchall()
 
-    exclude_unexpected_values: bool = result_format.get(
-        "exclude_unexpected_values", False
-    )
+    exclude_unexpected_values = result_format.exclude_unexpected_values
+    if exclude_unexpected_values is None:
+        exclude_unexpected_values = False
 
     return _get_sqlalchemy_customized_unexpected_index_list(
         exclude_unexpected_values=exclude_unexpected_values,
@@ -675,7 +675,7 @@ def _spark_map_condition_rows(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return filtered.collect()
 
     return filtered.limit(result_format["partial_unexpected_count"]).collect()
@@ -735,7 +735,7 @@ def _spark_map_condition_index(
         domain_kwargs=domain_kwargs
     )
     result_format = metric_value_kwargs["result_format"]
-    if not result_format.get("unexpected_index_column_names"):
+    if not result_format.unexpected_index_column_names:
         raise gx_exceptions.MetricResolutionError(
             message="unexpected_indices cannot be returned without 'unexpected_index_column_names'. Please check your configuration.",
             failed_metrics=["unexpected_index_list"],
@@ -745,9 +745,9 @@ def _spark_map_condition_index(
     filtered = data.filter(F.col("__unexpected") == True).drop(  # noqa: E712
         F.col("__unexpected")
     )
-    exclude_unexpected_values: bool = result_format.get(
-        "exclude_unexpected_values", False
-    )
+    exclude_unexpected_values: bool = result_format.exclude_unexpected_values
+    if exclude_unexpected_values is None:
+        exclude_unexpected_values = False
 
     unexpected_index_column_names: List[str] = result_format[
         "unexpected_index_column_names"
@@ -762,7 +762,7 @@ def _spark_map_condition_index(
                 f"Error: The unexpected_index_column '{col_name}' does not exist in Spark DataFrame. Please check your configuration and try again."
             )
 
-    if result_format["result_format"] != "COMPLETE":
+    if result_format.result_format != "COMPLETE":
         filtered = filtered.limit(result_format["partial_unexpected_count"])
 
     # Prune the dataframe down only the columns we care about
@@ -797,9 +797,9 @@ def _spark_map_condition_query(
     """
     result_format: dict = metric_value_kwargs["result_format"]
     # We will not return map_condition_query if return_unexpected_index_query = False
-    return_unexpected_index_query: Optional[bool] = result_format.get(
-        "return_unexpected_index_query"
-    )
+    return_unexpected_index_query: Optional[
+        bool
+    ] = result_format.return_unexpected_index_query
     if return_unexpected_index_query is False:
         return None
 

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -41,6 +41,7 @@ from great_expectations.util import (
 if TYPE_CHECKING:
     import pandas as pd
 
+    from great_expectations.core.result_format import ResultFormatConfig
     from great_expectations.execution_engine import (
         PandasExecutionEngine,
         SparkDFExecutionEngine,
@@ -156,7 +157,7 @@ def _pandas_map_condition_query(
     Requires `unexpected_index_column_names` to be part of `result_format` dict to specify primary_key columns
     to return, along with column the Expectation is run on.
     """
-    result_format: dict = metric_value_kwargs["result_format"]
+    result_format: ResultFormatConfig = metric_value_kwargs["result_format"]
 
     # We will not return map_condition_query if return_unexpected_index_query = False
     return_unexpected_index_query: Optional[

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -138,7 +138,7 @@ def _pandas_map_condition_index(
     )
     if result_format.result_format == "COMPLETE":
         return unexpected_index_list
-    return unexpected_index_list[: result_format["partial_unexpected_count"]]
+    return unexpected_index_list[: result_format.partial_unexpected_count]
 
 
 def _pandas_map_condition_query(
@@ -253,7 +253,7 @@ def _pandas_map_condition_rows(
     if result_format.result_format == "COMPLETE":
         return df
 
-    return df.iloc[: result_format["partial_unexpected_count"]]
+    return df.iloc[: result_format.partial_unexpected_count]
 
 
 def _sqlalchemy_map_condition_unexpected_count_aggregate_fn(
@@ -404,7 +404,7 @@ def _sqlalchemy_map_condition_rows(
 
     result_format = metric_value_kwargs["result_format"]
     if result_format.result_format != "COMPLETE":
-        query = query.limit(result_format["partial_unexpected_count"])
+        query = query.limit(result_format.partial_unexpected_count)
     try:
         return execution_engine.execute_query(query).fetchall()
     except sqlalchemy.OperationalError as oe:
@@ -585,7 +585,7 @@ def _sqlalchemy_map_condition_index(
     final_query: sa.select = (
         unexpected_condition_query_with_selected_columns.select_from(
             domain_records_as_selectable
-        ).limit(result_format["partial_unexpected_count"])
+        ).limit(result_format.partial_unexpected_count)
     )
     query_result: List[sqlalchemy.Row] = execution_engine.execute_query(
         final_query
@@ -678,7 +678,7 @@ def _spark_map_condition_rows(
     if result_format.result_format == "COMPLETE":
         return filtered.collect()
 
-    return filtered.limit(result_format["partial_unexpected_count"]).collect()
+    return filtered.limit(result_format.partial_unexpected_count).collect()
 
 
 def _spark_map_condition_index(
@@ -763,7 +763,7 @@ def _spark_map_condition_index(
             )
 
     if result_format.result_format != "COMPLETE":
-        filtered = filtered.limit(result_format["partial_unexpected_count"])
+        filtered = filtered.limit(result_format.partial_unexpected_count)
 
     # Prune the dataframe down only the columns we care about
     filtered = filtered.select(columns_to_keep)

--- a/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
@@ -82,7 +82,7 @@ def _pandas_multicolumn_map_condition_values(
     if result_format.result_format == "COMPLETE":
         return domain_values.to_dict("records")
 
-    return domain_values[: result_format["partial_unexpected_count"]].to_dict("records")
+    return domain_values[: result_format.partial_unexpected_count].to_dict("records")
 
 
 def _pandas_multicolumn_map_condition_filtered_row_count(
@@ -164,7 +164,7 @@ def _sqlalchemy_multicolumn_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
     if result_format.result_format != "COMPLETE":
-        query = query.limit(result_format["partial_unexpected_count"])
+        query = query.limit(result_format.partial_unexpected_count)
 
     return [val._asdict() for val in execution_engine.execute_query(query).fetchall()]
 
@@ -264,7 +264,7 @@ def _spark_multicolumn_map_condition_values(
     else:
         domain_values = (
             domain_values.select(column_selector)  # type: ignore[assignment]
-            .limit(result_format["partial_unexpected_count"])
+            .limit(result_format.partial_unexpected_count)
             .toPandas()
             .to_dict("records")
         )

--- a/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
@@ -79,7 +79,7 @@ def _pandas_multicolumn_map_condition_values(
 
     result_format = metric_value_kwargs["result_format"]
 
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         return domain_values.to_dict("records")
 
     return domain_values[: result_format["partial_unexpected_count"]].to_dict("records")
@@ -163,7 +163,7 @@ def _sqlalchemy_multicolumn_map_condition_values(
         query = query.select_from(selectable)
 
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] != "COMPLETE":
+    if result_format.result_format != "COMPLETE":
         query = query.limit(result_format["partial_unexpected_count"])
 
     return [val._asdict() for val in execution_engine.execute_query(query).fetchall()]
@@ -257,7 +257,7 @@ def _spark_multicolumn_map_condition_values(
     domain_values = filtered.select(column_selector)
 
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] == "COMPLETE":
+    if result_format.result_format == "COMPLETE":
         domain_values = (
             domain_values.select(column_selector).toPandas().to_dict("records")  # type: ignore[assignment]
         )

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1375,7 +1375,7 @@ def get_unexpected_indices_for_single_pandas_named_index(
     return unexpected_index_list
 
 
-def compute_unexpected_pandas_indices(
+def compute_unexpected_pandas_indices(  # noqa: PLR0912
     domain_records_df: pd.DataFrame,
     expectation_domain_column_list: List[str],
     result_format: Dict[str, Any],
@@ -1399,14 +1399,14 @@ def compute_unexpected_pandas_indices(
     """
     unexpected_index_column_names: List[str]
     unexpected_index_list: List[Dict[str, Any]]
-    exclude_unexpected_values: bool = result_format.get(
-        "exclude_unexpected_values", False
-    )
+    exclude_unexpected_values = result_format.exclude_unexpected_values
+    if exclude_unexpected_values is None:
+        exclude_unexpected_values = False
 
     if domain_records_df.index.name is not None:
-        unexpected_index_column_names = result_format.get(
-            "unexpected_index_column_names", [domain_records_df.index.name]
-        )
+        unexpected_index_column_names = result_format.unexpected_index_column_names
+        if unexpected_index_column_names is None:
+            unexpected_index_column_names = [domain_records_df.index.name]
         unexpected_index_list = get_unexpected_indices_for_single_pandas_named_index(
             domain_records_df=domain_records_df,
             unexpected_index_column_names=unexpected_index_column_names,
@@ -1415,9 +1415,9 @@ def compute_unexpected_pandas_indices(
         )
     # multiple named indices
     elif domain_records_df.index.names[0] is not None:
-        unexpected_index_column_names = result_format.get(
-            "unexpected_index_column_names", list(domain_records_df.index.names)
-        )
+        unexpected_index_column_names = result_format.unexpected_index_column_names
+        if unexpected_index_column_names is None:
+            unexpected_index_column_names = list(domain_records_df.index.names)
         unexpected_index_list = (
             get_unexpected_indices_for_multiple_pandas_named_indices(
                 domain_records_df=domain_records_df,
@@ -1427,7 +1427,7 @@ def compute_unexpected_pandas_indices(
             )
         )
     # named columns
-    elif result_format.get("unexpected_index_column_names"):
+    elif result_format.unexpected_index_column_names:
         unexpected_index_column_names = result_format["unexpected_index_column_names"]
         unexpected_index_list = []
         unexpected_indices: List[int | str] = list(domain_records_df.index)

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -71,6 +71,8 @@ from great_expectations.compatibility.bigquery import bigquery_types_tuple
 if TYPE_CHECKING:
     import pandas as pd
 
+    from great_expectations.core.result_format import ResultFormatConfig
+
 try:
     import teradatasqlalchemy.dialect
     import teradatasqlalchemy.types as teradatatypes
@@ -1378,7 +1380,7 @@ def get_unexpected_indices_for_single_pandas_named_index(
 def compute_unexpected_pandas_indices(  # noqa: PLR0912
     domain_records_df: pd.DataFrame,
     expectation_domain_column_list: List[str],
-    result_format: Dict[str, Any],
+    result_format: ResultFormatConfig,
     execution_engine: PandasExecutionEngine,
     metrics: Dict[str, Any],
 ) -> List[int] | List[Dict[str, Any]]:

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1428,7 +1428,7 @@ def compute_unexpected_pandas_indices(  # noqa: PLR0912
         )
     # named columns
     elif result_format.unexpected_index_column_names:
-        unexpected_index_column_names = result_format["unexpected_index_column_names"]
+        unexpected_index_column_names = result_format.unexpected_index_column_names
         unexpected_index_list = []
         unexpected_indices: List[int | str] = list(domain_records_df.index)
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -55,6 +55,7 @@ from great_expectations.core import (
     IDDict,
 )
 from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.util import (
     get_or_create_spark_application,
     get_sql_dialect_floating_point_infinity_value,
@@ -2308,16 +2309,14 @@ def evaluate_json_test_v3_api(  # noqa: PLR0912, PLR0913
         else:
             if pk_column:
                 runtime_kwargs = {
-                    "result_format": {
-                        "result_format": "COMPLETE",
-                        "unexpected_index_column_names": ["pk_index"],
-                    },
+                    "result_format": ResultFormatConfig(
+                        result_format="COMPLETE",
+                        unexpected_index_column_names=["pk_index"],
+                    ),
                 }
             else:
                 runtime_kwargs = {
-                    "result_format": {
-                        "result_format": "COMPLETE",
-                    },
+                    "result_format": {ResultFormatConfig(result_format="COMPLETE")},
                 }
             runtime_kwargs.update(kwargs)
             result = getattr(validator, expectation_type)(**runtime_kwargs)

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -2316,7 +2316,7 @@ def evaluate_json_test_v3_api(  # noqa: PLR0912, PLR0913
                 }
             else:
                 runtime_kwargs = {
-                    "result_format": {ResultFormatConfig(result_format="COMPLETE")},
+                    "result_format": ResultFormatConfig(result_format="COMPLETE"),
                 }
             runtime_kwargs.update(kwargs)
             result = getattr(validator, expectation_type)(**runtime_kwargs)

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -23,6 +23,7 @@ from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.util import get_or_create_spark_application
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import AbstractDataContext, FileDataContext
@@ -663,7 +664,9 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
         "action_list": common_action_list,
         "evaluation_parameters": {"param1": "1", "param2": '1 + "2"'},
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
         "template_name": None,
         "run_name_template": "%Y-%M-foo-bar-template-test",
@@ -1011,7 +1014,9 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
             "tolerance": 0.01,
         },
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
         "template_name": None,
         "run_name_template": None,
@@ -1102,7 +1107,9 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         "action_list": common_action_list,
         "evaluation_parameters": {"param1": "1", "param2": '1 + "2"'},
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
         "validations": [],
         "profilers": [],

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -1628,10 +1628,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_
     expected_unexpected_indices_output: list[dict[str, str | int]],
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1683,10 +1683,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_o
     expected_unexpected_indices_output: list[dict[str, str | int]],
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="SUMMARY",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1721,10 +1721,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_basic_out
     expect_column_values_to_be_in_set: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "BASIC",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="BASIC",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1769,10 +1769,10 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_o
     """
 
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -2084,10 +2084,10 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_ou
         - 1 Expectations added to suite
     """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="SUMMARY",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -2135,11 +2135,11 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_summary_ou
         - limit is 1 so we only get 1 output in the `partial_unexpected_index_list`
     """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "partial_unexpected_count": 1,
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="SUMMARY",
+            partial_unexpected_count=1,
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -11,6 +11,7 @@ from great_expectations.checkpoint.types.checkpoint_result import CheckpointResu
 from great_expectations.core import (
     ExpectationConfiguration,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.exceptions import CheckpointError
@@ -365,10 +366,12 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
     """
 
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["pk_1"],
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -420,11 +423,13 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
     """
 
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "return_unexpected_index_query": True,
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["pk_1"],
+                "return_unexpected_index_query": True,
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -466,10 +471,12 @@ def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_comp
     expect_column_pair_values_to_be_equal: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["pk_1"],
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -520,10 +527,12 @@ def test_sql_result_format_in_checkpoint_pk_defined_column_pair_expectation_summ
     expect_column_pair_values_to_be_equal: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "SUMMARY",
+                "unexpected_index_column_names": ["pk_1"],
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -575,11 +584,13 @@ def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation
     """
 
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "return_unexpected_index_query": True,
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["pk_1"],
+                "return_unexpected_index_query": True,
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -636,10 +647,12 @@ def test_sql_result_format_in_checkpoint_pk_defined_multi_column_sum_expectation
     expect_multicolumn_sum_to_equal: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "SUMMARY",
+                "unexpected_index_column_names": ["pk_1"],
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -695,11 +708,13 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
     """
 
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "return_unexpected_index_query": False,
-        }
+        "result_format": ResultFormatConfig(
+            **{
+                "result_format": "COMPLETE",
+                "unexpected_index_column_names": ["pk_1"],
+                "return_unexpected_index_query": False,
+            }
+        )
     }
 
     context = _add_expectations_and_checkpoint(
@@ -753,10 +768,12 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         expectations_list=[expect_column_values_to_be_in_set],
         dict_to_update_checkpoint=dict_to_update_checkpoint,
     )
-    result_format: dict = {
-        "result_format": "COMPLETE",
-        "unexpected_index_column_names": ["pk_1"],
-    }
+    result_format: dict = ResultFormatConfig(
+        **{
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    )
     result: CheckpointResult = context.run_checkpoint(
         checkpoint_name="my_checkpoint", result_format=result_format
     )
@@ -799,11 +816,13 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         checkpoint_config=reference_sql_checkpoint_config_for_animal_names_table,
         expectations_list=[expect_column_values_to_be_in_set],
     )
-    result_format: dict = {
-        "result_format": "COMPLETE",
-        "partial_unexpected_count": 1,
-        "unexpected_index_column_names": ["pk_1"],
-    }
+    result_format: dict = ResultFormatConfig(
+        **{
+            "result_format": "COMPLETE",
+            "partial_unexpected_count": 1,
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    )
     result: CheckpointResult = context.run_checkpoint(
         checkpoint_name="my_checkpoint", result_format=result_format
     )
@@ -844,10 +863,12 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         expectations_list=[expect_column_values_to_be_in_set],
     )
 
-    result_format: dict = {
-        "result_format": "COMPLETE",
-        "unexpected_index_column_names": ["i_dont_exist"],
-    }
+    result_format: dict = ResultFormatConfig(
+        **{
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["i_dont_exist"],
+        }
+    )
     with pytest.raises(CheckpointError) as e:
         context.run_checkpoint(
             checkpoint_name="my_checkpoint",
@@ -885,10 +906,12 @@ def test_sql_result_format_in_checkpoint_pk_defined_two_expectation_complete_out
             expect_column_values_to_not_be_in_set,
         ],
     )
-    result_format: dict = {
-        "result_format": "COMPLETE",
-        "unexpected_index_column_names": ["pk_1"],
-    }
+    result_format: dict = ResultFormatConfig(
+        **{
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    )
 
     result: CheckpointResult = context.run_checkpoint(
         checkpoint_name="my_checkpoint", result_format=result_format
@@ -938,12 +961,14 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_summary_outp
         - SUMMARY output, which means we have `partial_unexpected_index_list` only
         - 1 Expectations added to suite
     """
-    dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
+    dict_to_update_checkpoint: dict = ResultFormatConfig(
+        **{
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                unexpected_index_column_names=["pk_1"],
+            )
         }
-    }
+    )
     context = _add_expectations_and_checkpoint(
         data_context=data_context_with_connection_to_metrics_db,
         checkpoint_config=reference_sql_checkpoint_config_for_animal_names_table,
@@ -983,12 +1008,14 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_basic_output
         - BASIC output, which means we have no unexpected_index_list output
         - 1 Expectations added to suite
     """
-    dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "BASIC",
-            "unexpected_index_column_names": ["pk_1"],
+    dict_to_update_checkpoint: dict = ResultFormatConfig(
+        **{
+            "result_format": ResultFormatConfig(
+                result_format="BASIC",
+                unexpected_index_column_names=["pk_1"],
+            )
         }
-    }
+    )
     context = _add_expectations_and_checkpoint(
         data_context=data_context_with_connection_to_metrics_db,
         checkpoint_config=reference_sql_checkpoint_config_for_animal_names_table,
@@ -1025,9 +1052,7 @@ def test_sql_complete_output_no_id_pk_fallback(
     expect_column_values_to_be_in_set: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-        }
+        "result_format": ResultFormatConfig(result_format="COMPLETE")
     }
     context = _add_expectations_and_checkpoint(
         data_context=data_context_with_connection_to_metrics_db,
@@ -1075,10 +1100,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 ):
     """ """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1124,11 +1149,11 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 ):
     """ """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "return_unexpected_index_query": True,
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            return_unexpected_index_query=True,
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1174,11 +1199,11 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 ):
     """ """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "return_unexpected_index_query": False,
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            return_unexpected_index_query=False,
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1221,11 +1246,11 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_
 ):
     """ """
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "partial_unexpected_count": 1,
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            partial_unexpected_count=1,
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1353,10 +1378,10 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
     expect_column_values_to_be_in_set: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["i_dont_exist"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["i_dont_exist"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1388,10 +1413,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_two_expectation_complete_
     expected_unexpected_indices_output: list[dict[str, str | int]],
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1451,10 +1476,10 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_o
     expected_unexpected_indices_output: list[dict[str, str | int]],
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "SUMMARY",
-            "unexpected_index_column_names": ["pk_1"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="SUMMARY",
+            unexpected_index_column_names=["pk_1"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,
@@ -1568,10 +1593,10 @@ def test_pandas_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_e
     expect_column_values_to_be_in_set: ExpectationConfiguration,
 ):
     dict_to_update_checkpoint: dict = {
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["i_dont_exist"],
-        }
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["i_dont_exist"],
+        )
     }
     context = _add_expectations_and_checkpoint(
         data_context=in_memory_runtime_context,

--- a/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
@@ -19,6 +19,7 @@ from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import FileDataContext
 from great_expectations.data_context.types.base import (
@@ -250,7 +251,9 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
         "action_list": common_action_list,
         "evaluation_parameters": {"param1": "1", "param2": '1 + "2"'},
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20},
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            ),
         },
         "template_name": None,
         "run_name_template": "%Y-%M-foo-bar-template-test",
@@ -376,7 +379,9 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
             "tolerance": 0.01,
         },
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20},
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            ),
         },
         "template_name": None,
         "run_name_template": None,
@@ -467,7 +472,9 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         "action_list": common_action_list,
         "evaluation_parameters": {"param1": "1", "param2": '1 + "2"'},
         "runtime_configuration": {
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20},
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            ),
         },
         "validations": [],
         "profilers": [],

--- a/tests/expectations/metrics/column_map_metrics/test_column_map_condition_auxillary_methods.py
+++ b/tests/expectations/metrics/column_map_metrics/test_column_map_condition_auxillary_methods.py
@@ -7,6 +7,7 @@ import pytest
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.execution_engine import (
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
@@ -180,11 +181,11 @@ def test_sqlalchemy_column_map_condition_values(
         "strict_min": False,
         "strict_max": False,
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     desired_metric = MetricConfiguration(
@@ -254,11 +255,11 @@ def test_spark_column_map_condition_values(
         "strict_min": False,
         "strict_max": False,
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     desired_metric = MetricConfiguration(

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -7,6 +7,7 @@ from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypeSuffixes,
     SummarizationMetricNameSuffixes,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
@@ -52,13 +53,13 @@ def metric_value_kwargs_complete() -> dict:
     return {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=False,
+        ),
     }
 
 
@@ -116,11 +117,11 @@ def test_pd_unexpected_index_list_metric_without_id_pk(animal_table_df):
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     engine: PandasExecutionEngine = build_pandas_engine(df=df)
@@ -154,12 +155,12 @@ def test_pd_unexpected_index_list_metric_without_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: PandasExecutionEngine = build_pandas_engine(df=df)
@@ -226,13 +227,13 @@ def test_pd_unexpected_index_list_metric_with_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: PandasExecutionEngine = build_pandas_engine(df=df)
@@ -302,13 +303,13 @@ def test_sa_unexpected_index_list_metric_with_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df=df, sa=sa)
@@ -342,11 +343,11 @@ def test_sa_unexpected_index_list_metric_without_id_pk(sa, animal_table_df):
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df=df, sa=sa)
@@ -379,12 +380,12 @@ def test_sa_unexpected_index_list_metric_without_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df=df, sa=sa)
@@ -448,11 +449,11 @@ def test_sa_unexpected_index_query_metric_without_id_pk(sa, animal_table_df):
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df=df, sa=sa)
@@ -523,13 +524,13 @@ def test_spark_unexpected_index_list_metric_with_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            unexpected_index_column_names=["pk_1"],
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: SparkDFExecutionEngine = build_spark_engine(
@@ -567,11 +568,11 @@ def test_spark_unexpected_index_list_metric_without_id_pk(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     engine: SparkDFExecutionEngine = build_spark_engine(
@@ -605,12 +606,12 @@ def test_spark_unexpected_index_list_metric_without_id_pk_without_column_values(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-            "exclude_unexpected_values": True,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+            exclude_unexpected_values=True,
+        ),
     }
 
     engine: SparkDFExecutionEngine = build_spark_engine(
@@ -674,11 +675,11 @@ def test_pd_unexpected_index_query_metric_without_id_pk(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
     engine: PandasExecutionEngine = build_pandas_engine(df=df)
 
@@ -743,11 +744,11 @@ def test_spark_unexpected_index_query_metric_without_id_pk(
     metric_value_kwargs: dict = {
         "value_set": ["cat", "fish", "dog"],
         "parse_strings_as_datetimes": False,
-        "result_format": {
-            "result_format": "COMPLETE",
-            "partial_unexpected_count": 20,
-            "include_unexpected_rows": False,
-        },
+        "result_format": ResultFormatConfig(
+            result_format="COMPLETE",
+            partial_unexpected_count=20,
+            include_unexpected_rows=False,
+        ),
     }
 
     engine: SparkDFExecutionEngine = build_spark_engine(

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2176,7 +2176,9 @@ def test_map_column_values_increasing_pd():
         metric_name=f"column_values.increasing.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 1}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=1
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -2261,7 +2263,9 @@ def test_map_column_values_increasing_spark(spark_session):
         metric_name=f"column_values.increasing.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 1}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=1
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -2352,7 +2356,9 @@ def test_map_column_values_decreasing_pd():
         metric_name=f"column_values.decreasing.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 1}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=1
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -2437,7 +2443,9 @@ def test_map_column_values_decreasing_spark(spark_session):
         metric_name=f"column_values.decreasing.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 1}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=1
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -2499,7 +2507,9 @@ def test_map_unique_column_exists_pd():
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 1}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=1
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -2597,7 +2607,9 @@ def test_map_unique_column_exists_sa(sa):
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_VALUES.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -2614,7 +2626,9 @@ def test_map_unique_column_exists_sa(sa):
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_VALUE_COUNTS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -2630,7 +2644,9 @@ def test_map_unique_column_exists_sa(sa):
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -2775,7 +2791,9 @@ def test_map_unique_column_exists_spark(spark_session):
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_VALUES.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -2792,7 +2810,9 @@ def test_map_unique_column_exists_spark(spark_session):
         metric_name=f"column_values.unique.{SummarizationMetricNameSuffixes.UNEXPECTED_VALUE_COUNTS.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -2811,7 +2831,9 @@ def test_map_unique_column_exists_spark(spark_session):
             "column": "a",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+            "result_format": ResultFormatConfig(
+                result_format="BASIC", partial_unexpected_count=20
+            )
         },
     )
     desired_metric.metric_dependencies = {
@@ -3812,10 +3834,10 @@ def test_map_column_pairs_greater_metric_pd():
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -3842,10 +3864,10 @@ def test_map_column_pairs_greater_metric_pd():
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3890,10 +3912,10 @@ def test_map_column_pairs_greater_metric_sa(sa):
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -3914,10 +3936,10 @@ def test_map_column_pairs_greater_metric_sa(sa):
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3963,10 +3985,10 @@ def test_map_column_pairs_greater_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -3987,10 +4009,10 @@ def test_map_column_pairs_greater_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "or_equal": True,
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -4072,10 +4094,10 @@ def test_map_column_pairs_in_set_metric_sa(sa):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -4096,10 +4118,10 @@ def test_map_column_pairs_in_set_metric_sa(sa):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -4123,10 +4145,10 @@ def test_map_column_pairs_in_set_metric_sa(sa):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -4147,10 +4169,10 @@ def test_map_column_pairs_in_set_metric_sa(sa):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -4197,10 +4219,10 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -4221,10 +4243,10 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -4248,10 +4270,10 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     condition_metric.metric_dependencies = {
@@ -4272,10 +4294,10 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
         },
         metric_value_kwargs={
             "value_pairs_set": [(2, 1), (3, 2), (4, 3), (3, 3)],
-            "result_format": {
-                "result_format": "SUMMARY",
-                "partial_unexpected_count": 6,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+                partial_unexpected_count=6,
+            ),
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6571,7 +6593,9 @@ def test_map_select_column_values_unique_within_record_pd():  # noqa: PLR0915
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 8}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=8
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6820,7 +6844,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 8}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=8
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -7043,7 +7069,9 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 8}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=8
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -19,6 +19,7 @@ from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypeSuffixes,
     SummarizationMetricNameSuffixes,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
@@ -3173,7 +3174,9 @@ def test_map_column_pairs_equal_metric_pd():  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3195,7 +3198,9 @@ def test_map_column_pairs_equal_metric_pd():  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3260,7 +3265,9 @@ def test_map_column_pairs_equal_metric_pd():  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3290,7 +3297,9 @@ def test_map_column_pairs_equal_metric_pd():  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3422,7 +3431,9 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3443,7 +3454,9 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3506,7 +3519,9 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3531,7 +3546,9 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3639,7 +3656,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3660,7 +3679,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915
             "column_B": "c",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -3724,7 +3745,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -3749,7 +3772,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915
             "column_B": "d",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5234,7 +5259,9 @@ def test_map_multicolumn_sum_equal_pd():  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5255,7 +5282,9 @@ def test_map_multicolumn_sum_equal_pd():  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5319,7 +5348,9 @@ def test_map_multicolumn_sum_equal_pd():  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5345,7 +5376,9 @@ def test_map_multicolumn_sum_equal_pd():  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5444,7 +5477,9 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5464,7 +5499,9 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5526,7 +5563,9 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5547,7 +5586,9 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5648,7 +5689,9 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5668,7 +5711,9 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5731,7 +5776,9 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5752,7 +5799,9 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5849,7 +5898,9 @@ def test_map_compound_columns_unique_pd():  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5870,7 +5921,9 @@ def test_map_compound_columns_unique_pd():  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -5932,7 +5985,9 @@ def test_map_compound_columns_unique_pd():  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -5958,7 +6013,9 @@ def test_map_compound_columns_unique_pd():  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6076,7 +6133,9 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6096,7 +6155,9 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6173,7 +6234,9 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6193,7 +6256,9 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6291,7 +6356,9 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6311,7 +6378,9 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "b"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6372,7 +6441,9 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6392,7 +6463,9 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915
             "column_list": ["a", "c"],
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6528,7 +6601,9 @@ def test_map_select_column_values_unique_within_record_pd():  # noqa: PLR0915
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6611,7 +6686,9 @@ def test_map_select_column_values_unique_within_record_pd():  # noqa: PLR0915
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6640,7 +6717,9 @@ def test_map_select_column_values_unique_within_record_pd():  # noqa: PLR0915
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6766,7 +6845,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6833,7 +6914,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -6854,7 +6937,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -6983,7 +7068,9 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
             "ignore_row_if": "all_values_are_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {
@@ -7058,7 +7145,9 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_rows_metric.metric_dependencies = {
@@ -7079,7 +7168,9 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
             "ignore_row_if": "any_value_is_missing",
         },
         metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY", partial_unexpected_count=3
+            )
         },
     )
     unexpected_values_metric.metric_dependencies = {

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 
 from great_expectations.compatibility import sqlalchemy
-from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
@@ -18,6 +17,7 @@ from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypeSuffixes,
     SummarizationMetricNameSuffixes,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.data_context.util import file_relative_path
@@ -410,10 +410,10 @@ def test_pandas_unexpected_rows_basic_result_format(
             "column": "animals",
             "mostly": 0.9,
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "BASIC",
-                "include_unexpected_rows": True,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="BASIC",
+                include_unexpected_rows=True,
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -451,10 +451,10 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly
             "column": "animals",
             "mostly": 0.9,
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "SUMMARY",  # SUMMARY will include partial_unexpected* values only
-                "include_unexpected_rows": False,  # this is the default value, but making explicit for testing purposes
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",  # SUMMARY will include partial_unexpected* values only
+                include_unexpected_rows=False,  # this is the default value, but making explicit for testing purposes
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -493,10 +493,10 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_
             "column": "animals",
             "mostly": 0.9,
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "SUMMARY",  # SUMMARY will include partial_unexpected* values only
-                "include_unexpected_rows": True,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",  # SUMMARY will include partial_unexpected* values only
+                include_unexpected_rows=True,
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -539,10 +539,10 @@ def test_pandas_unexpected_rows_complete_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-                "include_unexpected_rows": True,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+                include_unexpected_rows=True,
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -588,9 +588,9 @@ def test_expectation_configuration_has_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+            ),
         },
     )
     with pytest.warns(UserWarning) as config_warning:
@@ -618,9 +618,9 @@ def test_pandas_default_complete_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -661,10 +661,10 @@ def test_pandas_unexpected_rows_complete_result_format_with_id_pk(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-                "unexpected_index_column_names": ["pk_1"],
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+                unexpected_index_column_names=["pk_1"],
+            ),
         },
     )
     # result_format configuration at ExpectationConfiguration-level will emit warning
@@ -717,9 +717,9 @@ def test_pandas_default_to_not_include_unexpected_rows(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -743,10 +743,10 @@ def test_pandas_specify_not_include_unexpected_rows(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-                "include_unexpected_rows": False,
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+                include_unexpected_rows=False,
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -757,23 +757,6 @@ def test_pandas_specify_not_include_unexpected_rows(
         )
     )
     assert result.result == expected_evr_without_unexpected_rows.result
-
-
-@pytest.mark.unit
-def test_include_unexpected_rows_without_explicit_result_format_raises_error():
-    expectation_configuration = ExpectationConfiguration(
-        expectation_type="expect_column_values_to_be_in_set",
-        kwargs={
-            "column": "animals",
-            "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "include_unexpected_rows": False,
-            },
-        },
-    )
-
-    with pytest.raises(ValidationError):
-        ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
 
 
 # Spark
@@ -787,9 +770,9 @@ def test_spark_single_column_complete_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+            ),
         },
     )
     expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
@@ -843,10 +826,10 @@ def test_spark_single_column_complete_result_format_with_id_pk(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-                "unexpected_index_column_names": ["pk_1"],
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+                unexpected_index_column_names=["pk_1"],
+            ),
         },
     )
     expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
@@ -915,9 +898,9 @@ def test_spark_single_column_summary_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "SUMMARY",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+            ),
         },
     )
     expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
@@ -968,9 +951,9 @@ def test_spark_single_column_basic_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "BASIC",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="BASIC",
+            ),
         },
     )
     expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
@@ -1017,9 +1000,9 @@ def test_sqlite_single_column_complete_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -1061,10 +1044,10 @@ def test_sqlite_single_column_complete_result_format_id_pk(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "COMPLETE",
-                "unexpected_index_column_names": ["pk_1"],
-            },
+            "result_format": ResultFormatConfig(
+                result_format="COMPLETE",
+                unexpected_index_column_names=["pk_1"],
+            ),
         },
     )
 
@@ -1118,9 +1101,9 @@ def test_sqlite_single_column_summary_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "SUMMARY",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="SUMMARY",
+            ),
         },
     )
     result: ExpectationValidationResult = (
@@ -1155,9 +1138,9 @@ def test_sqlite_single_column_basic_result_format(
         kwargs={
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
-            "result_format": {
-                "result_format": "BASIC",
-            },
+            "result_format": ResultFormatConfig(
+                result_format="BASIC",
+            ),
         },
     )
     result: ExpectationValidationResult = (

--- a/tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py
+++ b/tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py
@@ -4,6 +4,7 @@ import great_expectations as gx
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
+from great_expectations.core.result_format import ResultFormatConfig
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.types.base import CheckpointConfig
@@ -167,7 +168,9 @@ context.add_or_update_checkpoint(
     ],
     evaluation_parameters={"GT_PARAM": 1000, "LT_PARAM": 50000},
     runtime_configuration={
-        "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+        "result_format": ResultFormatConfig(
+            result_format="BASIC", partial_unexpected_count=20
+        )
     },
 )
 # </snippet>
@@ -228,7 +231,9 @@ context.add_or_update_checkpoint(
     ],
     evaluation_parameters={"GT_PARAM": 1000, "LT_PARAM": 50000},
     runtime_configuration={
-        "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+        "result_format": ResultFormatConfig(
+            result_format="BASIC", partial_unexpected_count=20
+        )
     },
 )
 # </snippet>
@@ -296,7 +301,9 @@ context.add_or_update_checkpoint(
     ],
     evaluation_parameters={"GT_PARAM": 1000, "LT_PARAM": 50000},
     runtime_configuration={
-        "result_format": {"result_format": "BASIC", "partial_unexpected_count": 20}
+        "result_format": ResultFormatConfig(
+            result_format="BASIC", partial_unexpected_count=20
+        )
     },
 )
 # </snippet>


### PR DESCRIPTION
Instead of a TypedDict, let's leverage rich types

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
