### PR TITLE
[DOCS] Document GX Cloud Expectation History Functionality

### DIFF
--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -76,17 +76,15 @@ The following table lists the available GX Cloud Expectations.
 
 View the Expectation history to determine when an Expectation was changed and who made the change. 
 
-1. In GX Cloud, click **Data Assets**.
+1. In GX Cloud, click **Expectation Suites**.
 
-2. In the **Data Assets** list, click the Data Asset name.
+2. In the **Expectation Suites** list, click the Expectation Suite name.
 
-3. Click the **Expectations** tab.
+3. Click the **Change Log** tab.
 
-4. Click the **Change Log** tab.
+4. Optional. Select an Expectation in the **Table of contents** pane to view the change history for a specific Expectation.
 
-5. Select an Expectation Suite in the **Expectation Suites** pane. 
-
-6. Optional. Select a column in the **Columns** pane to view the change history for a specific column.
+    The date, time, and email address of the users who changed the Expectation appear below the Expectation name.
 
 ## Delete an Expectation
 

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -72,6 +72,22 @@ The following table lists the available GX Cloud Expectations.
 
 6. Click **Save**.
 
+## View Expectation history
+
+View the Expectation history to determine when an Expectation was changed and who made the change. 
+
+1. In GX Cloud, click **Data Assets**.
+
+2. In the **Data Assets** list, click the Data Asset name.
+
+3. Click the **Expectations** tab.
+
+4. Click the **Change Log** tab.
+
+5. Select an Expectation Suite in the **Expectation Suites** pane. 
+
+6. Optional. Select a column in the **Columns** pane to view the change history for a specific column.
+
 ## Delete an Expectation
 
 1. In GX Cloud, click **Data Assets**.

--- a/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
+++ b/docs/docusaurus/docs/cloud/expectations/manage_expectations.md
@@ -84,7 +84,7 @@ View the Expectation history to determine when an Expectation was changed and wh
 
 4. Optional. Select an Expectation in the **Table of contents** pane to view the change history for a specific Expectation.
 
-    The date, time, and email address of the users who changed the Expectation appear below the Expectation name.
+    The date, time, and email address of the users who changed the Expectation appear below the Expectation name. Strikethrough text indicates an Expectation was deleted.
 
 ## Delete an Expectation
 

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -4,7 +4,9 @@ title: 'Set up GX Cloud'
 description: Set up GX Cloud.
 ---
 
-To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Cloud agent. If you're using Snowflake, see [Quickstart for GX Cloud and Snowflake](/docs/cloud/quickstarts/snowflake_quickstart).
+To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Cloud agent. 
+
+If you're using Snowflake and are ready to create Expectations and run Validations, see [Quickstart for GX Cloud and Snowflake](/docs/cloud/quickstarts/snowflake_quickstart).
 
 ## Request a GX Cloud Beta account
 
@@ -55,7 +57,7 @@ You'll need your user access token and organization ID to set your environment v
 
 Environment variables securely store your GX Cloud access credentials. The GX Cloud agent runs open source GX code in GX Cloud, and it allows you to securely access your data without connecting to it or interacting with it directly. 
 
-Currently, the GX Cloud user interface is configured for Snowflake and this procedure assumes you have a Snowflake Data Source. If you don't have a Snowflake Data Source, you won't be able to connect to Data Assets, create Expectations and Expectation Suites, run Validations, or create Checkpoints. 
+Currently, the GX Cloud user interface is configured for Snowflake and this procedure assumes you have a Snowflake Data Source. If you don't have a Snowflake Data Source, you won't be able to connect to Data Assets, create Expectation Suites and Expectations, run Validations, or create Checkpoints. 
 
 1. Start the Docker Engine.
 

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -148,6 +148,11 @@ module.exports = {
             },
             {
               type: 'link',
+              label: 'View Expectation history',
+              href: '/docs/cloud/expectations/manage_expectations#view-expectation-history',
+            },
+            {
+              type: 'link',
               label: 'Delete an Expectation',
               href: '/docs/cloud/expectations/manage_expectations#delete-an-expectation',
             },


### PR DESCRIPTION
[DSB-474](https://greatexpectations.atlassian.net/browse/DSB-474) requests adding content to the GX Cloud documentation that explains how to access Expectation history.  This PR implements this request.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Appropriate tests and docs have been updated



[DSB-474]: https://greatexpectations.atlassian.net/browse/DSB-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ