### PR TITLE
[MAINTENANCE] Remove `jsonpatch` and `colorama` dependencies

### DIFF
--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -36,7 +36,6 @@ class GXDependencies:
             "Ipython",
             "ipywidgets",
             "jinja2",
-            "jsonpatch",
             "jsonschema",
             "makefun",
             "marshmallow",

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -31,7 +31,6 @@ class GXDependencies:
     GX_REQUIRED_DEPENDENCIES: List[str] = sorted(
         [
             "altair",
-            "colorama",
             "cryptography",
             "Ipython",
             "ipywidgets",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 altair>=4.2.1,<5.0.0
-colorama>=0.4.3
 cryptography>=3.2
 Ipython>=7.16.3
 ipywidgets>=7.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cryptography>=3.2
 Ipython>=7.16.3
 ipywidgets>=7.5.1
 jinja2>=2.10
-jsonpatch>=1.22
 jsonschema>=2.5.1
 makefun>=1.7.0,<2
 marshmallow>=3.7.1,<4.0.0

--- a/tests/integration/usage_statistics/usage_stats_event_examples.py
+++ b/tests/integration/usage_statistics/usage_stats_event_examples.py
@@ -128,12 +128,6 @@ data_context_init_with_dependencies: dict = {
             },
             {
                 "install_environment": "required",
-                "package_name": "jsonpatch",
-                "installed": True,
-                "version": "1.32",
-            },
-            {
-                "install_environment": "required",
                 "package_name": "jsonschema",
                 "installed": True,
                 "version": "3.2.0",

--- a/tests/integration/usage_statistics/usage_stats_event_examples.py
+++ b/tests/integration/usage_statistics/usage_stats_event_examples.py
@@ -98,12 +98,6 @@ data_context_init_with_dependencies: dict = {
             },
             {
                 "install_environment": "required",
-                "package_name": "colorama",
-                "installed": True,
-                "version": "0.4.4",
-            },
-            {
-                "install_environment": "required",
                 "package_name": "cryptography",
                 "installed": True,
                 "version": "3.4.8",


### PR DESCRIPTION
No longer needed after ExpectationSuite updates

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
