### PR TITLE
[MAINTENANCE] Add Ruff rule to forbid private attribute access outside of origin class

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -373,25 +373,27 @@ def combine_backend_results(
                 logger.error(f"No backend_test_result_counts for {expectation_name}")
                 bad_key_names.append(expectation_name)
                 continue
-            maturity_checklist_object = expectation_instance._get_maturity_checklist(
-                library_metadata=diagnostic_object.library_metadata,
-                description=diagnostic_object.description,
-                examples=diagnostic_object.examples,
-                tests=diagnostic_object.tests,
-                backend_test_result_counts=backend_test_result_counts_object,
+            maturity_checklist_object = (
+                expectation_instance._get_maturity_checklist(  # noqa: SLF001
+                    library_metadata=diagnostic_object.library_metadata,
+                    description=diagnostic_object.description,
+                    examples=diagnostic_object.examples,
+                    tests=diagnostic_object.tests,
+                    backend_test_result_counts=backend_test_result_counts_object,
+                )
             )
             expectations_info[expectation_name][
                 "maturity_checklist"
             ] = maturity_checklist_object.to_dict()
             expectations_info[expectation_name][
                 "coverage_score"
-            ] = Expectation._get_coverage_score(
+            ] = Expectation._get_coverage_score(  # noqa: SLF001
                 backend_test_result_counts=backend_test_result_counts_object,
                 execution_engines=diagnostic_object.execution_engines,
             )
             expectations_info[expectation_name]["library_metadata"][
                 "maturity"
-            ] = Expectation._get_final_maturity_level(
+            ] = Expectation._get_final_maturity_level(  # noqa: SLF001
                 maturity_checklist=maturity_checklist_object
             )
 

--- a/assets/scripts/build_package_gallery.py
+++ b/assets/scripts/build_package_gallery.py
@@ -85,7 +85,7 @@ def _run_pip(stmt: str) -> None:
     if hasattr(pip, "main"):
         pip.main(args)
     else:
-        pip._internal.main(args)
+        pip._internal.main(args)  # noqa: SLF001
 
 
 def write_results_to_disk(path: str, package_manifests: List[dict]) -> None:

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/rule_based_profiler/data_assistant/data_profiler_structured_data_assistant.py
@@ -72,7 +72,7 @@ class DataProfilerStructuredDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return DataProfilerStructuredDataAssistantResult(
-            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,
+            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,  # noqa: SLF001
             profiler_config=data_assistant_result.profiler_config,
             profiler_execution_time=data_assistant_result.profiler_execution_time,
             rule_domain_builder_execution_time=data_assistant_result.rule_domain_builder_execution_time,
@@ -81,7 +81,7 @@ class DataProfilerStructuredDataAssistant(DataAssistant):
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
-            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,  # noqa: SLF001
         )
 
     @staticmethod

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
@@ -161,7 +161,7 @@ def test_profile_data_profiler_structured_data_assistant_result_get_expectation_
     assert mock_emit.call_count == 1
 
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert (
         actual_events[-1][0][0]["event"]
         == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value
@@ -217,7 +217,7 @@ def test_profile_data_profiler_structured_data_assistant_result_batch_id_to_batc
     parameter_node: ParameterNode
     batch_id: str
     assert all(
-        bobby_profile_data_profiler_structured_data_assistant_result._batch_id_to_batch_identifier_display_name_map[
+        bobby_profile_data_profiler_structured_data_assistant_result._batch_id_to_batch_identifier_display_name_map[  # noqa: SLF001
             batch_id
         ]
         is not None

--- a/contrib/cli/tests/test_package.py
+++ b/contrib/cli/tests/test_package.py
@@ -52,7 +52,7 @@ def test_update_expectations(
     package: GreatExpectationsContribPackageManifest,
     diagnostics: List[ExpectationDiagnostics],
 ):
-    package._update_expectations(diagnostics)
+    package._update_expectations(diagnostics)  # noqa: SLF001
 
     assert package.expectation_count == 3
     assert package.expectations and all(
@@ -78,7 +78,7 @@ ruamel.yaml>=0.16,<0.17.18  # package
     """
     requirements_file.write(contents)
 
-    package._update_dependencies(str(requirements_file))
+    package._update_dependencies(str(requirements_file))  # noqa: SLF001
     assert package.dependencies == [
         Dependency(
             text="altair", link="https://pypi.org/project/altair", version="<5, >=4.0.0"
@@ -108,7 +108,7 @@ def test_update_dependencies_with_invalid_path_exits_early(
     dependencies = [Dependency(text="my_dep", link="my_link")]
     package.dependencies = dependencies
 
-    package._update_dependencies("my_fake_path.txt")
+    package._update_dependencies("my_fake_path.txt")  # noqa: SLF001
 
     # Unchanged attrs since file state is invalid
     assert package.dependencies == dependencies
@@ -122,7 +122,7 @@ def test_update_from_package_info_with_valid_path(
     """
     package_info_file.write(contents)
 
-    package._update_from_package_info(str(package_info_file))
+    package._update_from_package_info(str(package_info_file))  # noqa: SLF001
 
 
 def test_update_from_package_info_with_valid_path_with_missing_keys(
@@ -138,7 +138,7 @@ def test_update_from_package_info_with_valid_path_with_missing_keys(
     """
     package_info_file.write(contents)
 
-    package._update_from_package_info(str(package_info_file))
+    package._update_from_package_info(str(package_info_file))  # noqa: SLF001
 
     # Unchanged attrs since file state is invalid
     assert package.code_owners == code_owners
@@ -153,7 +153,7 @@ def test_update_from_package_info_with_invalid_path_exits_early(
     package.code_owners = code_owners
     package.domain_experts = domain_experts
 
-    package._update_from_package_info("my_fake_path.yml")
+    package._update_from_package_info("my_fake_path.yml")  # noqa: SLF001
 
     # Unchanged attrs since file state is invalid
     assert package.code_owners == code_owners

--- a/contrib/experimental/great_expectations_experimental/rule_based_profiler/data_assistant/growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/rule_based_profiler/data_assistant/growth_numeric_data_assistant.py
@@ -110,7 +110,7 @@ class GrowthNumericDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return GrowthNumericDataAssistantResult(
-            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,
+            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,  # noqa: SLF001
             profiler_config=data_assistant_result.profiler_config,
             profiler_execution_time=data_assistant_result.profiler_execution_time,
             rule_domain_builder_execution_time=data_assistant_result.rule_domain_builder_execution_time,
@@ -119,7 +119,7 @@ class GrowthNumericDataAssistant(DataAssistant):
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
-            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,  # noqa: SLF001
         )
 
     @staticmethod

--- a/contrib/experimental/great_expectations_experimental/rule_based_profiler/data_assistant/statistics_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/rule_based_profiler/data_assistant/statistics_data_assistant.py
@@ -87,7 +87,7 @@ class StatisticsDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return StatisticsDataAssistantResult(
-            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,
+            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,  # noqa: SLF001
             profiler_config=data_assistant_result.profiler_config,
             profiler_execution_time=data_assistant_result.profiler_execution_time,
             rule_domain_builder_execution_time=data_assistant_result.rule_domain_builder_execution_time,
@@ -96,7 +96,7 @@ class StatisticsDataAssistant(DataAssistant):
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
-            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,  # noqa: SLF001
         )
 
     @staticmethod

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -152,7 +152,7 @@ def test_growth_numeric_data_assistant_result_get_expectation_suite(
     assert mock_emit.call_count == 1
 
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert (
         actual_events[-1][0][0]["event"]
         == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE
@@ -203,7 +203,7 @@ def test_growth_numeric_data_assistant_result_batch_id_to_batch_identifier_displ
     parameter_node: ParameterNode
     batch_id: str
     assert all(
-        bobby_growth_numeric_data_assistant_result._batch_id_to_batch_identifier_display_name_map[
+        bobby_growth_numeric_data_assistant_result._batch_id_to_batch_identifier_display_name_map[  # noqa: SLF001
             batch_id
         ]
         is not None

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
@@ -122,7 +122,7 @@ def test_statistics_data_assistant_result_batch_id_to_batch_identifier_display_n
     parameter_node: ParameterNode
     batch_id: str
     assert all(
-        bobby_statistics_data_assistant_result._batch_id_to_batch_identifier_display_name_map[
+        bobby_statistics_data_assistant_result._batch_id_to_batch_identifier_display_name_map[  # noqa: SLF001
             batch_id
         ]
         is not None

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -120,7 +120,9 @@ class BaseCheckpoint(ConfigPeer):
         checkpoint_config: CheckpointConfig,
         data_context: AbstractDataContext,
     ) -> None:
-        self._usage_statistics_handler = data_context._usage_statistics_handler
+        self._usage_statistics_handler = (
+            data_context._usage_statistics_handler  # noqa: SLF001
+        )
 
         self._data_context = data_context
 
@@ -473,7 +475,7 @@ class BaseCheckpoint(ConfigPeer):
             )
             if include_rendered_content is None:
                 include_rendered_content = (
-                    self._data_context._determine_if_expectation_validation_result_include_rendered_content()
+                    self._data_context._determine_if_expectation_validation_result_include_rendered_content()  # noqa: SLF001
                 )
 
             validator: Validator = self._validator or self.data_context.get_validator(

--- a/great_expectations/checkpoint/types/checkpoint_result.py
+++ b/great_expectations/checkpoint/types/checkpoint_result.py
@@ -433,7 +433,9 @@ class CheckpointResultSchema(Schema):
     @pre_dump
     def prepare_dump(self, data, **kwargs):
         data = copy.deepcopy(data)
-        data._run_results = convert_to_json_serializable(data.run_results)
+        data._run_results = convert_to_json_serializable(  # noqa: SLF001
+            data.run_results
+        )
         return data
 
     # noinspection PyUnusedLocal

--- a/great_expectations/core/async_executor.py
+++ b/great_expectations/core/async_executor.py
@@ -143,4 +143,4 @@ def patch_https_connection_pool(
 
     # Increase the HTTP pool size to avoid the "Connection pool is full, discarding connection: bigquery.googleapis.com"
     adapter = requests.adapters.HTTPAdapter(pool_connections=100, pool_maxsize=100)
-    bq._http.mount("https://", adapter)
+    bq._http.mount("https://", adapter)  # noqa: SLF001

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -1140,7 +1140,7 @@ def _get_runtime_batch_request(  # noqa: PLR0913
             # TODO: Raise a warning if kwargs exist
             pass
 
-        RuntimeBatchRequest._validate_runtime_batch_request_specific_init_parameters(
+        RuntimeBatchRequest._validate_runtime_batch_request_specific_init_parameters(  # noqa: SLF001
             runtime_parameters=runtime_parameters,
             batch_identifiers=batch_identifiers,
             batch_spec_passthrough=batch_spec_passthrough,

--- a/great_expectations/core/batch_config.py
+++ b/great_expectations/core/batch_config.py
@@ -29,4 +29,4 @@ class BatchConfig(pydantic.BaseModel):
         return self.data_asset.build_batch_request(options=batch_request_options)
 
     def save(self) -> None:
-        self.data_asset._save_batch_config(self)
+        self.data_asset._save_batch_config(self)  # noqa: SLF001

--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -199,8 +199,8 @@ class _CloudConfigurationProvider(_AbstractConfigurationProvider):
             GXCloudEnvironmentVariable.BASE_URL: base_url,
             GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
             # <GX_RENAME> Deprecated as of 0.15.37
-            GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-            GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
+            GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,  # noqa: SLF001
+            GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,  # noqa: SLF001
         }
 
         # organization_id is nullable so we conditionally include it in the output
@@ -209,7 +209,7 @@ class _CloudConfigurationProvider(_AbstractConfigurationProvider):
                 {
                     GXCloudEnvironmentVariable.ORGANIZATION_ID: organization_id,
                     # <GX_RENAME> Deprecated as of 0.15.37
-                    GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,
+                    GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,  # noqa: SLF001
                 }
             )
 

--- a/great_expectations/core/config_substitutor.py
+++ b/great_expectations/core/config_substitutor.py
@@ -352,9 +352,9 @@ class _ConfigurationSubstitutor:
             secret_version = "latest"
         name = f"projects/{project_id}/secrets/{secret_id}/versions/{secret_version}"
         try:
-            secret = client.access_secret_version(name=name)._pb.payload.data.decode(
-                "utf-8"
-            )
+            secret = client.access_secret_version(  # noqa: SLF001
+                name=name
+            )._pb.payload.data.decode("utf-8")
         except AttributeError:
             secret = client.access_secret_version(name=name).payload.data.decode(
                 "utf-8"

--- a/great_expectations/core/datasource_dict.py
+++ b/great_expectations/core/datasource_dict.py
@@ -169,8 +169,8 @@ class DatasourceDict(UserDict):
     def _init_fluent_datasource(
         self, name: str, ds: FluentDatasource
     ) -> FluentDatasource:
-        ds._data_context = self._context
-        ds._rebuild_asset_data_connectors()
+        ds._data_context = self._context  # noqa: SLF001
+        ds._rebuild_asset_data_connectors()  # noqa: SLF001
         if isinstance(ds, SupportsInMemoryDataAssets):
             for asset in ds.assets:
                 if asset.type == _IN_MEMORY_DATA_ASSET_TYPE:
@@ -195,7 +195,7 @@ class DatasourceDict(UserDict):
     def _init_block_style_datasource(
         self, name: str, config: DatasourceConfig
     ) -> BaseDatasource:
-        return self._context._init_block_style_datasource(
+        return self._context._init_block_style_datasource(  # noqa: SLF001
             datasource_name=name, datasource_config=config
         )
 

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -341,7 +341,7 @@ class ExpectationSuite(SerializableDictDot):
         for key in attributes_to_copy:
             setattr(result, key, deepcopy(getattr(self, key)))
 
-        result._data_context = self._data_context
+        result._data_context = self._data_context  # noqa: SLF001
 
         return result
 

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -131,8 +131,10 @@ class Anonymizer(BaseAnonymizer):
 
         anonymized_values: List[dict] = []
         for name, config in payload.items():
-            anonymize_value: dict = anonymizer._anonymize_datasource_info(
-                name=name, config=config
+            anonymize_value: dict = (
+                anonymizer._anonymize_datasource_info(  # noqa: SLF001
+                    name=name, config=config
+                )
             )
             anonymized_values.append(anonymize_value)
 

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -424,7 +424,9 @@ def add_datasource_usage_statistics(
             name
         ), "Guaranteed to have name from either `name` or `datasource` input args"
 
-        payload = datasource_anonymizer._anonymize_datasource_info(name, kwargs)
+        payload = datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
+            name, kwargs
+        )
     except Exception as e:
         logger.debug(
             f"{UsageStatsExceptionPrefix.EMIT_EXCEPTION.value}: {e} type: {type(e)}, add_datasource_usage_statistics: Unable to create add_datasource_usage_statistics payload field"
@@ -469,7 +471,7 @@ def get_checkpoint_run_usage_statistics(
     **kwargs,
 ) -> dict:
     usage_statistics_handler: UsageStatisticsHandler | None = (
-        checkpoint._usage_statistics_handler
+        checkpoint._usage_statistics_handler  # noqa: SLF001
     )
 
     data_context_id: str | None = None
@@ -514,12 +516,12 @@ def get_profiler_run_usage_statistics(
     **kwargs: dict,
 ) -> dict:
     usage_statistics_handler: UsageStatisticsHandler | None = (
-        profiler._usage_statistics_handler
+        profiler._usage_statistics_handler  # noqa: SLF001
     )
 
     data_context_id: str | None = None
     if usage_statistics_handler:
-        data_context_id = usage_statistics_handler._data_context_id
+        data_context_id = usage_statistics_handler._data_context_id  # noqa: SLF001
 
     anonymizer = _anonymizers.get(data_context_id, None)
     if anonymizer is None:

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -819,7 +819,7 @@ def get_or_create_spark_application(
         raise ValueError("SparkContext could not be started.")
 
     # noinspection PyUnresolvedReferences
-    sc_stopped: bool = spark_session.sparkContext._jsc.sc().isStopped()
+    sc_stopped: bool = spark_session.sparkContext._jsc.sc().isStopped()  # noqa: SLF001
     if not force_reuse_spark_context and spark_restart_required(
         current_spark_config=spark_session.sparkContext.getConf().getAll(),
         desired_spark_config=spark_config,
@@ -837,7 +837,7 @@ def get_or_create_spark_application(
         if spark_session is None:
             raise ValueError("SparkContext could not be started.")
         # noinspection PyProtectedMember,PyUnresolvedReferences
-        sc_stopped = spark_session.sparkContext._jsc.sc().isStopped()
+        sc_stopped = spark_session.sparkContext._jsc.sc().isStopped()  # noqa: SLF001
 
     if sc_stopped:
         raise ValueError("SparkContext stopped unexpectedly.")
@@ -882,7 +882,7 @@ def get_or_create_spark_session(
 
         spark_session = builder.getOrCreate()
         # noinspection PyProtectedMember,PyUnresolvedReferences
-        if spark_session.sparkContext._jsc.sc().isStopped():
+        if spark_session.sparkContext._jsc.sc().isStopped():  # noqa: SLF001
             raise ValueError("SparkContext stopped unexpectedly.")
 
     except AttributeError:

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -265,9 +265,11 @@ class DataAsset:
                     stored_config = expectation_config
                 else:
                     # Append the expectation to the config.
-                    stored_config = self._expectation_suite._add_expectation(
-                        expectation_configuration=expectation_config,
-                        send_usage_event=False,
+                    stored_config = (
+                        self._expectation_suite._add_expectation(  # noqa: SLF001
+                            expectation_configuration=expectation_config,
+                            send_usage_event=False,
+                        )
                     )
 
                 if include_config:
@@ -734,7 +736,7 @@ class DataAsset:
                     "loaded from a dictionary?"
                 )
                 if getattr(data_context, "_usage_statistics_handler", None):
-                    handler = data_context._usage_statistics_handler
+                    handler = data_context._usage_statistics_handler  # noqa: SLF001
                     handler.send_usage_message(
                         event=UsageStatsEvents.DATA_ASSET_VALIDATE,
                         event_payload=handler.anonymizer.anonymize(obj=self),

--- a/great_expectations/data_context/_version_checker.py
+++ b/great_expectations/data_context/_version_checker.py
@@ -76,7 +76,7 @@ class _VersionChecker:
 
         pypi_version = version.Version(pkg_version)
         # update the _LATEST_GX_VERSION_CACHE
-        self.__class__._LATEST_GX_VERSION_CACHE = pypi_version
+        self.__class__._LATEST_GX_VERSION_CACHE = pypi_version  # noqa: SLF001
         return pypi_version
 
     def _is_using_outdated_release(self, pypi_version: version.Version) -> bool:

--- a/great_expectations/data_context/config_validator/yaml_config_validator.py
+++ b/great_expectations/data_context/config_validator/yaml_config_validator.py
@@ -380,9 +380,11 @@ class _YamlConfigValidator:
         """
         print(f"\tInstantiating as a Store, since class_name is {class_name}")
         store_name: str = name or config.get("name") or "my_temp_store"
-        instantiated_class = self._data_context._build_store_from_config(
-            store_name=store_name,
-            store_config=config,
+        instantiated_class = (
+            self._data_context._build_store_from_config(  # noqa: SLF001
+                store_name=store_name,
+                store_config=config,
+            )
         )
         store_name = instantiated_class.store_name or store_name
         self._data_context.config["stores"][store_name] = config
@@ -404,10 +406,8 @@ class _YamlConfigValidator:
         datasource_name: str = name or config.get("name") or "my_temp_datasource"
         datasource_config = datasourceConfigSchema.load(config)
         datasource_config.name = datasource_name
-        instantiated_class = (
-            self._data_context._instantiate_datasource_from_config_with_substitution(
-                config=datasource_config
-            )
+        instantiated_class = self._data_context._instantiate_datasource_from_config_with_substitution(  # noqa: SLF001
+            config=datasource_config
         )
 
         anonymizer = Anonymizer(self._data_context.data_context_id)

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -711,7 +711,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             name=datasource_name, ds=datasource
         )
         assert isinstance(return_obj, FluentDatasource)
-        return_obj._data_context = self
+        return_obj._data_context = self  # noqa: SLF001
         self._save_project_config()
 
         return return_obj
@@ -735,12 +735,12 @@ class AbstractDataContext(ConfigPeer, ABC):
         else:
             updated_datasource = datasource
 
-        updated_datasource._rebuild_asset_data_connectors()
+        updated_datasource._rebuild_asset_data_connectors()  # noqa: SLF001
 
         updated_datasource = self.datasources.set_datasource(
             name=datasource_name, ds=updated_datasource
         )
-        updated_datasource._data_context = self  # TODO: move from here?
+        updated_datasource._data_context = self  # TODO: move from here?  # noqa: SLF001
         self._save_project_config()
 
         assert isinstance(updated_datasource, FluentDatasource)
@@ -1193,7 +1193,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             raise ValueError(str(e)) from e
 
         if not isinstance(datasource, BaseDatasource):
-            datasource._data_context = self
+            datasource._data_context = self  # noqa: SLF001
         return datasource
 
     def _serialize_substitute_and_sanitize_datasource_config(
@@ -3832,7 +3832,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         if self._datasource_store.cloud_mode:
             for fds in config.fluent_datasources.values():
                 datasource = self._add_fluent_datasource(**fds)
-                datasource._rebuild_asset_data_connectors()
+                datasource._rebuild_asset_data_connectors()  # noqa: SLF001
 
         datasources: Dict[str, DatasourceConfig] = cast(
             Dict[str, DatasourceConfig], config.datasources
@@ -3940,7 +3940,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         # Chetan - 20221103 - Directly accessing private attr in order to patch security vulnerabiliy around credential leakage.
         # This is to be removed once substitution logic is migrated from the context to the individual object level.
         raw_config_dict: dict = serializer.serialize(raw_config)
-        datasource._raw_config = raw_config_dict
+        datasource._raw_config = raw_config_dict  # noqa: SLF001
 
         return datasource
 
@@ -4583,7 +4583,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             ds_name = datasource.name
             logger.info(f"Loaded '{ds_name}' from fluent config")
 
-            datasource._rebuild_asset_data_connectors()
+            datasource._rebuild_asset_data_connectors()  # noqa: SLF001
 
             self._add_fluent_datasource(datasource=datasource)
 

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -334,7 +334,7 @@ class CloudDataContext(SerializableDataContext):
             cloud_base_url
             or cls._get_cloud_env_var(
                 primary_environment_variable=GXCloudEnvironmentVariable.BASE_URL,
-                deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_BASE_URL,
+                deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_BASE_URL,  # noqa: SLF001
                 conf_file_section="ge_cloud_config",
                 conf_file_option="base_url",
             )
@@ -342,13 +342,13 @@ class CloudDataContext(SerializableDataContext):
         )
         cloud_organization_id = cloud_organization_id or cls._get_cloud_env_var(
             primary_environment_variable=GXCloudEnvironmentVariable.ORGANIZATION_ID,
-            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID,
+            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID,  # noqa: SLF001
             conf_file_section="ge_cloud_config",
             conf_file_option="organization_id",
         )
         cloud_access_token = cloud_access_token or cls._get_cloud_env_var(
             primary_environment_variable=GXCloudEnvironmentVariable.ACCESS_TOKEN,
-            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN,
+            deprecated_environment_variable=GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN,  # noqa: SLF001
             conf_file_section="ge_cloud_config",
             conf_file_option="access_token",
         )

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -176,13 +176,11 @@ class FileDataContext(SerializableDataContext):
                     )
                     fluent_json_dict: dict[
                         str, JSONValues
-                    ] = self.fluent_config._json_dict()
-                    fluent_json_dict = (
-                        self.fluent_config._exclude_name_fields_from_fluent_datasources(
-                            config=fluent_json_dict
-                        )
+                    ] = self.fluent_config._json_dict()  # noqa: SLF001
+                    fluent_json_dict = self.fluent_config._exclude_name_fields_from_fluent_datasources(  # noqa: SLF001
+                        config=fluent_json_dict
                     )
-                    self.config._commented_map.update(fluent_json_dict)
+                    self.config._commented_map.update(fluent_json_dict)  # noqa: SLF001
 
                 self.config.to_yaml(outfile)
         except PermissionError as e:
@@ -228,7 +226,7 @@ class FileDataContext(SerializableDataContext):
                 gx_config = GxConfig.parse_yaml(path_to_fluent_yaml, _allow_empty=True)
 
                 for datasource in gx_config.datasources:
-                    datasource._data_context = self
+                    datasource._data_context = self  # noqa: SLF001
 
                 return gx_config
             logger.info(f"no fluent config at {path_to_fluent_yaml.absolute()}")

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -341,7 +341,7 @@ class FileDataContextVariables(DataContextVariables):
         store = DataContextStore(
             store_name="file_data_context_store",
         )
-        store._store_backend = store_backend
+        store._store_backend = store_backend  # noqa: SLF001
         return store
 
     @override
@@ -368,7 +368,7 @@ class FileDataContextVariables(DataContextVariables):
         """
         config_fluent_datasources_stash: Dict[
             str, FluentDatasource
-        ] = self.data_context._synchronize_fluent_datasources()
+        ] = self.data_context._synchronize_fluent_datasources()  # noqa: SLF001
         try:
             if config_fluent_datasources_stash:
                 logger.info(

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -127,7 +127,7 @@ class CloudMigrator:
                 cloud_access_token=cloud_access_token,
                 cloud_organization_id=cloud_organization_id,
             )
-            cloud_migrator._migrate_to_cloud(test_migrate)
+            cloud_migrator._migrate_to_cloud(test_migrate)  # noqa: SLF001
             if not test_migrate:  # Only send an event if this is not a test run.
                 send_usage_message(
                     data_context=context,

--- a/great_expectations/data_context/migrator/configuration_bundle.py
+++ b/great_expectations/data_context/migrator/configuration_bundle.py
@@ -90,8 +90,10 @@ class ConfigurationBundle:
         # to all Data Contexts.
         datasource_configs: List[DatasourceConfig | FluentDatasource] = []
         for datasource_name in datasource_names:
-            datasource_config = self._context._datasource_store.retrieve_by_name(
-                datasource_name=datasource_name
+            datasource_config = (
+                self._context._datasource_store.retrieve_by_name(  # noqa: SLF001
+                    datasource_name=datasource_name
+                )
             )
             datasource_config.name = datasource_name
             datasource_configs.append(datasource_config)

--- a/great_expectations/data_context/migrator/file_migrator.py
+++ b/great_expectations/data_context/migrator/file_migrator.py
@@ -62,7 +62,9 @@ class FileMigrator:
         self._migrate_primary_stores(
             target_stores=target_context.stores,
         )
-        self._migrate_datasource_store(target_store=target_context._datasource_store)
+        self._migrate_datasource_store(
+            target_store=target_context._datasource_store  # noqa: SLF001
+        )
         self._migrate_data_docs_sites(
             target_context=target_context,
         )
@@ -130,7 +132,7 @@ class FileMigrator:
 
     def _migrate_fluent_datasources(self, target_context: FileDataContext) -> None:
         target_context.fluent_config = self._fluent_config
-        target_context._save_project_config()
+        target_context._save_project_config()  # noqa: SLF001
 
     def _migrate_data_docs_site_configs(
         self,

--- a/great_expectations/data_context/store/data_asset_store.py
+++ b/great_expectations/data_context/store/data_asset_store.py
@@ -84,7 +84,7 @@ class DataAssetStore(Store):
         """
         See parent 'Store.serialize()' for more information
         """
-        return value._json_dict()
+        return value._json_dict()  # noqa: SLF001
 
     @override
     def deserialize(self, value: dict) -> FluentDataAsset:

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -90,7 +90,7 @@ class DatasourceStore(Store):
         See parent 'Store.serialize()' for more information
         """
         if isinstance(value, FluentDatasource):
-            return value._json_dict()
+            return value._json_dict()  # noqa: SLF001
         return self._serializer.serialize(value)
 
     @overload

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -120,9 +120,13 @@ class BaseYamlConfig(SerializableDictDot):
 
         if hasattr(cls.get_config_class(), "_schema_instance"):
             # noinspection PyProtectedMember
-            schema_instance: Optional[Schema] = cls.get_config_class()._schema_instance
+            schema_instance: Optional[
+                Schema
+            ] = cls.get_config_class()._schema_instance  # noqa: SLF001
             if schema_instance is None:
-                cls.get_config_class()._schema_instance = (cls.get_schema_class())()
+                cls.get_config_class()._schema_instance = (  # noqa: SLF001
+                    cls.get_schema_class()
+                )()
                 return cls.get_config_class().schema_instance
             else:
                 return schema_instance

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -394,7 +394,7 @@ Notes:
     # to manipulation results, we would just use `_metadata = ['row_count', ...]` here. The most likely
     # case is that we want the former, but also want to re-initialize these values to None so we don't
     # get an attribute error when trying to access them (I think this could be done in __finalize__?)
-    _internal_names = pd.DataFrame._internal_names + [  # type: ignore[attr-defined]
+    _internal_names = pd.DataFrame._internal_names + [  # type: ignore[attr-defined]  # noqa: SLF001
         "_batch_kwargs",
         "_batch_markers",
         "_batch_parameters",
@@ -423,7 +423,7 @@ Notes:
 
     def __finalize__(self, other, method=None, **kwargs):
         if isinstance(other, PandasDataset):
-            self._initialize_expectations(other._expectation_suite)
+            self._initialize_expectations(other._expectation_suite)  # noqa: SLF001
             # If other was coerced to be a PandasDataset (e.g. via _constructor call during self.copy() operation)
             # then it may not have discard_subset_failing_expectations set. Default to self value
             self.discard_subset_failing_expectations = getattr(

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -1399,7 +1399,7 @@ class SparkDFDataset(MetaSparkDFDataset):
         )
 
         value_set_df = (
-            pyspark.SQLContext(self.spark_df._sc)
+            pyspark.SQLContext(self.spark_df._sc)  # noqa: SLF001
             .createDataFrame(value_pairs_set, ["col_A", "col_B"])
             .select(F.array("col_A", "col_B").alias("set_AB"))
         )

--- a/great_expectations/datasource/fluent/config.py
+++ b/great_expectations/datasource/fluent/config.py
@@ -220,7 +220,7 @@ class GxConfig(FluentBaseModel):
                 # TODO: move this to a different 'validator' method
                 # attach the datasource to the nested assets, avoiding recursion errors
                 for asset in datasource.assets:
-                    asset._datasource = datasource
+                    asset._datasource = datasource  # noqa: SLF001
 
         logger.debug(f"Loaded 'datasources' ->\n{loaded_datasources!r}")
 

--- a/great_expectations/datasource/fluent/config_str.py
+++ b/great_expectations/datasource/fluent/config_str.py
@@ -87,7 +87,7 @@ def _check_config_substitutions_needed(
     if (
         need_config_subs
         and raise_warning_if_provider_not_present
-        and not datasource._config_provider
+        and not datasource._config_provider  # noqa: SLF001
     ):
         warnings.warn(
             f"config variables '{','.join(need_config_subs)}' need substitution but no `_ConfigurationProvider` is present"

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -55,9 +55,11 @@ def file_get_unfiltered_batch_definition_list_fn(
     batch_definition_set = set()
     for (
         batch_definition
-    ) in data_connector._get_batch_definition_list_from_data_references_cache():
+    ) in (
+        data_connector._get_batch_definition_list_from_data_references_cache()  # noqa: SLF001
+    ):
         if (
-            data_connector._batch_definition_matches_batch_request(
+            data_connector._batch_definition_matches_batch_request(  # noqa: SLF001
                 batch_definition=batch_definition, batch_request=batch_request
             )
             and batch_definition not in batch_definition_set

--- a/great_expectations/datasource/fluent/dynamic_pandas.py
+++ b/great_expectations/datasource/fluent/dynamic_pandas.py
@@ -357,7 +357,7 @@ def _to_pydantic_fields(
         if substitution:
             fields_dict.update(substitution)
         else:
-            no_annotation: bool = param.annotation is inspect._empty
+            no_annotation: bool = param.annotation is inspect._empty  # noqa: SLF001
             if no_annotation:
                 logger.debug(f"`{param_name}` has no type annotation")
                 FIELD_SKIPPED_NO_ANNOTATION.add(param_name)  # TODO: not skipped
@@ -407,8 +407,8 @@ def _create_pandas_asset_model(  # noqa: PLR0913
     def _get_reader_options_include(self) -> set[str]:
         return set()
 
-    model._get_reader_method = _get_reader_method
-    model._get_reader_options_include = _get_reader_options_include
+    model._get_reader_method = _get_reader_method  # noqa: SLF001
+    model._get_reader_options_include = _get_reader_options_include  # noqa: SLF001
 
     return model
 

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -236,7 +236,7 @@ class _FilePathDataAsset(DataAsset):
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options=options,
-                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]
+                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]  # noqa: SLF001
             )
             raise gx_exceptions.InvalidBatchRequestError(
                 "BatchRequest should have form:\n"
@@ -356,7 +356,7 @@ class _FilePathDataAsset(DataAsset):
                 exclude=self._EXCLUDE_FROM_READER_OPTIONS,
                 exclude_unset=True,
                 by_alias=True,
-                config_provider=self._datasource._config_provider,
+                config_provider=self._datasource._config_provider,  # noqa: SLF001
             ),
         }
 

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -547,7 +547,7 @@ class Datasource(
             found_asset: _DataAssetT = list(
                 filter(lambda asset: asset.name == asset_name, self.assets)
             )[0]
-            found_asset._datasource = self
+            found_asset._datasource = self  # noqa: SLF001
             return found_asset
         except IndexError as exc:
             raise LookupError(
@@ -566,7 +566,7 @@ class Datasource(
         asset = self.get_asset(asset_name=asset_name)
 
         if self._data_context and isinstance(self._data_context, CloudDataContext):
-            self._data_context._delete_asset(id=str(asset.id))
+            self._data_context._delete_asset(id=str(asset.id))  # noqa: SLF001
 
         self.assets = list(filter(lambda asset: asset.name != asset_name, self.assets))
         self._save_context_project_config()
@@ -581,7 +581,7 @@ class Datasource(
         """
         # The setter for datasource is non-functional, so we access _datasource directly.
         # See the comment in DataAsset for more information.
-        asset._datasource = self
+        asset._datasource = self  # noqa: SLF001
 
         if not connect_options:
             connect_options = {}
@@ -600,8 +600,10 @@ class Datasource(
         # if asset was added to a cloud FDS, _update_fluent_datasource will return FDS fetched from cloud,
         # which will contain the new asset populated with an id
         if self._data_context:
-            updated_datasource = self._data_context._update_fluent_datasource(
-                datasource=self
+            updated_datasource = (
+                self._data_context._update_fluent_datasource(  # noqa: SLF001
+                    datasource=self
+                )
             )
             assert isinstance(updated_datasource, Datasource)
             if asset_id := updated_datasource.get_asset(asset_name=asset.name).id:
@@ -613,7 +615,7 @@ class Datasource(
         """Check if a DataContext is available and save the project config."""
         if self._data_context:
             try:
-                self._data_context._save_project_config()
+                self._data_context._save_project_config()  # noqa: SLF001
             except TypeError as type_err:
                 warnings.warn(str(type_err), GxSerializationWarning)
 

--- a/great_expectations/datasource/fluent/metadatasource.py
+++ b/great_expectations/datasource/fluent/metadatasource.py
@@ -38,8 +38,8 @@ class MetaDatasource(ModelMetaclass):
 
         logger.debug(f"  {cls_name} __dict__ ->\n{pf(cls.__dict__, depth=3)}")
 
-        meta_cls.__cls_set.add(cls)
-        logger.debug(f"Datasources: {len(meta_cls.__cls_set)}")
+        meta_cls.__cls_set.add(cls)  # noqa: SLF001
+        logger.debug(f"Datasources: {len(meta_cls.__cls_set)}")  # noqa: SLF001
 
         if cls.__module__ == "__main__":
             logger.warning(

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -150,7 +150,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
                 f"'{data_asset.name}' is missing required argument 'abs_container'"
             )
 
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
+        data_asset._data_connector = self.data_connector_type.build_data_connector(  # noqa: SLF001
             datasource_name=self.name,
             data_asset_name=data_asset.name,
             azure_client=self._get_azure_client(),
@@ -164,7 +164,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -130,7 +130,7 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
                 exclude=self._EXCLUDE_FROM_READER_OPTIONS,
                 exclude_unset=True,
                 by_alias=True,
-                config_provider=self._datasource._config_provider,
+                config_provider=self._datasource._config_provider,  # noqa: SLF001
             ),
         )
         execution_engine: PandasExecutionEngine = self.datasource.get_execution_engine()
@@ -220,7 +220,7 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options={},
-                batch_slice=batch_request._batch_slice_input,
+                batch_slice=batch_request._batch_slice_input,  # noqa: SLF001
             )
             raise gx_exceptions.InvalidBatchRequestError(
                 "BatchRequest should have form:\n"
@@ -589,7 +589,9 @@ class _PandasDatasource(Datasource, Generic[_DataAssetT]):
 
         in_cloud_context: bool = False
         if self._data_context:
-            in_cloud_context = self._data_context._datasource_store.cloud_mode
+            in_cloud_context = (
+                self._data_context._datasource_store.cloud_mode  # noqa: SLF001
+            )
 
         if asset_name == DEFAULT_PANDAS_DATA_ASSET_NAME:
             if in_cloud_context:

--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.py
@@ -39,18 +39,20 @@ class PandasDBFSDatasource(PandasFilesystemDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            batching_regex=data_asset.batching_regex,
-            base_directory=self.base_directory,
-            glob_directive=glob_directive,
-            data_context_root_directory=self.data_context_root_directory,
-            file_path_template_map_fn=DBFSPath.convert_to_file_semantics_version,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                batching_regex=data_asset.batching_regex,
+                base_directory=self.base_directory,
+                glob_directive=glob_directive,
+                data_context_root_directory=self.data_context_root_directory,
+                file_path_template_map_fn=DBFSPath.convert_to_file_semantics_version,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -69,17 +69,19 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            batching_regex=data_asset.batching_regex,
-            base_directory=self.base_directory,
-            glob_directive=glob_directive,
-            data_context_root_directory=self.data_context_root_directory,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                batching_regex=data_asset.batching_regex,
+                base_directory=self.base_directory,
+                glob_directive=glob_directive,
+                data_context_root_directory=self.data_context_root_directory,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -139,21 +139,23 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            gcs_client=self._get_gcs_client(),
-            batching_regex=data_asset.batching_regex,
-            bucket_or_name=self.bucket_or_name,
-            prefix=gcs_prefix,
-            delimiter=gcs_delimiter,
-            max_results=gcs_max_results,
-            recursive_file_discovery=gcs_recursive_file_discovery,
-            file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                gcs_client=self._get_gcs_client(),
+                batching_regex=data_asset.batching_regex,
+                bucket_or_name=self.bucket_or_name,
+                prefix=gcs_prefix,
+                delimiter=gcs_delimiter,
+                max_results=gcs_max_results,
+                recursive_file_discovery=gcs_recursive_file_discovery,
+                file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/pandas_s3_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_s3_datasource.py
@@ -120,21 +120,23 @@ class PandasS3Datasource(_PandasFilePathDatasource):
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
 
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            s3_client=self._get_s3_client(),
-            batching_regex=data_asset.batching_regex,
-            bucket=self.bucket,
-            prefix=s3_prefix,
-            delimiter=s3_delimiter,
-            max_keys=s3_max_keys,
-            recursive_file_discovery=s3_recursive_file_discovery,
-            file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                s3_client=self._get_s3_client(),
+                batching_regex=data_asset.batching_regex,
+                bucket=self.bucket,
+                prefix=s3_prefix,
+                delimiter=s3_delimiter,
+                max_keys=s3_max_keys,
+                recursive_file_discovery=s3_recursive_file_discovery,
+                file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -123,7 +123,7 @@ class _SourceFactories:
             )
 
         # rollback type registrations if exception occurs
-        with cls.type_lookup.transaction() as ds_type_lookup, ds_type._type_lookup.transaction() as asset_type_lookup:
+        with cls.type_lookup.transaction() as ds_type_lookup, ds_type._type_lookup.transaction() as asset_type_lookup:  # noqa: SLF001
             cls._register_assets(ds_type, asset_type_lookup=asset_type_lookup)
 
             cls._register_datasource(
@@ -468,9 +468,11 @@ class _SourceFactories:
                 else datasource_type(**kwargs)
             )
             logger.debug(f"Adding {datasource_type} with {datasource.name}")
-            datasource._data_context = self._data_context
+            datasource._data_context = self._data_context  # noqa: SLF001
             datasource.test_connection()
-            datasource = self._data_context._add_fluent_datasource(datasource)
+            datasource = self._data_context._add_fluent_datasource(  # noqa: SLF001
+                datasource
+            )
 
             return datasource
 
@@ -519,9 +521,9 @@ class _SourceFactories:
             if id_:
                 updated_datasource.id = id_
 
-            updated_datasource._data_context = self._data_context
+            updated_datasource._data_context = self._data_context  # noqa: SLF001
             updated_datasource.test_connection()
-            return_obj = self._data_context._update_fluent_datasource(
+            return_obj = self._data_context._update_fluent_datasource(  # noqa: SLF001
                 datasource=updated_datasource
             )
             assert isinstance(return_obj, Datasource)
@@ -574,14 +576,16 @@ class _SourceFactories:
             if id_:
                 new_datasource.id = id_
 
-            new_datasource._data_context = self._data_context
+            new_datasource._data_context = self._data_context  # noqa: SLF001
             new_datasource.test_connection()
             if datasource_name in self._data_context.datasources:
-                return_obj = self._data_context._update_fluent_datasource(
-                    datasource=new_datasource
+                return_obj = (
+                    self._data_context._update_fluent_datasource(  # noqa: SLF001
+                        datasource=new_datasource
+                    )
                 )
             else:
-                return_obj = self._data_context._add_fluent_datasource(
+                return_obj = self._data_context._add_fluent_datasource(  # noqa: SLF001
                     datasource=new_datasource
                 )
             assert isinstance(return_obj, Datasource)
@@ -605,8 +609,10 @@ class _SourceFactories:
         def delete_datasource(name: str) -> None:
             logger.debug(f"Delete {datasource_type} with {name}")
             self._validate_current_datasource_type(name, datasource_type)
-            self._data_context._delete_fluent_datasource(datasource_name=name)
-            self._data_context._save_project_config()
+            self._data_context._delete_fluent_datasource(  # noqa: SLF001
+                datasource_name=name
+            )
+            self._data_context._save_project_config()  # noqa: SLF001
 
         delete_datasource.__doc__ = doc_string
         # attr-defined issue https://github.com/python/mypy/issues/12472
@@ -669,6 +675,8 @@ def _iter_all_registered_types(
             yield ds_name, ds_type
 
         if include_data_asset:
-            for asset_name in ds_type._type_lookup.type_names():
-                asset_type: Type[DataAsset] = ds_type._type_lookup[asset_name]
+            for asset_name in ds_type._type_lookup.type_names():  # noqa: SLF001
+                asset_type: Type[DataAsset] = ds_type._type_lookup[  # noqa: SLF001
+                    asset_name
+                ]
                 yield asset_name, asset_type

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -155,7 +155,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
                 f"'{data_asset.name}' is missing required argument 'abs_container'"
             )
 
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
+        data_asset._data_connector = self.data_connector_type.build_data_connector(  # noqa: SLF001
             datasource_name=self.name,
             data_asset_name=data_asset.name,
             azure_client=self._get_azure_client(),
@@ -169,7 +169,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -212,7 +212,7 @@ class DataFrameAsset(DataAsset, Generic[_SparkDataFrameT]):
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options={},
-                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]
+                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]  # noqa: SLF001
             )
             raise gx_exceptions.InvalidBatchRequestError(
                 "BatchRequest should have form:\n"

--- a/great_expectations/datasource/fluent/spark_dbfs_datasource.py
+++ b/great_expectations/datasource/fluent/spark_dbfs_datasource.py
@@ -42,18 +42,20 @@ class SparkDBFSDatasource(SparkFilesystemDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            batching_regex=data_asset.batching_regex,
-            base_directory=self.base_directory,
-            glob_directive=glob_directive,
-            data_context_root_directory=self.data_context_root_directory,
-            file_path_template_map_fn=DBFSPath.convert_to_protocol_version,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                batching_regex=data_asset.batching_regex,
+                base_directory=self.base_directory,
+                glob_directive=glob_directive,
+                data_context_root_directory=self.data_context_root_directory,
+                file_path_template_map_fn=DBFSPath.convert_to_protocol_version,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.py
@@ -69,7 +69,7 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
+        data_asset._data_connector = self.data_connector_type.build_data_connector(  # noqa: SLF001
             datasource_name=self.name,
             data_asset_name=data_asset.name,
             batching_regex=data_asset.batching_regex,
@@ -80,7 +80,7 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -140,21 +140,23 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
             raise TypeError(
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            gcs_client=self._get_gcs_client(),
-            batching_regex=data_asset.batching_regex,
-            bucket_or_name=self.bucket_or_name,
-            prefix=gcs_prefix,
-            delimiter=gcs_delimiter,
-            max_results=gcs_max_results,
-            recursive_file_discovery=gcs_recursive_file_discovery,
-            file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                gcs_client=self._get_gcs_client(),
+                batching_regex=data_asset.batching_regex,
+                bucket_or_name=self.bucket_or_name,
+                prefix=gcs_prefix,
+                delimiter=gcs_delimiter,
+                max_results=gcs_max_results,
+                recursive_file_discovery=gcs_recursive_file_discovery,
+                file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/spark_s3_datasource.py
+++ b/great_expectations/datasource/fluent/spark_s3_datasource.py
@@ -119,21 +119,23 @@ class SparkS3Datasource(_SparkFilePathDatasource):
                 f"_build_data_connector() got unexpected keyword arguments {list(kwargs.keys())}"
             )
 
-        data_asset._data_connector = self.data_connector_type.build_data_connector(
-            datasource_name=self.name,
-            data_asset_name=data_asset.name,
-            s3_client=self._get_s3_client(),
-            batching_regex=data_asset.batching_regex,
-            bucket=self.bucket,
-            prefix=s3_prefix,
-            delimiter=s3_delimiter,
-            max_keys=s3_max_keys,
-            recursive_file_discovery=s3_recursive_file_discovery,
-            file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
+        data_asset._data_connector = (  # noqa: SLF001
+            self.data_connector_type.build_data_connector(
+                datasource_name=self.name,
+                data_asset_name=data_asset.name,
+                s3_client=self._get_s3_client(),
+                batching_regex=data_asset.batching_regex,
+                bucket=self.bucket,
+                prefix=s3_prefix,
+                delimiter=s3_delimiter,
+                max_keys=s3_max_keys,
+                recursive_file_discovery=s3_recursive_file_discovery,
+                file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
+            )
         )
 
         # build a more specific `_test_connection_error_message`
-        data_asset._test_connection_error_message = (
+        data_asset._test_connection_error_message = (  # noqa: SLF001
             self.data_connector_type.build_test_connection_error_message(
                 data_asset_name=data_asset.name,
                 batching_regex=data_asset.batching_regex,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -464,9 +464,9 @@ class _SQLAsset(DataAsset):
         self.test_splitter_connection()
         # persist the config changes
         context: AbstractDataContext | None
-        if context := self._datasource._data_context:
+        if context := self._datasource._data_context:  # noqa: SLF001
             context.datasources[self._datasource.name] = self._datasource
-            context._save_project_config()
+            context._save_project_config()  # noqa: SLF001
         return self
 
     @public_api
@@ -777,7 +777,7 @@ class _SQLAsset(DataAsset):
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options=options,
-                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]
+                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined]  # noqa: SLF001
             )
             raise gx_exceptions.InvalidBatchRequestError(
                 "BatchRequest should have form:\n"
@@ -1117,7 +1117,7 @@ class SQLDatasource(Datasource):
             ) from e
         if self.assets and test_assets:
             for asset in self.assets:
-                asset._datasource = self
+                asset._datasource = self  # noqa: SLF001
                 asset.test_connection()
 
     @public_api

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -452,7 +452,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         if data_context is not None and getattr(
             data_context, "_usage_statistics_handler", None
         ):
-            handler = data_context._usage_statistics_handler
+            handler = data_context._usage_statistics_handler  # noqa: SLF001
             handler.send_usage_message(
                 event=UsageStatsEvents.EXECUTION_ENGINE_SQLALCHEMY_CONNECT,
                 event_payload={
@@ -686,7 +686,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                 selectable = sa.Table(
                     domain_kwargs["table"],
                     sa.MetaData(),
-                    schema=data_object._schema_name,
+                    schema=data_object._schema_name,  # noqa: SLF001
                 )
             else:
                 selectable = data_object.selectable

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -278,7 +278,7 @@ class MetaExpectation(ModelMetaclass):
             newclass.expectation_type = ""
 
         # noinspection PyUnresolvedReferences
-        newclass._register_renderer_functions()
+        newclass._register_renderer_functions()  # noqa: SLF001
         return newclass
 
 
@@ -1369,7 +1369,9 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
 
         backend_test_result_counts: List[
             ExpectationBackendTestResultCounts
-        ] = ExpectationDiagnostics._get_backends_from_test_results(test_results)
+        ] = ExpectationDiagnostics._get_backends_from_test_results(  # noqa: SLF001
+            test_results
+        )
 
         renderers: List[
             ExpectationRendererDiagnostics
@@ -1865,7 +1867,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 # The ExpectationTestDiagnostics instance will error when calling it's to_dict()
                 # method (AttributeError: 'ExpectationConfiguration' object has no attribute 'raw_kwargs')
                 validation_result.expectation_config.raw_kwargs = (
-                    validation_result.expectation_config._raw_kwargs
+                    validation_result.expectation_config._raw_kwargs  # noqa: SLF001
                 )
 
             test_results.append(
@@ -2155,32 +2157,44 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         production_checks = []
 
         experimental_checks.append(
-            ExpectationDiagnostics._check_library_metadata(library_metadata)
-        )
-        experimental_checks.append(ExpectationDiagnostics._check_docstring(description))
-        experimental_checks.append(
-            ExpectationDiagnostics._check_example_cases(examples, tests)
+            ExpectationDiagnostics._check_library_metadata(  # noqa: SLF001
+                library_metadata
+            )
         )
         experimental_checks.append(
-            ExpectationDiagnostics._check_core_logic_for_at_least_one_execution_engine(
+            ExpectationDiagnostics._check_docstring(description)  # noqa: SLF001
+        )
+        experimental_checks.append(
+            ExpectationDiagnostics._check_example_cases(examples, tests)  # noqa: SLF001
+        )
+        experimental_checks.append(
+            ExpectationDiagnostics._check_core_logic_for_at_least_one_execution_engine(  # noqa: SLF001
                 backend_test_result_counts
             )
         )
         beta_checks.append(
-            ExpectationDiagnostics._check_input_validation(self, examples)
+            ExpectationDiagnostics._check_input_validation(  # noqa: SLF001
+                self, examples
+            )
         )
-        beta_checks.append(ExpectationDiagnostics._check_renderer_methods(self))
         beta_checks.append(
-            ExpectationDiagnostics._check_core_logic_for_all_applicable_execution_engines(
+            ExpectationDiagnostics._check_renderer_methods(self)  # noqa: SLF001
+        )
+        beta_checks.append(
+            ExpectationDiagnostics._check_core_logic_for_all_applicable_execution_engines(  # noqa: SLF001
                 backend_test_result_counts
             )
         )
 
         production_checks.append(
-            ExpectationDiagnostics._check_full_test_suite(library_metadata)
+            ExpectationDiagnostics._check_full_test_suite(  # noqa: SLF001
+                library_metadata
+            )
         )
         production_checks.append(
-            ExpectationDiagnostics._check_manual_code_review(library_metadata)
+            ExpectationDiagnostics._check_manual_code_review(  # noqa: SLF001
+                library_metadata
+            )
         )
 
         return ExpectationDiagnosticMaturityMessages(

--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -203,9 +203,9 @@ class ExpectationConfiguration(SerializableDictDot):
     def get_raw_configuration(self) -> ExpectationConfiguration:
         # return configuration without substituted evaluation parameters
         raw_config = deepcopy(self)
-        if raw_config._raw_kwargs is not None:
-            raw_config._kwargs = raw_config._raw_kwargs
-            raw_config._raw_kwargs = None
+        if raw_config._raw_kwargs is not None:  # noqa: SLF001
+            raw_config._kwargs = raw_config._raw_kwargs  # noqa: SLF001
+            raw_config._raw_kwargs = None  # noqa: SLF001
 
         return raw_config
 

--- a/great_expectations/expectations/metrics/meta_metric_provider.py
+++ b/great_expectations/expectations/metrics/meta_metric_provider.py
@@ -10,7 +10,7 @@ class MetaMetricProvider(type):
     def __new__(cls, clsname, bases, attrs):
         newclass = super().__new__(cls, clsname, bases, attrs)
         # noinspection PyUnresolvedReferences
-        newclass._register_metric_functions()
+        newclass._register_metric_functions()  # noqa: SLF001
         return newclass
 
 

--- a/great_expectations/expectations/metrics/multicolumn_map_metrics/compound_columns_unique.py
+++ b/great_expectations/expectations/metrics/multicolumn_map_metrics/compound_columns_unique.py
@@ -152,7 +152,7 @@ class CompoundColumnsUnique(MulticolumnMapMetricProvider):
         compound_columns_count_query = (
             sa.select(
                 original_table_clause,
-                group_count_query.c._num_rows.label("_num_rows"),
+                group_count_query.c._num_rows.label("_num_rows"),  # noqa: SLF001
             )
             .select_from(
                 original_table_clause.join(
@@ -185,7 +185,9 @@ class CompoundColumnsUnique(MulticolumnMapMetricProvider):
         ]
 
         # noinspection PyProtectedMember
-        row_wise_cond = compound_columns_count_query.c._num_rows < 2  # noqa: PLR2004
+        row_wise_cond = (
+            compound_columns_count_query.c._num_rows < 2  # noqa: SLF001, PLR2004
+        )
 
         return row_wise_cond
 

--- a/great_expectations/expectations/metrics/query_metrics/query_template_values.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_template_values.py
@@ -94,7 +94,7 @@ class QueryTemplateValues(QueryMetricProvider):
         except Exception as e:
             if hasattr(e, "_query_id"):
                 # query_id removed because it duplicates the validation_results
-                e._query_id = None
+                e._query_id = None  # noqa: SLF001
             raise e
 
         return [element._asdict() for element in result]

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -678,7 +678,7 @@ def column_reflection_fallback(  # noqa: PLR0915
 
             result_object = connection.execute(query)
             # noinspection PyProtectedMember
-            col_names: List[str] = result_object._metadata.keys
+            col_names: List[str] = result_object._metadata.keys  # noqa: SLF001
             col_info_dict_list = [{"name": col_name} for col_name in col_names]
         return col_info_dict_list
 

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -66,7 +66,7 @@ def register_renderer(
     renderer_fn: Callable[..., Union[RenderedAtomicContent, RenderedContent]],
 ):
     # noinspection PyUnresolvedReferences
-    renderer_name = renderer_fn._renderer_type  # type: ignore[attr-defined]
+    renderer_name = renderer_fn._renderer_type  # type: ignore[attr-defined]  # noqa: SLF001
     if object_name not in _registered_renderers:
         logger.debug(f"Registering {renderer_name} for expectation_type {object_name}.")
         _registered_renderers[object_name] = {
@@ -368,7 +368,7 @@ def get_metric_kwargs(
         }
         if configuration:
             expectation_impl = get_expectation_impl(configuration.expectation_type)
-            configuration_kwargs = expectation_impl(
+            configuration_kwargs = expectation_impl(  # noqa: SLF001
                 **configuration.kwargs
             )._get_runtime_kwargs(runtime_configuration=runtime_configuration)
             if len(metric_kwargs["metric_domain_keys"]) > 0:

--- a/great_expectations/experimental/datasource/fabric.py
+++ b/great_expectations/experimental/datasource/fabric.py
@@ -89,7 +89,7 @@ class _PowerBIAsset(DataAsset):
                 exclude_none=True,
                 exclude_unset=True,
                 by_alias=True,
-                config_provider=self._datasource._config_provider,
+                config_provider=self._datasource._config_provider,  # noqa: SLF001
             ),
         }
 
@@ -165,7 +165,7 @@ class _PowerBIAsset(DataAsset):
                 datasource_name=self.datasource.name,
                 data_asset_name=self.name,
                 options={},
-                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined] # private attr does exist
+                batch_slice=batch_request._batch_slice_input,  # type: ignore[attr-defined] # private attr does exist  # noqa: SLF001
             )
             raise gx_exceptions.InvalidBatchRequestError(
                 "BatchRequest should have form:\n"
@@ -283,7 +283,7 @@ class FabricPowerBIDatasource(Datasource):
 
         if self.assets and test_assets:
             for asset in self.assets:
-                asset._datasource = self
+                asset._datasource = self  # noqa: SLF001
                 asset.test_connection()
 
     @public_api

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -238,9 +238,9 @@ class UserConfigurableProfiler:
             # Only `Validator`` has `get_expectation_suite()`
             # noinspection PyProtectedMember
             suite_name: str = (
-                self.profile_dataset._expectation_suite.expectation_suite_name  # type: ignore[union-attr]
+                self.profile_dataset._expectation_suite.expectation_suite_name  # type: ignore[union-attr]  # noqa: SLF001
             )
-            self.profile_dataset._expectation_suite = ExpectationSuite(  # type: ignore[union-attr]
+            self.profile_dataset._expectation_suite = ExpectationSuite(  # type: ignore[union-attr]  # noqa: SLF001
                 expectation_suite_name=suite_name, data_context=None
             )
 
@@ -290,7 +290,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
             and len(self.value_set_threshold) > 0,
         }
         send_usage_message(
-            data_context=self.profile_dataset._data_context,
+            data_context=self.profile_dataset._data_context,  # noqa: SLF001
             event=UsageStatsEvents.LEGACY_PROFILER_BUILD_SUITE,
             event_payload=event_payload,
             api_version="v2",
@@ -581,7 +581,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 + sorted(list(ProfilerTypeMapping.FLOAT_TYPE_NAMES)),
             )
 
-        profile_dataset._expectation_suite.remove_expectation(
+        profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
             ExpectationConfiguration(
                 expectation_type="expect_column_values_to_be_in_type_list",
                 kwargs={"column": column},
@@ -611,13 +611,13 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
             )
             column_info_entry["cardinality"] = column_cardinality
             # remove the expectations
-            profile_dataset._expectation_suite.remove_expectation(
+            profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                 ExpectationConfiguration(
                     expectation_type="expect_column_unique_value_count_to_be_between",
                     kwargs={"column": column_name},
                 )
             )
-            profile_dataset._expectation_suite.remove_expectation(
+            profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                 ExpectationConfiguration(
                     expectation_type="expect_column_proportion_of_unique_values_to_be_between",
                     kwargs={"column": column_name},
@@ -817,7 +817,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 column, value_set=None, result_format="SUMMARY"
             ).result["observed_value"]
 
-            profile_dataset._expectation_suite.remove_expectation(
+            profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                 ExpectationConfiguration(
                     expectation_type="expect_column_distinct_values_to_be_in_set",
                     kwargs={"column": column},
@@ -857,7 +857,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 )
 
             else:
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_min_to_be_between",
                         kwargs={"column": column},
@@ -881,7 +881,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 )
 
             else:
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_max_to_be_between",
                         kwargs={"column": column},
@@ -905,7 +905,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 )
 
             else:
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_mean_to_be_between",
                         kwargs={"column": column},
@@ -929,7 +929,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 )
 
             else:
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_median_to_be_between",
                         kwargs={"column": column},
@@ -988,7 +988,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 quantile_result.exception_info["exception_traceback"]
                 or quantile_result.exception_info["exception_message"]
             ):
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_quantile_values_to_be_between",
                         kwargs={"column": column},
@@ -1089,7 +1089,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 except TypeError:
                     pass
 
-            profile_dataset._expectation_suite.remove_expectation(
+            profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                 ExpectationConfiguration(
                     expectation_type="expect_column_min_to_be_between",
                     kwargs={"column": column},
@@ -1110,7 +1110,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 except TypeError:
                     pass
 
-            profile_dataset._expectation_suite.remove_expectation(
+            profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                 ExpectationConfiguration(
                     expectation_type="expect_column_max_to_be_between",
                     kwargs={"column": column},
@@ -1151,7 +1151,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                     # A safe_mostly_value of 0.001 gives us a rough way of ensuring that we don't wind up with a mostly
                     # value of 0 when we round
                     safe_mostly_value = max(0.001, potential_mostly_value)
-                    profile_dataset._expectation_suite.remove_expectation(
+                    profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                         ExpectationConfiguration(
                             expectation_type="expect_column_values_to_not_be_null",
                             kwargs={"column": column},
@@ -1192,7 +1192,7 @@ type detected is "{type(self.profile_dataset)!s}", which is illegal.
                 )
             else:
                 # noinspection PyProtectedMember
-                profile_dataset._expectation_suite.remove_expectation(
+                profile_dataset._expectation_suite.remove_expectation(  # noqa: SLF001
                     ExpectationConfiguration(
                         expectation_type="expect_column_proportion_of_unique_values_to_be_between",
                         kwargs={"column": column},

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -244,7 +244,9 @@ class ValidationResultsPageRenderer(Renderer):
         collapse_content_blocks: List[RenderedTableContent],
         columns: Dict[str, list],
     ) -> List[RenderedSectionContent]:
-        ordered_columns = Renderer._get_column_list_from_evrs(validation_results)
+        ordered_columns = Renderer._get_column_list_from_evrs(  # noqa: SLF001
+            validation_results
+        )
         sections = [
             RenderedSectionContent(
                 **{
@@ -968,9 +970,13 @@ class ProfilingResultsPageRenderer(Renderer):
         # TODO: When we implement a ValidationResultSuite class, this method will move there.
         columns = self._group_evrs_by_column(validation_results)
 
-        ordered_columns = Renderer._get_column_list_from_evrs(validation_results)
-        column_types = self._overview_section_renderer._get_column_types(
+        ordered_columns = Renderer._get_column_list_from_evrs(  # noqa: SLF001
             validation_results
+        )
+        column_types = (
+            self._overview_section_renderer._get_column_types(  # noqa: SLF001
+                validation_results
+            )
         )
 
         data_asset_name = batch_kwargs.get("data_asset_name")

--- a/great_expectations/render/renderer/renderer.py
+++ b/great_expectations/render/renderer/renderer.py
@@ -23,8 +23,8 @@ def renderer(
         def inner_func(*args: P.args, **kwargs: P.kwargs):
             return renderer_fn(*args, **kwargs)
 
-        inner_func._renderer_type = renderer_type  # type: ignore[attr-defined]
-        inner_func._renderer_definition_kwargs = kwargs  # type: ignore[attr-defined]
+        inner_func._renderer_type = renderer_type  # type: ignore[attr-defined]  # noqa: SLF001
+        inner_func._renderer_definition_kwargs = kwargs  # type: ignore[attr-defined]  # noqa: SLF001
         return inner_func
 
     return wrapper

--- a/great_expectations/rule_based_profiler/data_assistant/column_value_missing_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/column_value_missing_data_assistant.py
@@ -92,7 +92,7 @@ class ColumnValueMissingDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return ColumnValueMissingDataAssistantResult(
-            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,
+            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,  # noqa: SLF001
             profiler_config=data_assistant_result.profiler_config,
             profiler_execution_time=data_assistant_result.profiler_execution_time,
             rule_domain_builder_execution_time=data_assistant_result.rule_domain_builder_execution_time,
@@ -101,7 +101,7 @@ class ColumnValueMissingDataAssistant(DataAssistant):
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
-            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,  # noqa: SLF001
         )
 
     def _build_column_value_missing_rule(self) -> Rule:

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -92,7 +92,9 @@ class MetaDataAssistant(ABCMeta):
                 )
 
                 # noinspection PyTypeChecker
-                DataAssistantDispatcher._register(name=alias, data_assistant=newclass)
+                DataAssistantDispatcher._register(  # noqa: SLF001
+                    name=alias, data_assistant=newclass
+                )
 
         return newclass
 
@@ -566,7 +568,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
         if self._data_context is None:
             usage_statistics_handler = None
         else:
-            usage_statistics_handler = self._data_context._usage_statistics_handler
+            usage_statistics_handler = (
+                self._data_context._usage_statistics_handler  # noqa: SLF001
+            )
 
         batches: Dict[str, Union[Batch, FluentBatch]] = self._batches or {}
 

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -119,4 +119,6 @@ def get_registered_data_assistant_names() -> Set[str]:
     """
     This method returns names (registered data_assistant_type and alias name) of registered "DataAssistant" classes.
     """
-    return set(DataAssistantDispatcher._registered_data_assistants.keys())
+    return set(
+        DataAssistantDispatcher._registered_data_assistants.keys()  # noqa: SLF001
+    )

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -79,7 +79,7 @@ class VolumeDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return VolumeDataAssistantResult(
-            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,
+            _batch_id_to_batch_identifier_display_name_map=data_assistant_result._batch_id_to_batch_identifier_display_name_map,  # noqa: SLF001
             profiler_config=data_assistant_result.profiler_config,
             profiler_execution_time=data_assistant_result.profiler_execution_time,
             rule_domain_builder_execution_time=data_assistant_result.rule_domain_builder_execution_time,
@@ -88,7 +88,7 @@ class VolumeDataAssistant(DataAssistant):
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
-            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,  # noqa: SLF001
         )
 
     @staticmethod

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -265,12 +265,12 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         (
             best_regex_string,
             best_ratio,
-        ) = ParameterBuilder._get_best_candidate_above_threshold(
+        ) = ParameterBuilder._get_best_candidate_above_threshold(  # noqa: SLF001
             regex_string_success_ratios, threshold
         )
         # dict of sorted regex and ratios for all evaluated candidates
         sorted_regex_candidates_and_ratios: dict = (
-            ParameterBuilder._get_sorted_candidates_and_ratios(
+            ParameterBuilder._get_sorted_candidates_and_ratios(  # noqa: SLF001
                 regex_string_success_ratios
             )
         )

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -306,12 +306,12 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         (
             best_format_string,
             best_ratio,
-        ) = ParameterBuilder._get_best_candidate_above_threshold(
+        ) = ParameterBuilder._get_best_candidate_above_threshold(  # noqa: SLF001
             format_string_success_ratios, threshold
         )
         # dict of sorted datetime and ratios for all evaluated candidates
         sorted_format_strings_and_ratios: dict = (
-            ParameterBuilder._get_sorted_candidates_and_ratios(
+            ParameterBuilder._get_sorted_candidates_and_ratios(  # noqa: SLF001
                 format_string_success_ratios
             )
         )

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -200,9 +200,11 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         # Instantiate variables and builder attributes
         variables: Dict[str, Any] = rule_config.get("variables", {})
-        domain_builder: DomainBuilder = RuleBasedProfiler._init_rule_domain_builder(
-            domain_builder_config=rule_config.get("domain_builder"),
-            data_context=self._data_context,
+        domain_builder: DomainBuilder = (
+            RuleBasedProfiler._init_rule_domain_builder(  # noqa: SLF001
+                domain_builder_config=rule_config.get("domain_builder"),
+                data_context=self._data_context,
+            )
         )
         parameter_builders: Optional[
             List[ParameterBuilder]
@@ -594,7 +596,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         rule_config: dict
 
         override_rule_configs: Dict[str, Dict[str, Any]] = {
-            rule_name: RuleBasedProfiler._reconcile_rule_config(
+            rule_name: RuleBasedProfiler._reconcile_rule_config(  # noqa: SLF001
                 existing_rules=effective_rules,
                 rule_name=rule_name,
                 rule_config=rule_config,
@@ -772,7 +774,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         current_parameter_builders: Dict[
             str, ParameterBuilder
-        ] = rule._get_parameter_builders_as_dict()
+        ] = rule._get_parameter_builders_as_dict()  # noqa: SLF001
 
         parameter_builder_name: str
         parameter_builder: ParameterBuilder
@@ -854,7 +856,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         current_expectation_configuration_builders: Dict[
             str, ExpectationConfigurationBuilder
-        ] = rule._get_expectation_configuration_builders_as_dict()
+        ] = rule._get_expectation_configuration_builders_as_dict()  # noqa: SLF001
 
         expectation_configuration_builder_name: str
         expectation_configuration_builder: ExpectationConfigurationBuilder
@@ -1238,7 +1240,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: dict | None = None,
         profiler: RuleBasedProfiler | None = None,
     ) -> RuleBasedProfiler:
-        config = RuleBasedProfiler._resolve_profiler_config_for_store(
+        config = RuleBasedProfiler._resolve_profiler_config_for_store(  # noqa: SLF001
             name=name,
             id=id,
             config_version=config_version,
@@ -1247,7 +1249,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
             profiler=profiler,
         )
 
-        if not RuleBasedProfiler._check_validity_of_batch_requests_in_config(
+        if not RuleBasedProfiler._check_validity_of_batch_requests_in_config(  # noqa: SLF001
             config=config
         ):
             raise gx_exceptions.InvalidConfigError(

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -285,22 +285,22 @@ except (ImportError, KeyError):
 
 TRINO_TYPES: Dict[str, Any] = (
     {
-        "BOOLEAN": trino.trinotypes._type_map["boolean"],
-        "TINYINT": trino.trinotypes._type_map["tinyint"],
-        "SMALLINT": trino.trinotypes._type_map["smallint"],
-        "INT": trino.trinotypes._type_map["int"],
-        "INTEGER": trino.trinotypes._type_map["integer"],
-        "BIGINT": trino.trinotypes._type_map["bigint"],
-        "REAL": trino.trinotypes._type_map["real"],
-        "DOUBLE": trino.trinotypes._type_map["double"],
-        "DECIMAL": trino.trinotypes._type_map["decimal"],
-        "VARCHAR": trino.trinotypes._type_map["varchar"],
-        "CHAR": trino.trinotypes._type_map["char"],
-        "VARBINARY": trino.trinotypes._type_map["varbinary"],
-        "JSON": trino.trinotypes._type_map["json"],
-        "DATE": trino.trinotypes._type_map["date"],
-        "TIME": trino.trinotypes._type_map["time"],
-        "TIMESTAMP": trino.trinotypes._type_map["timestamp"],
+        "BOOLEAN": trino.trinotypes._type_map["boolean"],  # noqa: SLF001
+        "TINYINT": trino.trinotypes._type_map["tinyint"],  # noqa: SLF001
+        "SMALLINT": trino.trinotypes._type_map["smallint"],  # noqa: SLF001
+        "INT": trino.trinotypes._type_map["int"],  # noqa: SLF001
+        "INTEGER": trino.trinotypes._type_map["integer"],  # noqa: SLF001
+        "BIGINT": trino.trinotypes._type_map["bigint"],  # noqa: SLF001
+        "REAL": trino.trinotypes._type_map["real"],  # noqa: SLF001
+        "DOUBLE": trino.trinotypes._type_map["double"],  # noqa: SLF001
+        "DECIMAL": trino.trinotypes._type_map["decimal"],  # noqa: SLF001
+        "VARCHAR": trino.trinotypes._type_map["varchar"],  # noqa: SLF001
+        "CHAR": trino.trinotypes._type_map["char"],  # noqa: SLF001
+        "VARBINARY": trino.trinotypes._type_map["varbinary"],  # noqa: SLF001
+        "JSON": trino.trinotypes._type_map["json"],  # noqa: SLF001
+        "DATE": trino.trinotypes._type_map["date"],  # noqa: SLF001
+        "TIME": trino.trinotypes._type_map["time"],  # noqa: SLF001
+        "TIMESTAMP": trino.trinotypes._type_map["timestamp"],  # noqa: SLF001
     }
     if trino.trinotypes
     else {}
@@ -1126,7 +1126,9 @@ def build_sa_validator_with_data(  # noqa: C901, PLR0912, PLR0913, PLR0915
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    context.datasources["my_test_datasource"]._execution_engine = execution_engine
+    context.datasources[  # noqa: SLF001
+        "my_test_datasource"
+    ]._execution_engine = execution_engine
     my_data_connector: ConfiguredAssetSqlDataConnector = (
         ConfiguredAssetSqlDataConnector(
             name="my_sql_data_connector",
@@ -2269,10 +2271,12 @@ def evaluate_json_test_v3_api(  # noqa: PLR0912, PLR0913
         _debug = lambda x: x  # noqa: E731
 
     expectation_suite = ExpectationSuite(
-        "json_test_suite", data_context=validator._data_context
+        "json_test_suite", data_context=validator._data_context  # noqa: SLF001
     )
     # noinspection PyProtectedMember
-    validator._initialize_expectations(expectation_suite=expectation_suite)
+    validator._initialize_expectations(  # noqa: SLF001
+        expectation_suite=expectation_suite
+    )
     # validator.set_default_expectation_argument("result_format", "COMPLETE")
 
     if "title" not in test:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1168,7 +1168,9 @@ def get_clickhouse_sqlalchemy_potential_type(type_module, type_) -> Any:
         elif type_.lower() in ("fixedstring"):
             ch_type = type_module.types.String
         else:
-            ch_type = type_module.ClickHouseDialect()._get_column_type("", ch_type)
+            ch_type = type_module.ClickHouseDialect()._get_column_type(  # noqa: SLF001
+                "", ch_type
+            )
 
     if hasattr(ch_type, "nested_type"):
         ch_type = type(ch_type.nested_type)
@@ -1180,12 +1182,14 @@ def get_clickhouse_sqlalchemy_potential_type(type_module, type_) -> Any:
 def get_pyathena_potential_type(type_module, type_) -> str:
     if version.parse(type_module.pyathena.__version__) >= version.parse("2.5.0"):
         # introduction of new column type mapping in 2.5
-        potential_type = type_module.AthenaDialect()._get_column_type(type_)
+        potential_type = type_module.AthenaDialect()._get_column_type(  # noqa: SLF001
+            type_
+        )
     else:
         if type_ == "string":
             type_ = "varchar"
         # < 2.5 column type mapping
-        potential_type = type_module._TYPE_MAPPINGS.get(type_)
+        potential_type = type_module._TYPE_MAPPINGS.get(type_)  # noqa: SLF001
 
     return potential_type
 

--- a/great_expectations/validation_operators/types/validation_operator_result.py
+++ b/great_expectations/validation_operators/types/validation_operator_result.py
@@ -285,7 +285,9 @@ class ValidationOperatorResultSchema(Schema):
     @pre_dump
     def prepare_dump(self, data, **kwargs):
         data = deepcopy(data)
-        data._run_results = convert_to_json_serializable(data.run_results)
+        data._run_results = convert_to_json_serializable(  # noqa: SLF001
+            data.run_results
+        )
         return data
 
     # noinspection PyUnusedLocal

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -307,7 +307,7 @@ class ActionListValidationOperator(ValidationOperator):
                 and isinstance(item[1], str)
             ):
                 raise ValueError("Unable to build batch from item.")
-            batch = self.data_context._get_batch_v2(
+            batch = self.data_context._get_batch_v2(  # noqa: SLF001
                 batch_kwargs=item[0], expectation_suite_name=item[1]
             )
         else:
@@ -391,14 +391,14 @@ class ActionListValidationOperator(ValidationOperator):
                 if self._using_cloud_context:
                     expectation_suite_identifier = GXCloudIdentifier(
                         resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
-                        id=batch._expectation_suite.ge_cloud_id,
+                        id=batch._expectation_suite.ge_cloud_id,  # noqa: SLF001
                     )
                     validation_result_id = GXCloudIdentifier(
                         resource_type=GXCloudRESTResource.VALIDATION_RESULT
                     )
                 else:
                     expectation_suite_identifier = ExpectationSuiteIdentifier(
-                        expectation_suite_name=batch._expectation_suite.expectation_suite_name
+                        expectation_suite_name=batch._expectation_suite.expectation_suite_name  # noqa: SLF001
                     )
                     validation_result_id = ValidationResultIdentifier(
                         batch_identifier=batch_identifier,
@@ -415,7 +415,7 @@ class ActionListValidationOperator(ValidationOperator):
                 batch_actions_results = self._run_actions(
                     batch=batch,
                     expectation_suite_identifier=expectation_suite_identifier,
-                    expectation_suite=batch._expectation_suite,
+                    expectation_suite=batch._expectation_suite,  # noqa: SLF001
                     batch_validation_result=validation_result,
                     run_id=run_id,
                     validation_result_id=validation_result_id,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -554,7 +554,7 @@ class Validator:
                     stored_config = configuration.get_raw_configuration()
                 else:
                     # Append the expectation to the config.
-                    stored_config = self._expectation_suite._add_expectation(
+                    stored_config = self._expectation_suite._add_expectation(  # noqa: SLF001
                         expectation_configuration=configuration.get_raw_configuration(),
                         send_usage_event=False,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,8 @@ select = [
     "DTZ", # flake8-datetimez-dtz - prevent use of tz naive datetimes
     # https://beta.ruff.rs/docs/rules/#pylint-pl
     "PL", # pylint
+    # https://docs.astral.sh/ruff/rules/private-member-access/
+    "SLF",
     # https://beta.ruff.rs/docs/rules/#ruff-specific-rules-ruf
     "RUF", # custom ruff rules
 ]

--- a/scripts/gen_stub.py
+++ b/scripts/gen_stub.py
@@ -74,7 +74,7 @@ def print_add_asset_method_signatures(
     Prints out all of the asset methods for a given datasource in a format that be used
     for defining methods in stub files.
     """
-    type_lookup: TypeLookup = datasource_class._type_lookup
+    type_lookup: TypeLookup = datasource_class._type_lookup  # noqa: SLF001
 
     for asset_type_name in type_lookup.type_names():
         asset_type = type_lookup[asset_type_name]

--- a/tests/actions/test_validation_operators.py
+++ b/tests/actions/test_validation_operators.py
@@ -76,7 +76,7 @@ def warning_failure_validation_operator_data_context(
     )
 
     data_context.add_expectation_suite(expectation_suite_name="f1.failure")
-    df = data_context._get_batch_v2(
+    df = data_context._get_batch_v2(  # noqa: SLF001
         expectation_suite_name="f1.failure",
         batch_kwargs=data_context.build_batch_kwargs(
             "my_datasource", "subdir_reader", "f1"
@@ -89,7 +89,7 @@ def warning_failure_validation_operator_data_context(
     data_context.update_expectation_suite(expectation_suite=failure_expectations)
 
     data_context.add_expectation_suite(expectation_suite_name="f1.warning")
-    df = data_context._get_batch_v2(
+    df = data_context._get_batch_v2(  # noqa: SLF001
         expectation_suite_name="f1.warning",
         batch_kwargs=data_context.build_batch_kwargs(
             "my_datasource", "subdir_reader", "f1"
@@ -142,7 +142,7 @@ def test_errors_warnings_validation_operator_run_slack_query(
         run_id=RunIdentifier(run_name="test_100"),
         base_expectation_suite_name="f1",
     )
-    slack_query = vo._build_slack_query(return_obj)
+    slack_query = vo._build_slack_query(return_obj)  # noqa: SLF001
     expected_slack_query = {
         "blocks": [
             {"type": "divider"},

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -42,7 +42,7 @@ def validation_operators_data_context(
     )
     data_context.add_expectation_suite("f1.foo")
 
-    df = data_context._get_batch_v2(
+    df = data_context._get_batch_v2(  # noqa: SLF001
         batch_kwargs=data_context.build_batch_kwargs(
             "my_datasource", "subdir_reader", "f1"
         ),
@@ -162,7 +162,7 @@ def test_action_list_operator(validation_operators_data_context):
         "my_datasource", "subdir_reader", "f1"
     )
 
-    batch = data_context._get_batch_v2(
+    batch = data_context._get_batch_v2(  # noqa: SLF001
         expectation_suite_name="f1.failure", batch_kwargs=validator_batch_kwargs
     )
 
@@ -266,7 +266,7 @@ def test_warning_and_failure_validation_operator(validation_operators_data_conte
         "my_datasource", "subdir_reader", "f1"
     )
 
-    batch = data_context._get_batch_v2(
+    batch = data_context._get_batch_v2(  # noqa: SLF001
         expectation_suite_name="f1.warning", batch_kwargs=validator_batch_kwargs
     )
 

--- a/tests/checkpoint/conftest.py
+++ b/tests/checkpoint/conftest.py
@@ -108,7 +108,7 @@ def titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_exp
     suite.add(expectation=expectation)
     context.update_expectation_suite(expectation_suite=suite)
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     return context
 
 
@@ -145,7 +145,7 @@ def titanic_data_context_with_fluent_pandas_datasources_stats_enabled_and_expect
     suite.add_expectation(expectation, send_usage_event=False)
     context.update_expectation_suite(expectation_suite=suite)
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     return context
 
@@ -176,7 +176,7 @@ def titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_
     suite.add_expectation(expectation, send_usage_event=False)
     context.update_expectation_suite(expectation_suite=suite)
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     return context
 
@@ -312,7 +312,7 @@ def titanic_spark_data_context_with_v013_datasource_with_checkpoints_v1_with_emp
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     return context
 
@@ -389,7 +389,7 @@ def context_with_single_taxi_csv_spark(
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     return context
 
@@ -408,5 +408,5 @@ def context_with_single_csv_spark_and_suite(
     suite.add_expectation(expectation, send_usage_event=False)
     context.update_expectation_suite(expectation_suite=suite)
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     return context

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -139,9 +139,9 @@ def test_basic_checkpoint_config_validation(  # noqa: PLR0915
     assert mock_emit.call_count == 1
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call]
+    expected_events: List[unittest.mock._Call]  # noqa: SLF001
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call]
+    actual_events: List[unittest.mock._Call]  # noqa: SLF001
 
     expected_events = [
         mock.call(
@@ -547,7 +547,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
     ]
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call] = [
+    expected_events: List[unittest.mock._Call] = [  # noqa: SLF001
         mock.call(
             {
                 "event": "data_context.test_yaml_config",
@@ -560,7 +560,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
         ),
     ]
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events == expected_events
 
     assert len(data_context.list_checkpoints()) == 0
@@ -795,7 +795,7 @@ def test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_y
     assert mock_emit.call_count == 6
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call] = [
+    expected_events: List[unittest.mock._Call] = [  # noqa: SLF001
         mock.call(
             {
                 "event": "data_context.test_yaml_config",
@@ -907,7 +907,7 @@ def test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_y
         ),
     ]
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events == expected_events
 
     data_context.delete_checkpoint(name="airflow_checkpoint")
@@ -1827,7 +1827,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
     assert mock_emit.call_count == 1
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call] = [
+    expected_events: List[unittest.mock._Call] = [  # noqa: SLF001
         mock.call(
             {
                 "event_payload": {
@@ -1911,7 +1911,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         )
     ]
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events == expected_events
 
     assert len(context.validations_store.list_keys()) == 0
@@ -1931,7 +1931,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
     assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call] = [
+    expected_events: List[unittest.mock._Call] = [  # noqa: SLF001
         mock.call(
             {
                 "event_payload": {
@@ -2163,7 +2163,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         ),
     ]
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events == expected_events
 
     # Since there are two validations, confirming there should be two "data_asset.validate" events

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -345,7 +345,7 @@ def _add_expectations_and_checkpoint(
         ),
     )
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     return context
 
 

--- a/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
@@ -148,7 +148,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
     ]
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[unittest.mock._Call] = [
+    expected_events: List[unittest.mock._Call] = [  # noqa: SLF001
         mock.call(
             {
                 "event": "data_context.test_yaml_config",
@@ -161,7 +161,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
         ),
     ]
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events == expected_events
 
     assert len(data_context.list_checkpoints()) == 0
@@ -1132,7 +1132,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
     assert mock_emit.call_count == 13
 
     # noinspection PyUnresolvedReferences
-    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list  # noqa: SLF001
 
     # Since there are two validations, confirming there should be two "data_asset.validate" events
     num_data_asset_validate_events = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -512,11 +512,11 @@ def preload_latest_gx_cache():
     logger.info(
         f"Seeding _VersionChecker._LATEST_GX_VERSION_CACHE with {current_version}"
     )
-    _VersionChecker._LATEST_GX_VERSION_CACHE = current_version
+    _VersionChecker._LATEST_GX_VERSION_CACHE = current_version  # noqa: SLF001
     yield current_version
     # teardown
     logger.info("Clearing _VersionChecker._LATEST_GX_VERSION_CACHE ")
-    _VersionChecker._LATEST_GX_VERSION_CACHE = None
+    _VersionChecker._LATEST_GX_VERSION_CACHE = None  # noqa: SLF001
 
 
 @pytest.fixture(scope="module")
@@ -1035,7 +1035,7 @@ def data_context_with_connection_to_metrics_db(
         name="my_datasource", yaml_config=datasource_config, pretty_print=False
     )
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1187,7 +1187,7 @@ def titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_em
         name="my_datasource", yaml_config=datasource_config, pretty_print=False
     )
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1600,7 +1600,7 @@ def titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoi
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1683,7 +1683,7 @@ def deterministic_asset_data_connector_context(
         name="my_datasource", yaml_config=datasource_config, pretty_print=False
     )
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1814,7 +1814,7 @@ def titanic_data_context_with_fluent_pandas_datasources_with_checkpoints_v1_with
     _ = asset.build_batch_request(dataframe=df)
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1869,7 +1869,7 @@ def titanic_data_context_with_fluent_pandas_and_spark_datasources_with_checkpoin
     _ = asset.build_batch_request(dataframe=spark_df)
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -1900,7 +1900,7 @@ def titanic_data_context_with_fluent_pandas_and_sqlite_datasources_with_checkpoi
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -2209,7 +2209,7 @@ def titanic_data_context_with_fluent_pandas_datasources_stats_enabled_with_check
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -2264,7 +2264,7 @@ def titanic_data_context_with_fluent_pandas_and_spark_datasources_stats_enabled_
     _ = asset.build_batch_request(dataframe=spark_df)
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -2295,7 +2295,7 @@ def titanic_data_context_with_fluent_pandas_and_sqlite_datasources_stats_enabled
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     project_manager.set_project(context)
     return context
 
@@ -2854,7 +2854,7 @@ def data_context_with_fluent_datasource(
         name="my_pandas_datasource", base_directory=filesystem_csv_2
     )
     # noinspection PyProtectedMember
-    empty_data_context._save_project_config()
+    empty_data_context._save_project_config()  # noqa: SLF001
     return empty_data_context
 
 
@@ -3518,15 +3518,15 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
 
     base_url = env_vars.get(
         GXCloudEnvironmentVariable.BASE_URL,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_BASE_URL),
+        env_vars.get(GXCloudEnvironmentVariable._OLD_BASE_URL),  # noqa: SLF001
     )
     organization_id = env_vars.get(
         GXCloudEnvironmentVariable.ORGANIZATION_ID,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID),
+        env_vars.get(GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID),  # noqa: SLF001
     )
     access_token = env_vars.get(
         GXCloudEnvironmentVariable.ACCESS_TOKEN,
-        env_vars.get(GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN),
+        env_vars.get(GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN),  # noqa: SLF001
     )
     cloud_config = GXCloudConfig(
         base_url=base_url,
@@ -3594,7 +3594,7 @@ def empty_data_context_in_cloud_mode(
             context_root_dir=project_path_name,
         )
 
-    context._datasources = (
+    context._datasources = (  # noqa: SLF001
         {}
     )  # Basic in-memory mock for DatasourceDict to avoid HTTP calls
     return context
@@ -4067,7 +4067,7 @@ def alice_columnar_table_single_batch(empty_data_context):
         # NOTE Will 20211208 add_expectation() method, although being called by an ExpectationSuite instance, is being
         # called within a fixture, and we will prevent it from sending a usage_event by calling the private method
         # _add_expectation().
-        expected_expectation_suite._add_expectation(
+        expected_expectation_suite._add_expectation(  # noqa: SLF001
             expectation_configuration=expectation_configuration, send_usage_event=False
         )
 
@@ -4427,7 +4427,7 @@ def alice_columnar_table_single_batch_context(
     # We need our salt to be consistent between runs to ensure idempotent anonymized values
     # <WILL> 20220630 - this is part of the DataContext Refactor and will be removed
     # (ie. adjusted to be context._usage_statistics_handler)
-    context._usage_statistics_handler = UsageStatisticsHandler(
+    context._usage_statistics_handler = UsageStatisticsHandler(  # noqa: SLF001
         data_context=context,
         data_context_id="00000000-0000-0000-0000-00000000a004",
         usage_statistics_url="N/A",
@@ -5418,7 +5418,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
     for expectation_configuration in expectation_configurations:
         # NOTE Will 20211208 add_expectation() method, although being called by an ExpectationSuite instance, is being
         # called within a fixture, and we will prevent it from sending a usage_event by calling the private method.
-        expected_expectation_suite_quantiles_estimator._add_expectation(
+        expected_expectation_suite_quantiles_estimator._add_expectation(  # noqa: SLF001
             expectation_configuration=expectation_configuration, send_usage_event=False
         )
 
@@ -7401,7 +7401,7 @@ def bobby_columnar_table_multi_batch_deterministic_data_context(
                 "integration",
                 "fixtures",
                 "yellow_tripdata_pandas_fixture",
-                FileDataContext._LEGACY_GX_DIR,
+                FileDataContext._LEGACY_GX_DIR,  # noqa: SLF001
                 FileDataContext.GX_YML,
             ),
         ),
@@ -7482,7 +7482,7 @@ def bobby_columnar_table_multi_batch_probabilistic_data_context(
                 "integration",
                 "fixtures",
                 "yellow_tripdata_pandas_fixture",
-                FileDataContext._LEGACY_GX_DIR,
+                FileDataContext._LEGACY_GX_DIR,  # noqa: SLF001
                 FileDataContext.GX_YML,
             ),
         ),
@@ -7653,7 +7653,7 @@ def bobster_columnar_table_multi_batch_normal_mean_5000_stdev_1000_data_context(
                 "integration",
                 "fixtures",
                 "yellow_tripdata_pandas_fixture",
-                FileDataContext._LEGACY_GX_DIR,
+                FileDataContext._LEGACY_GX_DIR,  # noqa: SLF001
                 FileDataContext.GX_YML,
             ),
         ),
@@ -7841,7 +7841,7 @@ def quentin_columnar_table_multi_batch_data_context(
                 "integration",
                 "fixtures",
                 "yellow_tripdata_pandas_fixture",
-                FileDataContext._LEGACY_GX_DIR,
+                FileDataContext._LEGACY_GX_DIR,  # noqa: SLF001
                 FileDataContext.GX_YML,
             ),
         ),

--- a/tests/core/test_batch_config.py
+++ b/tests/core/test_batch_config.py
@@ -14,7 +14,7 @@ from great_expectations.datasource.fluent.interfaces import DataAsset
 def mock_data_asset(monkeypatch) -> DataAsset:
     monkeypatch.setattr(DataAsset, "build_batch_request", Mock())
     data_asset: DataAsset = DataAsset(name="my_data_asset", type="table")
-    data_asset._save_batch_config = Mock()
+    data_asset._save_batch_config = Mock()  # noqa: SLF001
 
     return data_asset
 
@@ -38,7 +38,9 @@ def test_save(mock_data_asset):
 
     batch_config.save()
 
-    mock_data_asset._save_batch_config.assert_called_once_with(batch_config)
+    mock_data_asset._save_batch_config.assert_called_once_with(  # noqa: SLF001
+        batch_config
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_config_provider.py
+++ b/tests/core/test_config_provider.py
@@ -27,9 +27,9 @@ organization_id = "0dcf5ce1-806f-4199-9e69-e24dfba5e62a"
                 GXCloudEnvironmentVariable.BASE_URL: base_url,
                 GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
                 GXCloudEnvironmentVariable.ORGANIZATION_ID: organization_id,
-                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
-                GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,
+                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,  # noqa: SLF001
+                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,  # noqa: SLF001
+                GXCloudEnvironmentVariable._OLD_ORGANIZATION_ID: organization_id,  # noqa: SLF001
             },
             id="include_org_id",
         ),
@@ -38,8 +38,8 @@ organization_id = "0dcf5ce1-806f-4199-9e69-e24dfba5e62a"
             {
                 GXCloudEnvironmentVariable.BASE_URL: base_url,
                 GXCloudEnvironmentVariable.ACCESS_TOKEN: access_token,
-                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,
-                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,
+                GXCloudEnvironmentVariable._OLD_BASE_URL: base_url,  # noqa: SLF001
+                GXCloudEnvironmentVariable._OLD_ACCESS_TOKEN: access_token,  # noqa: SLF001
             },
             id="omit_org_id",
         ),

--- a/tests/core/test_config_substitutor.py
+++ b/tests/core/test_config_substitutor.py
@@ -185,9 +185,9 @@ class MockedSecretManagerServiceClient:
             pass
 
         response = Response()
-        response._pb = Response()
-        response._pb.payload = Response()
-        response._pb.payload.data = self.secret_response
+        response._pb = Response()  # noqa: SLF001
+        response._pb.payload = Response()  # noqa: SLF001
+        response._pb.payload.data = self.secret_response  # noqa: SLF001
 
         return response
 

--- a/tests/core/test_datasource_dict.py
+++ b/tests/core/test_datasource_dict.py
@@ -139,7 +139,7 @@ def pandas_block_datasource_config(
 def test_datasource_dict_data_property_requests_store_just_in_time(
     empty_datasource_dict: DatasourceDict,
 ):
-    store = empty_datasource_dict._datasource_store
+    store = empty_datasource_dict._datasource_store  # noqa: SLF001
 
     store.list_keys_count = 0
     _ = empty_datasource_dict.data
@@ -150,7 +150,7 @@ def test_datasource_dict_data_property_requests_store_just_in_time(
 def test_datasource_dict___contains___requests_store_just_in_time(
     empty_datasource_dict: DatasourceDict,
 ):
-    store = empty_datasource_dict._datasource_store
+    store = empty_datasource_dict._datasource_store  # noqa: SLF001
 
     store.list_keys_count = 0
     _ = "foo" in empty_datasource_dict.data
@@ -161,7 +161,7 @@ def test_datasource_dict___contains___requests_store_just_in_time(
 def test_datasource_dict___setitem___with_fds(
     empty_datasource_dict: DatasourceDict, pandas_fds: PandasDatasource
 ):
-    store = empty_datasource_dict._datasource_store
+    store = empty_datasource_dict._datasource_store  # noqa: SLF001
     assert store.set_count == 0
 
     empty_datasource_dict[pandas_fds.name] = pandas_fds
@@ -172,7 +172,7 @@ def test_datasource_dict___setitem___with_fds(
 def test_datasource_dict___setitem___with_block_datasource(
     empty_datasource_dict: DatasourceDict, pandas_block_datasource: Datasource
 ):
-    store = empty_datasource_dict._datasource_store
+    store = empty_datasource_dict._datasource_store  # noqa: SLF001
     assert store.set_count == 0
 
     empty_datasource_dict[pandas_block_datasource.name] = pandas_block_datasource
@@ -183,7 +183,7 @@ def test_datasource_dict___setitem___with_block_datasource(
 def test_datasource_dict___delitem__raises_key_error_on_store_miss(
     empty_datasource_dict: DatasourceDict,
 ):
-    store = empty_datasource_dict._datasource_store
+    store = empty_datasource_dict._datasource_store  # noqa: SLF001
     assert store.remove_key_count == 0
 
     with pytest.raises(KeyError):
@@ -210,7 +210,7 @@ def test_datasource_dict___getitem___with_fds(
     datasource_dict = build_datasource_dict_with_store_spy(
         datasource_configs=[pandas_fds]
     )
-    store = datasource_dict._datasource_store
+    store = datasource_dict._datasource_store  # noqa: SLF001
     assert store.get_count == 0
 
     retrieved_fds = datasource_dict[pandas_fds.name]
@@ -225,7 +225,7 @@ def test_datasource_dict___getitem___with_block_datasource(
     datasource_dict = build_datasource_dict_with_store_spy(
         datasource_configs=[pandas_block_datasource_config]
     )
-    store = datasource_dict._datasource_store
+    store = datasource_dict._datasource_store  # noqa: SLF001
     assert store.get_count == 0
 
     retrieved_ds = datasource_dict[pandas_block_datasource_config["name"]]
@@ -283,7 +283,7 @@ def cacheable_datasource_dict_with_fds(
 def test_cacheable_datasource_dict___contains___uses_cache(
     cacheable_datasource_dict_with_fds: CacheableDatasourceDict, pandas_fds_name: str
 ):
-    store = cacheable_datasource_dict_with_fds._datasource_store
+    store = cacheable_datasource_dict_with_fds._datasource_store  # noqa: SLF001
 
     assert store.get_count == 0
     # Lookup will not check store due to presence in cache
@@ -295,7 +295,7 @@ def test_cacheable_datasource_dict___contains___uses_cache(
 def test_cacheable_datasource_dict___contains___requests_store_upon_cache_miss(
     cacheable_datasource_dict_with_fds: CacheableDatasourceDict,
 ):
-    store = cacheable_datasource_dict_with_fds._datasource_store
+    store = cacheable_datasource_dict_with_fds._datasource_store  # noqa: SLF001
 
     assert store.get_count == 0
     assert store.has_key_count == 0
@@ -311,7 +311,7 @@ def test_cacheable_datasource_dict___setitem___with_fds(
     empty_cacheable_datasource_dict: CacheableDatasourceDict,
     pandas_fds: PandasDatasource,
 ):
-    store = empty_cacheable_datasource_dict._datasource_store
+    store = empty_cacheable_datasource_dict._datasource_store  # noqa: SLF001
     assert store.set_count == 0
 
     # FDS are not persisted with stores (only cache)
@@ -323,7 +323,7 @@ def test_cacheable_datasource_dict___setitem___with_fds(
 def test_cacheable_datasource_dict___setitem___with_block_datasource(
     empty_cacheable_datasource_dict: DatasourceDict, pandas_block_datasource: Datasource
 ):
-    store = empty_cacheable_datasource_dict._datasource_store
+    store = empty_cacheable_datasource_dict._datasource_store  # noqa: SLF001
     assert store.set_count == 0
 
     # non-FDS use both store and cache
@@ -341,7 +341,7 @@ def test_cacheable_datasource_dict___delitem__updates_both_cache_and_store(
     datasource_dict = build_cacheable_datasource_dict_with_store_spy(
         datasource_configs=[pandas_block_datasource_config], populate_cache=True
     )
-    store = datasource_dict._datasource_store
+    store = datasource_dict._datasource_store  # noqa: SLF001
     name = pandas_block_datasource_config["name"]
     assert store.remove_key_count == 0
 
@@ -357,7 +357,7 @@ def test_cacheable_datasource_dict___delitem__updates_both_cache_and_store(
 def test_cacheable_datasource_dict___delitem__raises_key_error_on_store_miss(
     empty_cacheable_datasource_dict: CacheableDatasourceDict,
 ):
-    store = empty_cacheable_datasource_dict._datasource_store
+    store = empty_cacheable_datasource_dict._datasource_store  # noqa: SLF001
     assert store.remove_key_count == 0
 
     with pytest.raises(KeyError):
@@ -386,7 +386,7 @@ def test_cacheable_datasource_dict___getitem___with_fds(
         datasource_configs=[pandas_fds],
         populate_cache=False,
     )
-    store = datasource_dict._datasource_store
+    store = datasource_dict._datasource_store  # noqa: SLF001
     assert store.get_count == 0
 
     retrieved_fds = datasource_dict[pandas_fds.name]
@@ -402,7 +402,7 @@ def test_cacheable_datasource_dict___getitem___with_block_datasource(
     datasource_dict = build_cacheable_datasource_dict_with_store_spy(
         datasource_configs=[pandas_block_datasource_config], populate_cache=False
     )
-    store = datasource_dict._datasource_store
+    store = datasource_dict._datasource_store  # noqa: SLF001
     assert store.get_count == 0
 
     retrieved_ds = datasource_dict[pandas_block_datasource_config["name"]]

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -84,7 +84,7 @@ class TestInit:
         default_meta = {"great_expectations_version": ge_version}
 
         assert suite.expectation_suite_name == fake_expectation_suite_name
-        assert suite._data_context is None
+        assert suite._data_context is None  # noqa: SLF001
         assert suite.expectations == []
         assert suite.evaluation_parameters == {}
         assert suite.data_asset_type is None
@@ -124,7 +124,7 @@ class TestInit:
             ge_cloud_id=test_id,
         )
         assert suite.expectation_suite_name == fake_expectation_suite_name
-        assert suite._data_context == dummy_data_context
+        assert suite._data_context == dummy_data_context  # noqa: SLF001
         assert suite.expectation_configurations == [
             expect_column_values_to_be_in_set_col_a_with_meta
         ]

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -49,8 +49,8 @@ def test_anonymizer_no_salt():
 
     test_name = "i_am_a_name"
 
-    anon_name_1 = anonymizer1._anonymize_string(test_name)
-    anon_name_2 = anonymizer2._anonymize_string(test_name)
+    anon_name_1 = anonymizer1._anonymize_string(test_name)  # noqa: SLF001
+    anon_name_2 = anonymizer2._anonymize_string(test_name)  # noqa: SLF001
     assert anon_name_1 != anon_name_2
     assert len(anon_name_1) == 32
     assert len(anon_name_2) == 32
@@ -61,8 +61,8 @@ def test_anonymizer_no_salt():
 
     test_name = "i_am_a_name"
 
-    anon_name_1 = anonymizer1._anonymize_string(test_name)
-    anon_name_2 = anonymizer2._anonymize_string(test_name)
+    anon_name_1 = anonymizer1._anonymize_string(test_name)  # noqa: SLF001
+    anon_name_2 = anonymizer2._anonymize_string(test_name)  # noqa: SLF001
     assert anon_name_1 != anon_name_2
     assert len(anon_name_1) == 32
     assert len(anon_name_2) == 32
@@ -77,8 +77,8 @@ def test_anonymizer_consistent_salt():
 
     test_name = "i_am_a_name"
 
-    anon_name_1 = anonymizer1._anonymize_string(test_name)
-    anon_name_2 = anonymizer2._anonymize_string(test_name)
+    anon_name_1 = anonymizer1._anonymize_string(test_name)  # noqa: SLF001
+    anon_name_2 = anonymizer2._anonymize_string(test_name)  # noqa: SLF001
     assert anon_name_1 == anon_name_2
     assert len(anon_name_1) == 32
     assert len(anon_name_2) == 32
@@ -181,9 +181,11 @@ def test_anonymizer_get_parent_class():
 def test_anonymize_object_info_with_core_ge_object(
     anonymizer_with_consistent_salt: Anonymizer,
 ):
-    anonymized_result: dict = anonymizer_with_consistent_salt._anonymize_object_info(
-        anonymized_info_dict={},
-        object_=ExpectationSuite(expectation_suite_name="my_suite"),
+    anonymized_result: dict = (
+        anonymizer_with_consistent_salt._anonymize_object_info(  # noqa: SLF001
+            anonymized_info_dict={},
+            object_=ExpectationSuite(expectation_suite_name="my_suite"),
+        )
     )
 
     assert anonymized_result == {"parent_class": "ExpectationSuite"}
@@ -193,9 +195,11 @@ def test_anonymize_object_info_with_core_ge_object(
 def test_anonymize_object_info_with_custom_user_defined_object_with_single_parent(
     anonymizer_with_consistent_salt: Anonymizer,
 ):
-    anonymized_result: dict = anonymizer_with_consistent_salt._anonymize_object_info(
-        anonymized_info_dict={},
-        object_=MyCustomExpectationSuite(expectation_suite_name="my_suite"),
+    anonymized_result: dict = (
+        anonymizer_with_consistent_salt._anonymize_object_info(  # noqa: SLF001
+            anonymized_info_dict={},
+            object_=MyCustomExpectationSuite(expectation_suite_name="my_suite"),
+        )
     )
 
     assert anonymized_result == {
@@ -208,8 +212,10 @@ def test_anonymize_object_info_with_custom_user_defined_object_with_single_paren
 def test_anonymize_object_info_with_custom_user_defined_object_with_no_parent(
     anonymizer_with_consistent_salt: Anonymizer,
 ):
-    anonymized_result: dict = anonymizer_with_consistent_salt._anonymize_object_info(
-        anonymized_info_dict={}, object_=BaseTestClass()
+    anonymized_result: dict = (
+        anonymizer_with_consistent_salt._anonymize_object_info(  # noqa: SLF001
+            anonymized_info_dict={}, object_=BaseTestClass()
+        )
     )
 
     assert anonymized_result == {
@@ -222,9 +228,11 @@ def test_anonymize_object_info_with_custom_user_defined_object_with_no_parent(
 def test_anonymize_object_info_with_custom_user_defined_object_with_multiple_parents(
     anonymizer_with_consistent_salt: Anonymizer,
 ):
-    anonymized_result: dict = anonymizer_with_consistent_salt._anonymize_object_info(
-        anonymized_info_dict={},
-        object_=MyCustomMultipleInheritanceClass(expectation_suite_name="my_name"),
+    anonymized_result: dict = (
+        anonymizer_with_consistent_salt._anonymize_object_info(  # noqa: SLF001
+            anonymized_info_dict={},
+            object_=MyCustomMultipleInheritanceClass(expectation_suite_name="my_name"),
+        )
     )
 
     assert anonymized_result == {
@@ -238,7 +246,7 @@ def test_anonymize_object_info_with_missing_args_raises_error(
     anonymizer_with_consistent_salt: Anonymizer,
 ):
     with pytest.raises(AssertionError) as e:
-        anonymizer_with_consistent_salt._anonymize_object_info(
+        anonymizer_with_consistent_salt._anonymize_object_info(  # noqa: SLF001
             anonymized_info_dict={},
             object_=None,
             object_class=None,

--- a/tests/core/usage_statistics/test_package_dependencies.py
+++ b/tests/core/usage_statistics/test_package_dependencies.py
@@ -49,7 +49,9 @@ def test__get_dependency_names():
         "-",
     ]
     ge_dependencies = GXDependencies()
-    observed_dependencies = ge_dependencies._get_dependency_names(mock_dependencies)
+    observed_dependencies = ge_dependencies._get_dependency_names(  # noqa: SLF001
+        mock_dependencies
+    )
     assert observed_dependencies == expected_dependendencies
 
 

--- a/tests/core/usage_statistics/test_payload_builder.py
+++ b/tests/core/usage_statistics/test_payload_builder.py
@@ -19,8 +19,8 @@ def test_build_init_payload(
     """This test is for a happy path only but will fail if there is an exception thrown in init_payload"""
 
     context = titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled
-    usage_statistics_handler = context._usage_statistics_handler
-    builder = usage_statistics_handler._builder
+    usage_statistics_handler = context._usage_statistics_handler  # noqa: SLF001
+    builder = usage_statistics_handler._builder  # noqa: SLF001
     init_payload = builder.build_init_payload()
     assert list(init_payload.keys()) == [
         "platform.system",
@@ -59,11 +59,11 @@ def test_usage_statistics_handler_build_envelope(
     )
 
     assert (
-        usage_statistics_handler._data_context_id
+        usage_statistics_handler._data_context_id  # noqa: SLF001
         == "00000000-0000-0000-0000-000000000001"
     )
 
-    builder = usage_statistics_handler._builder
+    builder = usage_statistics_handler._builder  # noqa: SLF001
     envelope = builder.build_envelope(sample_partial_message)
 
     expected_keys = [
@@ -97,7 +97,7 @@ def test_determine_hashed_mac_address():
 
     # Picking an arbitrary 48-bit positive integer as a mock MAC addr
     with mock.patch("uuid.getnode", return_value=170040650683345) as mock_node:
-        hashed_mac_address = builder._determine_hashed_mac_address()
+        hashed_mac_address = builder._determine_hashed_mac_address()  # noqa: SLF001
 
     mock_node.assert_called_once()
     assert (

--- a/tests/core/usage_statistics/test_usage_statistics.py
+++ b/tests/core/usage_statistics/test_usage_statistics.py
@@ -91,7 +91,7 @@ def test_global_override_environment_variable_data_context(
         is True
     )
     context = get_context(in_memory_data_context_config_usage_stats_enabled)
-    project_config = context._project_config
+    project_config = context._project_config  # noqa: SLF001
     assert project_config.anonymous_usage_statistics.enabled is False
 
 
@@ -132,7 +132,7 @@ def test_global_override_from_config_file_in_etc(
             context = get_context(
                 deepcopy(in_memory_data_context_config_usage_stats_enabled)
             )
-            project_config = context._project_config
+            project_config = context._project_config  # noqa: SLF001
             assert project_config.anonymous_usage_statistics.enabled is False
 
 
@@ -177,7 +177,7 @@ def test_global_override_from_config_file_in_home_folder(
             context = get_context(
                 deepcopy(in_memory_data_context_config_usage_stats_enabled)
             )
-            project_config = context._project_config
+            project_config = context._project_config  # noqa: SLF001
             assert project_config.anonymous_usage_statistics.enabled is False
 
 
@@ -199,7 +199,7 @@ def test_global_override_in_yml(tmp_path_factory, monkeypatch):
     )
 
     assert (
-        get_context(
+        get_context(  # noqa: SLF001
             context_root_dir=context_path
         )._project_config.anonymous_usage_statistics.enabled
         is False
@@ -259,7 +259,7 @@ def test_global_override_conf_overrides_yml_and_env_variable(
     )
 
     assert (
-        get_context(
+        get_context(  # noqa: SLF001
             context_root_dir=context_path
         )._project_config.anonymous_usage_statistics.enabled
         is True
@@ -270,7 +270,7 @@ def test_global_override_conf_overrides_yml_and_env_variable(
         config_dirs,
     ):
         context = get_context(context_root_dir=context_path)
-        project_config = context._project_config
+        project_config = context._project_config  # noqa: SLF001
         assert project_config.anonymous_usage_statistics.enabled is False
 
 
@@ -325,7 +325,7 @@ def test_global_override_env_overrides_yml_and_conf(tmp_path_factory, monkeypatc
     )
 
     assert (
-        get_context(
+        get_context(  # noqa: SLF001
             context_root_dir=context_path
         )._project_config.anonymous_usage_statistics.enabled
         is False
@@ -336,7 +336,7 @@ def test_global_override_env_overrides_yml_and_conf(tmp_path_factory, monkeypatc
         config_dirs,
     ):
         context = get_context(context_root_dir=context_path)
-        project_config = context._project_config
+        project_config = context._project_config  # noqa: SLF001
         assert project_config.anonymous_usage_statistics.enabled is False
 
 
@@ -391,7 +391,7 @@ def test_global_override_yml_overrides_env_and_conf(tmp_path_factory, monkeypatc
     )
 
     assert (
-        get_context(
+        get_context(  # noqa: SLF001
             context_root_dir=context_path
         )._project_config.anonymous_usage_statistics.enabled
         is False
@@ -402,5 +402,5 @@ def test_global_override_yml_overrides_env_and_conf(tmp_path_factory, monkeypatc
         config_dirs,
     ):
         context = get_context(context_root_dir=context_path)
-        project_config = context._project_config
+        project_config = context._project_config  # noqa: SLF001
         assert project_config.anonymous_usage_statistics.enabled is False

--- a/tests/core/usage_statistics/test_usage_statistics_handler_methods.py
+++ b/tests/core/usage_statistics/test_usage_statistics_handler_methods.py
@@ -36,7 +36,7 @@ def test_usage_statistics_handler_validate_message_failure(
     )
 
     assert (
-        usage_statistics_handler._data_context_id
+        usage_statistics_handler._data_context_id  # noqa: SLF001
         == "00000000-0000-0000-0000-000000000001"
     )
 
@@ -86,7 +86,7 @@ def test_usage_statistics_handler_validate_message_success(
     )
 
     assert (
-        usage_statistics_handler._data_context_id
+        usage_statistics_handler._data_context_id  # noqa: SLF001
         == "00000000-0000-0000-0000-000000000001"
     )
 

--- a/tests/data_context/abstract_data_context/test_abstract_data_context_datasource_crud.py
+++ b/tests/data_context/abstract_data_context/test_abstract_data_context_datasource_crud.py
@@ -107,8 +107,8 @@ def test_add_datasource_sanitizes_instantiated_objs_config(
 
     # Raw config attached to object should reflect what needs to be persisted (no sensitive credentials!)
     assert (
-        instantiated_datasource._raw_config["data_connectors"][data_connector_name][
-            "base_directory"
-        ]
+        instantiated_datasource._raw_config["data_connectors"][  # noqa: SLF001
+            data_connector_name
+        ]["base_directory"]
         == f"${variable}"
     )

--- a/tests/data_context/abstract_data_context/test_datasource_delete.py
+++ b/tests/data_context/abstract_data_context/test_datasource_delete.py
@@ -18,7 +18,9 @@ def test_datasource_delete_removes_from_cache_and_config_data_context(
     assert len(context.datasources) == 1
     assert datasource_name in context.datasources
     assert datasource_name in context.config.datasources
-    assert context._datasource_store.retrieve_by_name(datasource_name=datasource_name)
+    assert context._datasource_store.retrieve_by_name(  # noqa: SLF001
+        datasource_name=datasource_name
+    )
 
     context.delete_datasource(datasource_name)
 
@@ -27,6 +29,6 @@ def test_datasource_delete_removes_from_cache_and_config_data_context(
     assert datasource_name not in context.datasources
     assert datasource_name not in context.config.datasources
     with pytest.raises(ValueError):
-        assert not context._datasource_store.retrieve_by_name(
+        assert not context._datasource_store.retrieve_by_name(  # noqa: SLF001
             datasource_name=datasource_name
         )

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -620,7 +620,7 @@ def test_expectation_suite_gx_cloud_identifier_requires_id_or_resource_name(
     key = GXCloudIdentifier(resource_type=GXCloudRESTResource.EXPECTATION_SUITE)
 
     with pytest.raises(ValueError):
-        context.expectations_store._validate_key(key=key)
+        context.expectations_store._validate_key(key=key)  # noqa: SLF001
 
 
 @pytest.mark.cloud

--- a/tests/data_context/cloud_data_context/test_version_checker.py
+++ b/tests/data_context/cloud_data_context/test_version_checker.py
@@ -9,10 +9,10 @@ _MOCK_PYPI_VERSION = "0.16.8"
 
 @pytest.fixture
 def enable_pypi_version_check():
-    stashed_version = _VersionChecker._LATEST_GX_VERSION_CACHE
-    _VersionChecker._LATEST_GX_VERSION_CACHE = None
+    stashed_version = _VersionChecker._LATEST_GX_VERSION_CACHE  # noqa: SLF001
+    _VersionChecker._LATEST_GX_VERSION_CACHE = None  # noqa: SLF001
     yield
-    _VersionChecker._LATEST_GX_VERSION_CACHE = stashed_version
+    _VersionChecker._LATEST_GX_VERSION_CACHE = stashed_version  # noqa: SLF001
 
 
 @pytest.mark.parametrize(
@@ -39,7 +39,7 @@ def test_check_if_using_latest_gx(
     pypi_payload = {"info": {"version": _MOCK_PYPI_VERSION}}
     responses.add(
         responses.GET,
-        _VersionChecker._PYPI_GX_ENDPOINT,
+        _VersionChecker._PYPI_GX_ENDPOINT,  # noqa: SLF001
         json=pypi_payload,
         status=status,
     )

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -131,7 +131,7 @@ def test__send_configuration_bundle_sends_valid_http_request(
 ):
     migrator = migrator_with_mock_context
     with mock.patch("requests.Session.post", autospec=True) as mock_post:
-        migrator._send_configuration_bundle(
+        migrator._send_configuration_bundle(  # noqa: SLF001
             serialized_bundle=serialized_configuration_bundle, test_migrate=False
         )
 
@@ -171,7 +171,7 @@ def test__send_validation_results_sends_valid_http_request(
     }
 
     with mock.patch("requests.Session.post", autospec=True) as mock_post:
-        migrator._send_validation_results(
+        migrator._send_validation_results(  # noqa: SLF001
             serialized_validation_results=validation_results, test_migrate=False
         )
 
@@ -265,7 +265,7 @@ def test__migrate_to_cloud_outputs_warnings(
 
     caplog.set_level(logging.INFO)
     with mock.patch("requests.Session.post", autospec=True):
-        migrator._migrate_to_cloud(test_migrate=test_migrate)
+        migrator._migrate_to_cloud(test_migrate=test_migrate)  # noqa: SLF001
 
     actual_logs = [rec.message for rec in caplog.records]
     aggregated_log_output = "\n".join(log for log in actual_logs)
@@ -344,7 +344,7 @@ def test__migrate_to_cloud_happy_path_prints_to_stdout(
     migrator = migrator_with_stub_base_data_context
 
     with mock.patch("requests.Session.post", autospec=True):
-        migrator._migrate_to_cloud(test_migrate=test_migrate)
+        migrator._migrate_to_cloud(test_migrate=test_migrate)  # noqa: SLF001
 
     stdout, _ = capsys.readouterr()
     assert_stdout_is_accurate_and_properly_ordered(
@@ -366,7 +366,7 @@ def test__migrate_to_cloud_bad_bundle_request_prints_to_stdout(
         mock_post.return_value = MigrationResponse(
             message="Bad request!", status_code=400, success=False
         )
-        migrator._migrate_to_cloud(test_migrate=False)
+        migrator._migrate_to_cloud(test_migrate=False)  # noqa: SLF001
 
     stdout, _ = capsys.readouterr()
     expected_statements = [
@@ -412,7 +412,7 @@ def test__migrate_to_cloud_bad_validations_request_prints_to_stdout(
     ) as mock_post:
         # Ensure that the first call, which is the bundle request, goes through successfully
         mock_post.side_effect = [good_response, bad_response]
-        migrator._migrate_to_cloud(test_migrate=False)
+        migrator._migrate_to_cloud(test_migrate=False)  # noqa: SLF001
 
     stdout, _ = capsys.readouterr()
     expected_statements = [

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -25,7 +25,7 @@ class TestConfigurationBundleCreate:
         config_bundle = ConfigurationBundle(context)
 
         assert config_bundle.is_usage_stats_enabled()
-        assert config_bundle._data_context_variables is not None
+        assert config_bundle._data_context_variables is not None  # noqa: SLF001
         assert len(config_bundle.expectation_suites) == 1
         assert len(config_bundle.checkpoints) == 1
         assert len(config_bundle.validation_results) == 1

--- a/tests/data_context/migrator/test_file_migrator.py
+++ b/tests/data_context/migrator/test_file_migrator.py
@@ -36,7 +36,7 @@ def construct_file_migrator() -> Callable:
     def _construct_file_migrator(context: AbstractDataContext):
         return FileMigrator(
             primary_stores=context.stores,
-            datasource_store=context._datasource_store,
+            datasource_store=context._datasource_store,  # noqa: SLF001
             variables=context.variables,
             fluent_config=context.fluent_config,
         )
@@ -147,7 +147,7 @@ def test_migrate_transfers_fluent_datasources(
     datasource_name = "my_experimental_datasource_awaiting_migration"
 
     context.sources.add_pandas(datasource_name)
-    context._synchronize_fluent_datasources()
+    context._synchronize_fluent_datasources()  # noqa: SLF001
 
     # Construct and run migrator
     tmp_path.mkdir(exist_ok=True)

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 def checkpoint_store_with_mock_backend() -> Tuple[CheckpointStore, mock.MagicMock]:
     store = CheckpointStore(store_name="checkpoint_store")
     mock_backend = mock.MagicMock()
-    store._store_backend = mock_backend
+    store._store_backend = mock_backend  # noqa: SLF001
 
     return store, mock_backend
 
@@ -570,7 +570,7 @@ def test_add_checkpoint(
     store, mock_backend = checkpoint_store_with_mock_backend
 
     context = mock.MagicMock(spec=FileDataContext)
-    context._usage_statistics_handler = mock.MagicMock()
+    context._usage_statistics_handler = mock.MagicMock()  # noqa: SLF001
     checkpoint_name = "my_checkpoint"
     checkpoint = Checkpoint(name=checkpoint_name, data_context=context)
 

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -325,7 +325,9 @@ def test_self_check(capsys) -> None:
 def test_determine_key_constructs_key(
     name: Optional[str], id: Optional[str], expected_key: DataContextKey
 ) -> None:
-    actual_key = ConfigurationStore(store_name="test")._determine_key(name=name, id=id)
+    actual_key = ConfigurationStore(store_name="test")._determine_key(  # noqa: SLF001
+        name=name, id=id
+    )
     assert actual_key == expected_key
 
 
@@ -345,7 +347,9 @@ def test_determine_key_raises_error_with_conflicting_args(
     name: Optional[str], id: Optional[str]
 ) -> None:
     with pytest.raises(AssertionError) as e:
-        ConfigurationStore(store_name="test")._determine_key(name=name, id=id)
+        ConfigurationStore(store_name="test")._determine_key(  # noqa: SLF001
+            name=name, id=id
+        )
 
     assert "Must provide either name or id" in str(e.value)
 

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -41,7 +41,9 @@ def test_database_store_backend_schema_spec(caplog, sa, test_backends):
 
     # clean up values
     with store_backend.engine.begin() as connection:
-        connection.execute(sa.text(f"DROP TABLE {store_backend._table};"))
+        connection.execute(
+            sa.text(f"DROP TABLE {store_backend._table};")  # noqa: SLF001
+        )
 
 
 def test_database_store_backend_get_url_for_key(caplog, sa, test_backends):

--- a/tests/data_context/store/test_evaluation_parameter_store.py
+++ b/tests/data_context/store/test_evaluation_parameter_store.py
@@ -288,7 +288,7 @@ def test_evaluation_parameter_store_calls_proper_cloud_tuple_store_methods(
     evaluation_parameter_store = EvaluationParameterStore()
     run_id = RunIdentifier()
     s3_store = TupleS3StoreBackend(bucket="my_bucket")
-    evaluation_parameter_store._store_backend = s3_store
+    evaluation_parameter_store._store_backend = s3_store  # noqa: SLF001
 
     # Sanity check to ensure neither parent nor child method has been called
     assert not mock_s3_list_keys.called
@@ -322,7 +322,7 @@ def test_evaluation_parameter_store_calls_proper_azure_tuple_store_methods(
     azure_store = TupleAzureBlobStoreBackend(
         container="my_container", connection_string="my_connection_string"
     )
-    evaluation_parameter_store._store_backend = azure_store
+    evaluation_parameter_store._store_backend = azure_store  # noqa: SLF001
 
     # Sanity check to ensure neither parent nor child method has been called
     assert not mock_azure_list_keys.called
@@ -354,7 +354,7 @@ def test_evaluation_parameter_store_calls_proper_gcs_tuple_store_methods(
     evaluation_parameter_store = EvaluationParameterStore()
     run_id = RunIdentifier()
     gcs_store = TupleGCSStoreBackend(bucket="my_bucket", project="my_project")
-    evaluation_parameter_store._store_backend = gcs_store
+    evaluation_parameter_store._store_backend = gcs_store  # noqa: SLF001
 
     # Sanity check to ensure neither parent nor child method has been called
     assert not mock_gcs_list_keys.called

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -122,7 +122,7 @@ def validation_operators_data_context(
     )
     data_context.add_expectation_suite("f1.foo")
 
-    df = data_context._get_batch_v2(
+    df = data_context._get_batch_v2(  # noqa: SLF001
         batch_kwargs=data_context.build_batch_kwargs(
             "my_datasource", "subdir_reader", "f1"
         ),
@@ -160,19 +160,19 @@ def parameterized_expectation_suite(empty_data_context_stats_enabled):
 def test_StoreBackendValidation():
     backend = InMemoryStoreBackend()
 
-    backend._validate_key(("I", "am", "a", "string", "tuple"))
+    backend._validate_key(("I", "am", "a", "string", "tuple"))  # noqa: SLF001
 
     with pytest.raises(TypeError):
-        backend._validate_key("nope")
+        backend._validate_key("nope")  # noqa: SLF001
 
     with pytest.raises(TypeError):
-        backend._validate_key(("I", "am", "a", "string", 100))
+        backend._validate_key(("I", "am", "a", "string", 100))  # noqa: SLF001
 
     with pytest.raises(TypeError):
-        backend._validate_key(("I", "am", "a", "string", None))
+        backend._validate_key(("I", "am", "a", "string", None))  # noqa: SLF001
 
     # zero-length tuple is allowed
-    backend._validate_key(())
+    backend._validate_key(())  # noqa: SLF001
 
 
 def check_store_backend_store_backend_id_functionality(
@@ -448,17 +448,17 @@ def test_FilesystemStoreBackend_two_way_string_conversion(tmp_path_factory):
     )
 
     tuple_ = ("A__a", "B-b", "C")
-    converted_string = my_store._convert_key_to_filepath(tuple_)
+    converted_string = my_store._convert_key_to_filepath(tuple_)  # noqa: SLF001
     assert converted_string == "A__a/B-b/C/foo-C-expectations.txt"
 
-    recovered_key = my_store._convert_filepath_to_key(
+    recovered_key = my_store._convert_filepath_to_key(  # noqa: SLF001
         "A__a/B-b/C/foo-C-expectations.txt"
     )
     assert recovered_key == tuple_
 
     with pytest.raises(ValueError):
         tuple_ = ("A/a", "B-b", "C")
-        converted_string = my_store._convert_key_to_filepath(tuple_)
+        converted_string = my_store._convert_key_to_filepath(tuple_)  # noqa: SLF001
 
 
 @pytest.mark.filesystem
@@ -888,7 +888,7 @@ def test_TupleS3StoreBackend_with_empty_prefixes(aws_credentials):
     assert my_store.get(("AAA",)) == "aaa"
 
     obj = boto3.client("s3").get_object(Bucket=bucket, Key=prefix + "my_file_AAA")
-    assert my_store._build_s3_object_key(("AAA",)) == "my_file_AAA"
+    assert my_store._build_s3_object_key(("AAA",)) == "my_file_AAA"  # noqa: SLF001
     assert obj["ContentType"] == "text/html; charset=utf-8"
     assert obj["ContentEncoding"] == "utf-8"
 
@@ -1144,7 +1144,7 @@ def test_TupleAzureBlobStoreBackend_credential():
     with mock.patch(
         "great_expectations.compatibility.azure.BlobServiceClient", autospec=True
     ):
-        mock_container_client = my_store._container_client
+        mock_container_client = my_store._container_client  # noqa: SLF001
         my_store.set(("AAA",), "aaa")
         mock_container_client.upload_blob.assert_called_once_with(
             name="this_is_a_test_prefix/AAA",
@@ -1184,7 +1184,7 @@ def test_TupleAzureBlobStoreBackend_connection_string():
     with mock.patch(
         "great_expectations.compatibility.azure.BlobServiceClient", autospec=True
     ) as mock_azure_blob_client:
-        mock_container_client = my_store._container_client
+        mock_container_client = my_store._container_client  # noqa: SLF001
         mock_azure_blob_client.from_connection_string.assert_called_once()
 
         my_store.set(("AAA",), "aaa")
@@ -1230,7 +1230,7 @@ def test_TupleAzureBlobStoreBackend_account_url():
             "great_expectations.compatibility.azure.DefaultAzureCredential",
             autospec=True,
         ) as mock_azure_credential:
-            mock_container_client = my_store._container_client
+            mock_container_client = my_store._container_client  # noqa: SLF001
             mock_azure_blob_client.assert_called_once()
 
             my_store.get(("BBB",))
@@ -1600,7 +1600,9 @@ def test_InMemoryStoreBackend_add_or_update(previous_key_exists: bool):
 @pytest.mark.unit
 def test_store_backend_path_special_character_escape():
     path = "/validations/default/pandas_data_asset/20230315T205136.109084Z/default_pandas_datasource-#ephemeral_pandas_asset.html"
-    escaped_path = StoreBackend._url_path_escape_special_characters(path=path)
+    escaped_path = StoreBackend._url_path_escape_special_characters(  # noqa: SLF001
+        path=path
+    )
     assert (
         escaped_path
         == "/validations/default/pandas_data_asset/20230315T205136.109084Z/default_pandas_datasource-%23ephemeral_pandas_asset.html"

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -299,12 +299,12 @@ def test_compile_evaluation_parameter_dependencies(
     data_context_parameterized_expectation_suite,
 ):
     assert (
-        data_context_parameterized_expectation_suite._evaluation_parameter_dependencies
+        data_context_parameterized_expectation_suite._evaluation_parameter_dependencies  # noqa: SLF001
         == {}
     )
-    data_context_parameterized_expectation_suite._compile_evaluation_parameter_dependencies()
+    data_context_parameterized_expectation_suite._compile_evaluation_parameter_dependencies()  # noqa: SLF001
     assert (
-        data_context_parameterized_expectation_suite._evaluation_parameter_dependencies
+        data_context_parameterized_expectation_suite._evaluation_parameter_dependencies  # noqa: SLF001
         == {
             "source_diabetes_data.default": [
                 {
@@ -437,12 +437,18 @@ def test__normalize_absolute_or_relative_path(
         config_path,
     )
 
-    assert context._normalize_absolute_or_relative_path("yikes").endswith(
+    assert context._normalize_absolute_or_relative_path(  # noqa: SLF001
+        "yikes"
+    ).endswith(
         os.path.join(test_dir, "yikes")  # noqa: PTH118
     )
 
-    assert test_dir not in context._normalize_absolute_or_relative_path("/yikes")
-    assert "/yikes" == context._normalize_absolute_or_relative_path("/yikes")
+    assert test_dir not in context._normalize_absolute_or_relative_path(  # noqa: SLF001
+        "/yikes"
+    )
+    assert "/yikes" == context._normalize_absolute_or_relative_path(  # noqa: SLF001
+        "/yikes"
+    )
 
 
 @pytest.mark.filesystem
@@ -616,7 +622,10 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_true
     ge_dir = empty_context.root_directory
     empty_context.add_datasource("arthur", **{"class_name": "PandasDatasource"})
     assert (
-        FileDataContext._does_project_have_a_datasource_in_config_file(ge_dir) is True
+        FileDataContext._does_project_have_a_datasource_in_config_file(  # noqa: SLF001
+            ge_dir
+        )
+        is True
     )
 
 
@@ -626,7 +635,10 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
 ):
     ge_dir = empty_context.root_directory
     assert (
-        FileDataContext._does_project_have_a_datasource_in_config_file(ge_dir) is False
+        FileDataContext._does_project_have_a_datasource_in_config_file(  # noqa: SLF001
+            ge_dir
+        )
+        is False
     )
 
 
@@ -637,7 +649,10 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
     ge_dir = empty_context.root_directory
     safe_remove(os.path.join(ge_dir, empty_context.GX_YML))  # noqa: PTH118
     assert (
-        FileDataContext._does_project_have_a_datasource_in_config_file(ge_dir) is False
+        FileDataContext._does_project_have_a_datasource_in_config_file(  # noqa: SLF001
+            ge_dir
+        )
+        is False
     )
 
 
@@ -648,7 +663,10 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
     ge_dir = empty_context.root_directory
     safe_remove(os.path.join(ge_dir))  # noqa: PTH118
     assert (
-        FileDataContext._does_project_have_a_datasource_in_config_file(ge_dir) is False
+        FileDataContext._does_project_have_a_datasource_in_config_file(  # noqa: SLF001
+            ge_dir
+        )
+        is False
     )
 
 
@@ -660,7 +678,10 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
     with open(os.path.join(ge_dir, FileDataContext.GX_YML), "w") as yml:  # noqa: PTH118
         yml.write("this file: is not a valid ge config")
     assert (
-        FileDataContext._does_project_have_a_datasource_in_config_file(ge_dir) is False
+        FileDataContext._does_project_have_a_datasource_in_config_file(  # noqa: SLF001
+            ge_dir
+        )
+        is False
     )
 
 
@@ -946,7 +967,7 @@ def test_data_context_create_does_not_overwrite_existing_config_variables_yml(
 def test_scaffold_directories(tmp_path_factory):
     empty_directory = str(tmp_path_factory.mktemp("test_scaffold_directories"))
     empty_directory = pathlib.Path(empty_directory)
-    FileDataContext._scaffold_directories(empty_directory)
+    FileDataContext._scaffold_directories(empty_directory)  # noqa: SLF001
 
     assert set(os.listdir(empty_directory)) == {
         "plugins",
@@ -2514,7 +2535,9 @@ def test_check_for_usage_stats_sync_finds_diff(
     context = empty_data_context_stats_enabled
     project_config = data_context_config_with_datasources
 
-    res = context._check_for_usage_stats_sync(project_config=project_config)
+    res = context._check_for_usage_stats_sync(  # noqa: SLF001
+        project_config=project_config
+    )
     assert res is True
 
 
@@ -2532,7 +2555,9 @@ def test_check_for_usage_stats_sync_does_not_find_diff(
     context = empty_data_context_stats_enabled
     project_config = copy.deepcopy(context.config)  # Using same exact config
 
-    res = context._check_for_usage_stats_sync(project_config=project_config)
+    res = context._check_for_usage_stats_sync(  # noqa: SLF001
+        project_config=project_config
+    )
     assert res is False
 
 
@@ -2545,7 +2570,9 @@ def test_check_for_usage_stats_sync_short_circuits_due_to_disabled_usage_stats(
     project_config = data_context_config_with_datasources
     project_config.anonymous_usage_statistics.enabled = False
 
-    res = context._check_for_usage_stats_sync(project_config=project_config)
+    res = context._check_for_usage_stats_sync(  # noqa: SLF001
+        project_config=project_config
+    )
     assert res is False
 
 
@@ -2782,7 +2809,7 @@ def test_set_oss_id_with_empty_config(in_memory_runtime_context: EphemeralDataCo
     context = in_memory_runtime_context
     config = configparser.ConfigParser()
 
-    oss_id = context._set_oss_id(config)
+    oss_id = context._set_oss_id(config)  # noqa: SLF001
 
     assert config.sections() == ["anonymous_usage_statistics"]
     assert list(config["anonymous_usage_statistics"]) == ["oss_id"]
@@ -2805,7 +2832,7 @@ def test_set_oss_id_with_existing_config(
     )
     config["anonymous_usage_statistics"]["usage_statistics_url"] = usage_statistics_url
 
-    oss_id = context._set_oss_id(config)
+    oss_id = context._set_oss_id(config)  # noqa: SLF001
 
     assert config.sections() == ["anonymous_usage_statistics"]
     assert list(config["anonymous_usage_statistics"]) == [

--- a/tests/data_context/test_data_context_config_ui.py
+++ b/tests/data_context/test_data_context_config_ui.py
@@ -1493,7 +1493,7 @@ def test_DataContextConfig_with_S3StoreBackendDefaults_and_simple_defaults_with_
 
     data_context = get_context(project_config=data_context_config)
     assert (
-        data_context.datasources["my_pandas_datasource"]
+        data_context.datasources["my_pandas_datasource"]  # noqa: SLF001
         .get_batch_kwargs_generator("subdir_reader")
         ._base_directory
         == "../data/"

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -97,9 +97,9 @@ def test_substituted_config_variables_not_written_to_file(tmp_path_factory):
 
     # instantiate data_context twice to go through cycle of loading config from file then saving
     context = get_context(context_root_dir=context_path)
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     context_config_commented_map = dataContextConfigSchema.dump(
-        get_context(context_root_dir=context_path)._project_config
+        get_context(context_root_dir=context_path)._project_config  # noqa: SLF001
     )
     context_config_commented_map.pop("anonymous_usage_statistics")
 

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -143,7 +143,7 @@ def test_open_docs_with_two_local_sites_specify_open_one(
 @pytest.fixture
 def context_with_no_sites(empty_data_context):
     context = empty_data_context
-    context._project_config["data_docs_sites"] = None
+    context._project_config["data_docs_sites"] = None  # noqa: SLF001
     return context
 
 
@@ -265,7 +265,7 @@ def test_existing_local_data_docs_urls_returns_single_url_from_customized_local_
     ge_dir = os.path.join(empty_directory, FileDataContext.GX_DIR)  # noqa: PTH118
     context = get_context(context_root_dir=ge_dir)
 
-    context._project_config["data_docs_sites"] = {
+    context._project_config["data_docs_sites"] = {  # noqa: SLF001
         "my_rad_site": {
             "class_name": "SiteBuilder",
             "store_backend": {
@@ -277,7 +277,7 @@ def test_existing_local_data_docs_urls_returns_single_url_from_customized_local_
 
     # TODO Workaround project config programmatic config manipulation
     #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     context = get_context(context_root_dir=ge_dir)
     context.build_data_docs()
 
@@ -299,7 +299,7 @@ def test_existing_local_data_docs_urls_returns_multiple_urls_from_customized_loc
     ge_dir = os.path.join(empty_directory, FileDataContext.GX_DIR)  # noqa: PTH118
     context = get_context(context_root_dir=ge_dir)
 
-    context._project_config["data_docs_sites"] = {
+    context._project_config["data_docs_sites"] = {  # noqa: SLF001
         "my_rad_site": {
             "class_name": "SiteBuilder",
             "store_backend": {
@@ -318,7 +318,7 @@ def test_existing_local_data_docs_urls_returns_multiple_urls_from_customized_loc
 
     # TODO Workaround project config programmatic config manipulation
     #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     context = get_context(context_root_dir=ge_dir)
     context.build_data_docs()
     data_docs_dir = os.path.join(ge_dir, "uncommitted/data_docs/")  # noqa: PTH118
@@ -360,10 +360,10 @@ def test_build_data_docs_skipping_index_does_not_build_index(
             },
         },
     }
-    context._project_config = config
+    context._project_config = config  # noqa: SLF001
     # TODO Workaround project config programmatic config manipulation
     #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     del context
     context = get_context(context_root_dir=ge_dir)
     data_docs_dir = os.path.join(ge_dir, "uncommitted", "data_docs")  # noqa: PTH118

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -73,7 +73,9 @@ def test_data_context_instantiates_gx_cloud_store_backend_with_cloud_config(
         cloud_mode=True,
     )
 
-    assert isinstance(context._datasource_store.store_backend, GXCloudStoreBackend)
+    assert isinstance(
+        context._datasource_store.store_backend, GXCloudStoreBackend  # noqa: SLF001
+    )
 
 
 @pytest.mark.filesystem
@@ -93,7 +95,9 @@ def test_data_context_instantiates_inline_store_backend_with_filesystem_config(
         cloud_mode=False,
     )
 
-    assert isinstance(context._datasource_store.store_backend, InlineStoreBackend)
+    assert isinstance(
+        context._datasource_store.store_backend, InlineStoreBackend  # noqa: SLF001
+    )
 
 
 @pytest.mark.unit

--- a/tests/data_context/test_data_context_deprecation.py
+++ b/tests/data_context/test_data_context_deprecation.py
@@ -38,7 +38,7 @@ ge_cloud_config = GXCloudConfig(
 def test_data_context__resolve_id_and_ge_cloud_id_success(
     id: str | None, ge_cloud_id: str | None, expected: str | None
 ):
-    resolved = AbstractDataContext._resolve_id_and_ge_cloud_id(
+    resolved = AbstractDataContext._resolve_id_and_ge_cloud_id(  # noqa: SLF001
         id=id, ge_cloud_id=ge_cloud_id
     )
     assert resolved == expected
@@ -50,7 +50,7 @@ def test_data_context__resolve_id_and_ge_cloud_id_failure():
     ge_cloud_id = "def456"
 
     with pytest.raises(ValueError) as e:
-        _ = AbstractDataContext._resolve_id_and_ge_cloud_id(
+        _ = AbstractDataContext._resolve_id_and_ge_cloud_id(  # noqa: SLF001
             id=id, ge_cloud_id=ge_cloud_id
         )
 

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -101,20 +101,28 @@ def test_data_context_in_cloud_mode_passes_base_url_to_store_backend(
 
     # The DatasourceStore should not have the default base_url or commonly used test base urls
     assert (
-        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        not context._datasource_store.store_backend.config[  # noqa: SLF001
+            "ge_cloud_base_url"
+        ]
         == CLOUD_DEFAULT_BASE_URL
     )
     assert (
-        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        not context._datasource_store.store_backend.config[  # noqa: SLF001
+            "ge_cloud_base_url"
+        ]
         == ge_cloud_base_url
     )
     assert (
-        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        not context._datasource_store.store_backend.config[  # noqa: SLF001
+            "ge_cloud_base_url"
+        ]
         == "https://app.test.greatexpectations.io"
     )
 
     # The DatasourceStore should have the custom base url set
     assert (
-        context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        context._datasource_store.store_backend.config[  # noqa: SLF001
+            "ge_cloud_base_url"
+        ]
         == custom_base_url
     )

--- a/tests/data_context/test_data_context_in_code_config.py
+++ b/tests/data_context/test_data_context_in_code_config.py
@@ -241,7 +241,9 @@ def test_DataContext_construct_data_context_id_uses_id_of_currently_configured_e
         in_code_data_context.stores["expectations_S3_store"].store_backend_id
     )
     in_code_data_context_data_context_id = in_code_data_context.data_context_id
-    constructed_data_context_id = in_code_data_context._construct_data_context_id()
+    constructed_data_context_id = (
+        in_code_data_context._construct_data_context_id()  # noqa: SLF001
+    )
     assert (
         in_code_data_context_expectations_store_store_backend_id
         == in_code_data_context_data_context_id
@@ -431,38 +433,38 @@ def test_suppress_store_backend_id_is_true_for_inactive_stores():
     # Check here that suppress_store_backend_id == True for inactive stores
     # and False for active stores
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "inactive_expectations_S3_store"
         ).store_backend._suppress_store_backend_id
         is True
     )
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "inactive_validations_S3_store"
         ).store_backend._suppress_store_backend_id
         is True
     )
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "expectations_S3_store"
         ).store_backend._suppress_store_backend_id
         is False
     )
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "validations_S3_store"
         ).store_backend._suppress_store_backend_id
         is False
     )
     # InMemoryStoreBackend created for evaluation_parameters_store & inactive_evaluation_parameters_store
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "inactive_evaluation_parameter_store"
         ).store_backend._suppress_store_backend_id
         is False
     )
     assert (
-        in_code_data_context.stores.get(
+        in_code_data_context.stores.get(  # noqa: SLF001
             "evaluation_parameter_store"
         ).store_backend._suppress_store_backend_id
         is False

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -1543,9 +1543,9 @@ data_connectors:
 
     # Raw config attached to object should reflect what needs to be persisted (no sensitive credentials!)
     assert (
-        instantiated_class._raw_config["data_connectors"][data_connector_name][
-            "base_directory"
-        ]
+        instantiated_class._raw_config["data_connectors"][  # noqa: SLF001
+            data_connector_name
+        ]["base_directory"]
         == f"${variable}"
     )
 

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -105,7 +105,7 @@ def data_context_with_runtime_sql_datasource_for_testing_get_batch(
     )
 
     # noinspection PyProtectedMember
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
     return context
 
 
@@ -155,14 +155,16 @@ def test__normalize_absolute_or_relative_path(
         config_path,
     )
 
-    assert context._normalize_absolute_or_relative_path("yikes").endswith(
-        f"{test_dir}/yikes"
-    )
+    assert context._normalize_absolute_or_relative_path(  # noqa: SLF001
+        "yikes"
+    ).endswith(f"{test_dir}/yikes")
     assert (
         "test__normalize_absolute_or_relative_path__dir"
-        not in context._normalize_absolute_or_relative_path("/yikes")
+        not in context._normalize_absolute_or_relative_path("/yikes")  # noqa: SLF001
     )
-    assert "/yikes" == context._normalize_absolute_or_relative_path("/yikes")
+    assert "/yikes" == context._normalize_absolute_or_relative_path(  # noqa: SLF001
+        "/yikes"
+    )
 
 
 @pytest.mark.filesystem
@@ -410,7 +412,7 @@ data_connectors:
         == f"{context.root_directory}/test_dir_0/A"
     )
     assert (
-        my_datasource.data_connectors[
+        my_datasource.data_connectors[  # noqa: SLF001
             "my_filesystem_data_connector"
         ]._get_full_file_path_for_asset(
             path="bigfile_1.csv",

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -374,7 +374,7 @@ def test_get_context_finds_legacy_great_expectations_dir(
     working_dir = tmp_path / "a" / "b" / "c" / "d" / "working_dir"
 
     # Scaffold great_expectations
-    context_root_dir = working_dir / FileDataContext._LEGACY_GX_DIR
+    context_root_dir = working_dir / FileDataContext._LEGACY_GX_DIR  # noqa: SLF001
     context_root_dir.mkdir(parents=True)
 
     # Scaffold great_expectations.yml
@@ -392,4 +392,4 @@ def test_get_context_finds_legacy_great_expectations_dir(
     assert isinstance(context, FileDataContext)
 
     project_root_dir = pathlib.Path(context.root_directory)
-    assert project_root_dir.stem == FileDataContext._LEGACY_GX_DIR
+    assert project_root_dir.stem == FileDataContext._LEGACY_GX_DIR  # noqa: SLF001

--- a/tests/data_context/test_pandas_datetime_suites.py
+++ b/tests/data_context/test_pandas_datetime_suites.py
@@ -41,7 +41,7 @@ def test_save_expectation_suite_with_datetime_objects(
 
         empty_suite = context.add_expectation_suite("test_suite")
 
-        batch = context._get_batch_v2(
+        batch = context._get_batch_v2(  # noqa: SLF001
             batch_kwargs=batch_kwargs, expectation_suite_name=empty_suite
         )
         for param in evaluation_parameters:
@@ -81,7 +81,7 @@ def test_save_expectation_suite_with_datetime_objects(
         )
 
         # Check that we can reload the expectation suite and validate
-        reloaded_batch = context._get_batch_v2(
+        reloaded_batch = context._get_batch_v2(  # noqa: SLF001
             batch_kwargs=batch_kwargs, expectation_suite_name=reloaded_expectation_suite
         )
 

--- a/tests/datasource/data_connector/sorters/test_sorters.py
+++ b/tests/datasource/data_connector/sorters/test_sorters.py
@@ -45,7 +45,7 @@ def test_sorter_instantiation_datetime():
     assert isinstance(my_dt, DateTimeSorter)
     assert my_dt.name == "dt"
     assert my_dt.reverse is True
-    assert my_dt._datetime_format == "%Y%m%d"
+    assert my_dt._datetime_format == "%Y%m%d"  # noqa: SLF001
 
 
 def test_sorter_instantiation_numeric():
@@ -78,7 +78,7 @@ def test_sorter_instantiation_custom_list():
     assert my_custom.name == "custom"
     assert my_custom.reverse is False
     # noinspection PyProtectedMember
-    assert my_custom._reference_list == ["a", "b", "c"]
+    assert my_custom._reference_list == ["a", "b", "c"]  # noqa: SLF001
     # with incorrectly configured reference list
     sorter_params: dict = {
         "reference_list": [
@@ -108,7 +108,9 @@ def test_sorter_instantiation_custom_list_with_periodic_table(
     }
     my_custom_sorter = CustomListSorter(name="element", orderby="asc", **sorter_params)
     # noinspection PyProtectedMember
-    assert my_custom_sorter._reference_list == periodic_table_of_elements
+    assert (
+        my_custom_sorter._reference_list == periodic_table_of_elements  # noqa: SLF001
+    )
     # This element exists : Hydrogen
     test_batch_def = BatchDefinition(
         datasource_name="test",

--- a/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
@@ -268,7 +268,7 @@ def test_instantiation_with_account_url_and_credential(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -303,7 +303,7 @@ def test_instantiation_with_conn_str_and_credential(
 
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -329,7 +329,7 @@ def test_instantiation_with_valid_account_url_assigns_account_name(mock_azure_co
             "credential": "my_credential",
         },
     )
-    assert my_data_connector._account_name == "my_account_url"
+    assert my_data_connector._account_name == "my_account_url"  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -353,7 +353,7 @@ def test_instantiation_with_valid_conn_str_assigns_account_name(mock_azure_conn)
             "credential": "my_credential",
         },
     )
-    assert my_data_connector._account_name == "storagesample"
+    assert my_data_connector._account_name == "storagesample"  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -827,7 +827,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     # It is important to note that although this is a minor deviation, it is deemed to be immaterial as we still end up testing our desired behavior.
 
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_azure_data_connector",
@@ -1461,7 +1461,7 @@ azure_options:
         ],
     ]
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert len(my_data_connector.get_unmatched_data_references()) == 0
 
@@ -1574,19 +1574,19 @@ azure_options:
     )
 
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/alpha/files/go/here/alpha-202001.csv", "alpha"
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/alpha/files/go/here/alpha-202001.csv"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/beta_here/beta-202002.txt", "beta"
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/beta_here/beta-202002.txt"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/gamma-202005.csv", "gamma"
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/gamma-202005.csv"

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -94,7 +94,7 @@ def test__get_full_file_path_for_asset_pandas(fs: FakeFilesystem):
     my_data_connector.data_context_root_directory = base_directory
 
     assert (
-        my_data_connector._get_full_file_path_for_asset(
+        my_data_connector._get_full_file_path_for_asset(  # noqa: SLF001
             path="bigfile_1.csv", asset=my_data_connector.assets["A"]
         )
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
@@ -199,7 +199,7 @@ def test__get_full_file_path_for_asset_spark(basic_spark_df_execution_engine, fs
     my_data_connector.data_context_root_directory = base_directory
 
     assert (
-        my_data_connector._get_full_file_path_for_asset(
+        my_data_connector._get_full_file_path_for_asset(  # noqa: SLF001
             path="bigfile_1.csv", asset=my_data_connector.assets["A"]
         )
         == f"{base_directory_colon}/test_dir_0/A/B/C/bigfile_1.csv"

--- a/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
@@ -73,7 +73,7 @@ def test_basic_instantiation(tmp_path_factory):
     }
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -323,7 +323,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
 
     # with unnamed data_asset_name
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_filesystem_data_connector",
@@ -709,7 +709,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
 
     # with unnamed data_asset_name
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_filesystem_data_connector",
@@ -977,7 +977,7 @@ def test_relative_asset_base_directory_path(tmp_path_factory):
     my_data_connector.data_context_root_directory = base_directory
 
     assert (
-        my_data_connector._get_full_file_path_for_asset(
+        my_data_connector._get_full_file_path_for_asset(  # noqa: SLF001
             path="bigfile_1.csv", asset=my_data_connector.assets["A"]
         )
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
@@ -1068,7 +1068,7 @@ def test_relative_default_and_relative_asset_base_directory_paths(tmp_path_facto
 
     assert my_data_connector.base_directory == f"{base_directory}/test_dir_0/A"
     assert (
-        my_data_connector._get_full_file_path_for_asset(
+        my_data_connector._get_full_file_path_for_asset(  # noqa: SLF001
             path="bigfile_1.csv", asset=my_data_connector.assets["A"]
         )
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
@@ -1288,7 +1288,7 @@ assets:
         },
     )
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert len(my_data_connector.get_unmatched_data_references()) == 0
 
@@ -1603,7 +1603,7 @@ def test__file_object_caching_for_FileDataConnector(tmp_path_factory):
     assert len(my_data_connector.get_unmatched_data_references()) == 0
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert len(my_data_connector.get_unmatched_data_references()) == 0
     assert my_data_connector.get_data_reference_count() == 4

--- a/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
@@ -261,7 +261,7 @@ def test_instantiation_without_args(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -298,7 +298,7 @@ def test_instantiation_with_filename_arg(
 
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -335,7 +335,7 @@ def test_instantiation_with_info_arg(
 
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -708,7 +708,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     # It is important to note that although this is a minor deviation, it is deemed to be immaterial as we still end up testing our desired behavior.
 
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_gcs_data_connector",
@@ -1298,7 +1298,7 @@ assets:
         ],
     ]
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert len(my_data_connector.get_unmatched_data_references()) == 0
 
@@ -1403,19 +1403,19 @@ assets:
     )
 
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/alpha/files/go/here/alpha-202001.csv", "alpha"
         )
         == "gs://my_bucket/my_base_directory/alpha/files/go/here/alpha-202001.csv"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/beta_here/beta-202002.txt", "beta"
         )
         == "gs://my_bucket/my_base_directory/beta_here/beta-202002.txt"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/gamma-202005.csv", "gamma"
         )
         == "gs://my_bucket/my_base_directory/gamma-202005.csv"

--- a/tests/datasource/data_connector/test_configured_asset_glue_catalog_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_glue_catalog_data_connector.py
@@ -795,7 +795,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__mod(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -848,7 +848,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__list(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -901,7 +901,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__hash(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -958,7 +958,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__whole_table(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1009,7 +1009,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__column_value(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1065,7 +1065,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__divided_integer(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1124,7 +1124,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__mod_integer(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1181,7 +1181,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__multi_column_values(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1238,7 +1238,7 @@ def test_get_batch_data_and_metadata_with_splitting_method__hashed_column(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
@@ -1294,7 +1294,7 @@ def test_get_batch_data_and_metadata_with_partitions(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     batch_definition = BatchDefinition(
         datasource_name="FAKE_Datasource_NAME",

--- a/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
@@ -86,7 +86,7 @@ def test_basic_instantiation():
     }
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -346,7 +346,7 @@ def test_return_all_batch_definitions_unsorted():
 
     # with unnamed data_asset_name
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_s3_data_connector",
@@ -1082,7 +1082,7 @@ assets:
         },
     )
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert len(my_data_connector.get_unmatched_data_references()) == 0
 

--- a/tests/datasource/data_connector/test_data_connector.py
+++ b/tests/datasource/data_connector/test_data_connector.py
@@ -216,10 +216,8 @@ def test_for_self_check_using_InferredAssetFilesystemDataConnector_SparkDFExecut
 @pytest.mark.filesystem
 def test__get_instantiation_through_instantiate_class_from_config(basic_data_connector):
     # noinspection PyProtectedMember
-    data_references: list = (
-        basic_data_connector._get_data_reference_list_from_cache_by_data_asset_name(
-            data_asset_name="my_asset_name"
-        )
+    data_references: list = basic_data_connector._get_data_reference_list_from_cache_by_data_asset_name(  # noqa: SLF001
+        data_asset_name="my_asset_name"
     )
     assert len(data_references) == 0
     assert data_references == []

--- a/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
@@ -267,7 +267,7 @@ def test_instantiation_with_account_url_and_credential(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -301,7 +301,7 @@ def test_instantiation_with_conn_str_and_credential(
 
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 3
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -326,7 +326,7 @@ def test_instantiation_with_valid_account_url_assigns_account_name(mock_azure_co
             "credential": "my_credential",
         },
     )
-    assert my_data_connector._account_name == "my_account_url"
+    assert my_data_connector._account_name == "my_account_url"  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -349,7 +349,7 @@ def test_instantiation_with_valid_conn_str_assigns_account_name(mock_azure_conn)
             "credential": "my_credential",
         },
     )
-    assert my_data_connector._account_name == "storagesample"
+    assert my_data_connector._account_name == "storagesample"  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -794,7 +794,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     # It is important to note that although this is a minor deviation, it is deemed to be immaterial as we still end up testing our desired behavior.
 
     unsorted_batch_definition_list = (
-        my_data_connector._get_batch_definition_list_from_batch_request(
+        my_data_connector._get_batch_definition_list_from_batch_request(  # noqa: SLF001
             BatchRequestBase(
                 datasource_name="test_environment",
                 data_connector_name="general_azure_data_connector",
@@ -1363,20 +1363,20 @@ azure_options:
     ]
 
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/alpha/files/go/here/alpha-202001.csv",
             data_asset_name="alpha",
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/alpha/files/go/here/alpha-202001.csv"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/beta_here/beta-202002.txt", data_asset_name="beta"
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/beta_here/beta-202002.txt"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/gamma-202005.csv", data_asset_name="gamma"
         )
         == "my_account_url.blob.core.windows.net/my_container/my_base_directory/gamma-202005.csv"
@@ -1442,20 +1442,20 @@ azure_options:
     ]
 
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/alpha/files/go/here/alpha-202001.csv",
             data_asset_name="alpha",
         )
         == "wasbs://my_container@my_account_url.blob.core.windows.net/my_base_directory/alpha/files/go/here/alpha-202001.csv"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/beta_here/beta-202002.txt", data_asset_name="beta"
         )
         == "wasbs://my_container@my_account_url.blob.core.windows.net/my_base_directory/beta_here/beta-202002.txt"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             path="my_base_directory/gamma-202005.csv", data_asset_name="gamma"
         )
         == "wasbs://my_container@my_account_url.blob.core.windows.net/my_base_directory/gamma-202005.csv"

--- a/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
@@ -69,7 +69,7 @@ def test__get_full_file_path_pandas(fs: FakeFilesystem):
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
@@ -132,7 +132,7 @@ def test__get_full_file_path_spark(basic_spark_df_execution_engine, fs):
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []

--- a/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
@@ -47,7 +47,7 @@ def test_basic_instantiation(tmp_path_factory):
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
@@ -102,7 +102,7 @@ def test_simple_regex_example_with_implicit_data_asset_names_self_check(
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     self_check_report_object = my_data_connector.self_check()
 
@@ -161,7 +161,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(tmp_path_factory):
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     # Test for an unknown execution environment
     with pytest.raises(ValueError):
@@ -267,7 +267,7 @@ def test_self_check(tmp_path_factory):
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     self_check_report_object = my_data_connector.self_check()
 

--- a/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
@@ -75,7 +75,7 @@ def test_instantiation_without_args(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -115,7 +115,7 @@ def test_instantiation_with_filename_arg(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -155,7 +155,7 @@ def test_instantiation_with_info_arg(
     )
     assert my_data_connector.self_check() == expected_config_dict
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
 
@@ -236,7 +236,7 @@ def test_get_batch_definition_list_from_batch_request_with_unknown_data_connecto
         prefix="",
     )
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     # Raises error in `DataConnector._validate_batch_request()` due to `data-connector_name` in BatchRequest not matching DataConnector name
     with pytest.raises(ValueError):
@@ -284,7 +284,7 @@ def test_simple_regex_example_with_implicit_data_asset_names_self_check(
         prefix="",
     )
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     self_check_report_object = my_data_connector.self_check()
 
@@ -341,7 +341,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(
         prefix="",
     )
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert (
         len(
@@ -423,7 +423,7 @@ def test_self_check(mock_gcs_conn, mock_list_keys, mock_emit):
         prefix="",
     )
 
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
     self_check_report_object = my_data_connector.self_check()
 
     assert self_check_report_object == {
@@ -1222,19 +1222,19 @@ default_regex:
     )
 
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/alpha/files/go/here/alpha-202001.csv", "alpha"
         )
         == "gs://my_bucket/my_base_directory/alpha/files/go/here/alpha-202001.csv"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/beta_here/beta-202002.txt", "beta"
         )
         == "gs://my_bucket/my_base_directory/beta_here/beta-202002.txt"
     )
     assert (
-        my_data_connector._get_full_file_path(
+        my_data_connector._get_full_file_path(  # noqa: SLF001
             "my_base_directory/gamma-202005.csv", "gamma"
         )
         == "gs://my_bucket/my_base_directory/gamma-202005.csv"

--- a/tests/datasource/data_connector/test_inferred_asset_glue_catalog_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_glue_catalog_data_connector.py
@@ -215,7 +215,7 @@ def test_get_batch_data_and_metadata_with_partitions(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]
+    in_memory_runtime_context.datasources["FAKE_Datasource_NAME"]._execution_engine = execution_engine  # type: ignore[union-attr]  # noqa: SLF001
 
     my_data_connector = in_memory_runtime_context.datasources[
         "FAKE_Datasource_NAME"

--- a/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
@@ -61,7 +61,7 @@ def test_basic_instantiation():
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
@@ -117,7 +117,7 @@ def test_simple_regex_example_with_implicit_data_asset_names_self_check():
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     self_check_report_object = my_data_connector.self_check()
 
@@ -179,7 +179,7 @@ def test_complex_regex_example_with_implicit_data_asset_names():
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     # Test for an unknown execution environment
     with pytest.raises(ValueError):
@@ -292,7 +292,7 @@ def test_self_check():
     )
 
     # noinspection PyProtectedMember
-    my_data_connector._refresh_data_references_cache()
+    my_data_connector._refresh_data_references_cache()  # noqa: SLF001
 
     self_check_report_object = my_data_connector.self_check()
 

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -173,7 +173,7 @@ def test_add_batch_identifiers_correct(basic_datasource_with_assets):
     test_runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    assert test_runtime_data_connector._batch_identifiers == {
+    assert test_runtime_data_connector._batch_identifiers == {  # noqa: SLF001
         "runtime": ["hour", "minute"],
         "asset_a": ["day", "month"],
         "asset_b": ["day", "month", "year"],
@@ -728,7 +728,7 @@ def test_data_references_cache_updating_after_batch_request(
         batch_request=batch_request
     )
 
-    assert test_runtime_data_connector._data_references_cache == {
+    assert test_runtime_data_connector._data_references_cache == {  # noqa: SLF001
         "my_data_asset_1": {
             "1234567890": [
                 BatchDefinition(
@@ -763,7 +763,7 @@ def test_data_references_cache_updating_after_batch_request(
         batch_request=batch_request
     )
 
-    assert test_runtime_data_connector._data_references_cache == {
+    assert test_runtime_data_connector._data_references_cache == {  # noqa: SLF001
         "my_data_asset_1": {
             "1234567890": [
                 BatchDefinition(
@@ -808,7 +808,7 @@ def test_data_references_cache_updating_after_batch_request(
         batch_request=batch_request
     )
 
-    assert test_runtime_data_connector._data_references_cache == {
+    assert test_runtime_data_connector._data_references_cache == {  # noqa: SLF001
         "my_data_asset_1": {
             "1234567890": [
                 BatchDefinition(
@@ -890,7 +890,7 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
             batch_identifiers=IDDict({"month": 1, "day": 1}),
         )
     ]
-    assert runtime_data_connector._data_references_cache == {
+    assert runtime_data_connector._data_references_cache == {  # noqa: SLF001
         "asset_a": {
             "1-1": [
                 BatchDefinition(
@@ -928,7 +928,7 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
             batch_identifiers=IDDict({"month": 2, "day": 1}),
         ),
     ]
-    assert runtime_data_connector._data_references_cache == {
+    assert runtime_data_connector._data_references_cache == {  # noqa: SLF001
         "asset_a": {
             "1-1": [
                 BatchDefinition(
@@ -1050,7 +1050,7 @@ def test__get_data_reference_list(basic_datasource):
     # noinspection PyProtectedMember
     data_reference_list: List[
         str
-    ] = test_runtime_data_connector._get_data_reference_list()
+    ] = test_runtime_data_connector._get_data_reference_list()  # noqa: SLF001
 
     assert data_reference_list == expected_data_reference_list
 
@@ -1060,7 +1060,7 @@ def test_refresh_data_references_cache(basic_datasource):
     test_runtime_data_connector: RuntimeDataConnector = (
         basic_datasource.data_connectors["test_runtime_data_connector"]
     )
-    assert len(test_runtime_data_connector._data_references_cache) == 0
+    assert len(test_runtime_data_connector._data_references_cache) == 0  # noqa: SLF001
 
 
 @pytest.mark.unit
@@ -1079,7 +1079,7 @@ def test__generate_batch_spec_parameters_from_batch_definition(
     expected_batch_spec_parameters: dict = {"data_asset_name": "my_data_asset"}
 
     # noinspection PyProtectedMember
-    batch_spec_parameters: dict = test_runtime_data_connector._generate_batch_spec_parameters_from_batch_definition(
+    batch_spec_parameters: dict = test_runtime_data_connector._generate_batch_spec_parameters_from_batch_definition(  # noqa: SLF001
         batch_definition=BatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="test_runtime_data_connector",
@@ -1159,7 +1159,9 @@ def test__get_data_reference_name(basic_datasource):
     )
 
     assert (
-        test_runtime_data_connector._get_data_reference_name(batch_identifiers)
+        test_runtime_data_connector._get_data_reference_name(  # noqa: SLF001
+            batch_identifiers
+        )
         == "1234567890"
     )
 
@@ -1176,7 +1178,9 @@ def test__get_data_reference_name(basic_datasource):
     )
 
     assert (
-        test_runtime_data_connector._get_data_reference_name(batch_identifiers)
+        test_runtime_data_connector._get_data_reference_name(  # noqa: SLF001
+            batch_identifiers
+        )
         == "1234567890-1111111111"
     )
 

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -107,7 +107,7 @@ def get_data_context_for_datasource_and_execution_engine(
         },
     )
     # Updating "execution_engine" to insure peculiarities, incorporated herein, propagate to "ExecutionEngine" itself.
-    context.datasources["my_test_datasource"]._execution_engine = sql_alchemy_execution_engine  # type: ignore[union-attr]
+    context.datasources["my_test_datasource"]._execution_engine = sql_alchemy_execution_engine  # type: ignore[union-attr]  # noqa: SLF001
     return context
 
 
@@ -2180,7 +2180,7 @@ def test_introspect_db(
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},
     )
 
-    assert my_data_connector._introspect_db() == [
+    assert my_data_connector._introspect_db() == [  # noqa: SLF001
         {
             "schema_name": "main",
             "table_name": "table_containing_id_spacers_for_D",
@@ -2280,7 +2280,7 @@ def test_introspect_db(
         },
     ]
 
-    assert my_data_connector._introspect_db(schema_name="main") == [
+    assert my_data_connector._introspect_db(schema_name="main") == [  # noqa: SLF001
         {
             "schema_name": "main",
             "table_name": "table_containing_id_spacers_for_D",
@@ -2380,10 +2380,10 @@ def test_introspect_db(
         },
     ]
 
-    assert my_data_connector._introspect_db(schema_name="waffle") == []
+    assert my_data_connector._introspect_db(schema_name="waffle") == []  # noqa: SLF001
 
     # This is a weak test, since this db doesn't have any additional schemas or system tables to show.
-    assert my_data_connector._introspect_db(
+    assert my_data_connector._introspect_db(  # noqa: SLF001
         ignore_information_schemas_and_system_tables=False
     ) == [
         {

--- a/tests/datasource/fluent/_fake_cloud_api.py
+++ b/tests/datasource/fluent/_fake_cloud_api.py
@@ -130,7 +130,7 @@ def create_fake_db_seed_data(fds_config: Optional[GxConfig] = None) -> FakeDBTyp
     datasource_config: dict[str, dict | str] = {}
     datasources_by_id: dict[str, dict] = {}
 
-    for ds in fds_config._json_dict()["fluent_datasources"]:
+    for ds in fds_config._json_dict()["fluent_datasources"]:  # noqa: SLF001
         name: str = ds["name"]
         datasource_names.add(name)
 

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -379,7 +379,7 @@ def seeded_cloud_context(
     seed_cloud,  # NOTE: this fixture must be called before the CloudDataContext is created
     empty_cloud_context_fluent,
 ):
-    empty_cloud_context_fluent._init_datasources()
+    empty_cloud_context_fluent._init_datasources()  # noqa: SLF001
     return empty_cloud_context_fluent
 
 

--- a/tests/datasource/fluent/data_asset/data_connector/test_dbfs_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_dbfs_data_connector.py
@@ -67,7 +67,7 @@ def test__get_full_file_path_pandas(fs: FakeFilesystem):
     )
 
     assert (
-        cast(DBFSDataConnector, my_data_connector)._get_full_file_path(
+        cast(DBFSDataConnector, my_data_connector)._get_full_file_path(  # noqa: SLF001
             path="bigfile_1.csv"
         )
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
@@ -121,7 +121,7 @@ def test__get_full_file_path_spark(basic_spark_df_execution_engine, fs):
     )
 
     assert (
-        cast(DBFSDataConnector, my_data_connector)._get_full_file_path(
+        cast(DBFSDataConnector, my_data_connector)._get_full_file_path(  # noqa: SLF001
             path="bigfile_1.csv"
         )
         == f"{base_directory_colon}/test_dir_0/A/B/C/bigfile_1.csv"

--- a/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
@@ -825,7 +825,7 @@ def test_relative_base_directory_path(tmp_path_factory):
     ]
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert (
-        my_data_connector._get_full_file_path(path="bigfile_1.csv")
+        my_data_connector._get_full_file_path(path="bigfile_1.csv")  # noqa: SLF001
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
     )
 

--- a/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
@@ -971,7 +971,9 @@ def test_s3_checkpoint_run_using_different_store_prefixes_successfully(
     context.validations_store_name = "validations_S3_store"
     context.expectations_store_name = "expectations_S3_store"
     assert len(context.stores) == 7
-    assert isinstance(context.expectations_store._store_backend, TupleS3StoreBackend)
+    assert isinstance(
+        context.expectations_store._store_backend, TupleS3StoreBackend  # noqa: SLF001
+    )
 
     datasource = context.sources.add_or_update_pandas_s3(
         name="s3_datasource", bucket=bucket
@@ -1054,7 +1056,9 @@ def test_s3_checkpoint_run_using_same_store_prefixes_errors(
     context.validations_store_name = "validations_S3_store"
     context.expectations_store_name = "expectations_S3_store"
     assert len(context.stores) == 7
-    assert isinstance(context.expectations_store._store_backend, TupleS3StoreBackend)
+    assert isinstance(
+        context.expectations_store._store_backend, TupleS3StoreBackend  # noqa: SLF001
+    )
 
     datasource = context.sources.add_or_update_pandas_s3(
         name="s3_datasource", bucket=bucket

--- a/tests/datasource/fluent/integration/integration_test_utils.py
+++ b/tests/datasource/fluent/integration/integration_test_utils.py
@@ -95,7 +95,9 @@ def run_checkpoint_and_data_doc(
     checkpoint_result = checkpoint.run()
 
     # Verify checkpoint runs successfully
-    assert checkpoint_result._success, "Running expectation suite failed"
+    assert (
+        checkpoint_result._success  # noqa: SLF001
+    ), "Running expectation suite failed"
     number_of_runs = len(checkpoint_result.run_results)
     assert (
         number_of_runs == 1

--- a/tests/datasource/fluent/test_config.py
+++ b/tests/datasource/fluent/test_config.py
@@ -868,7 +868,7 @@ def test_config_substitution_retains_original_value_on_save(
         == my_conn_str
     )
 
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     round_tripped = cast(
         dict, yaml.load(file_dc_config_file_with_substitutions.read_text())
@@ -918,7 +918,7 @@ def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
         "new_asset", table_name="yellow_tripdata_sample_2019_01"
     )
 
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     round_tripped_datasources = cast(
         dict, yaml.load(file_dc_config_file_with_substitutions.read_text())

--- a/tests/datasource/fluent/test_contexts.py
+++ b/tests/datasource/fluent/test_contexts.py
@@ -55,7 +55,7 @@ def test_add_fluent_datasource_are_persisted(
     mocker: MockerFixture,
 ):
     context = empty_cloud_context_fluent
-    set_spy = mocker.spy(context._datasource_store, "set")
+    set_spy = mocker.spy(context._datasource_store, "set")  # noqa: SLF001
 
     datasource_name = "save_ds_test"
 
@@ -157,7 +157,7 @@ def test_delete_asset_with_cloud_data_context(
     mocker: MockerFixture,
 ):
     context = seeded_cloud_context
-    remove_key_spy = mocker.spy(context._data_asset_store, "remove_key")
+    remove_key_spy = mocker.spy(context._data_asset_store, "remove_key")  # noqa: SLF001
 
     datasource_name = "my_pg_ds"
     datasource = context.fluent_datasources[datasource_name]
@@ -420,7 +420,10 @@ def test_data_connectors_are_built_on_config_load(
             dc_datasources[datasource.type].append(datasource.name)
 
             for asset in datasource.assets:
-                assert isinstance(asset._data_connector, datasource.data_connector_type)
+                assert isinstance(
+                    asset._data_connector,  # noqa: SLF001
+                    datasource.data_connector_type,
+                )
             print()
 
     print(f"Datasources with DataConnectors\n{pf(dict(dc_datasources))}")

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -72,7 +72,7 @@ class DataContext:
             cls._config = GxConfig.parse_yaml(config_path)
             for ds_name, datasource in cls._config.datasources.items():
                 logger.info(f"Loaded '{ds_name}' from config")
-                cls._context._add_fluent_datasource(datasource)
+                cls._context._add_fluent_datasource(datasource)  # noqa: SLF001
                 # TODO: add assets?
 
         return cls._context
@@ -137,7 +137,9 @@ def context_sources_cleanup() -> _SourceFactories:
     """Return the sources object and reset types/factories on teardown"""
     try:
         # setup
-        sources_copy = copy.deepcopy(_SourceFactories._SourceFactories__crud_registry)
+        sources_copy = copy.deepcopy(
+            _SourceFactories._SourceFactories__crud_registry  # noqa: SLF001
+        )
         type_lookup_copy = copy.deepcopy(_SourceFactories.type_lookup)
         sources = get_context().sources
 
@@ -147,13 +149,13 @@ def context_sources_cleanup() -> _SourceFactories:
 
         yield sources
     finally:
-        _SourceFactories._SourceFactories__crud_registry = sources_copy
+        _SourceFactories._SourceFactories__crud_registry = sources_copy  # noqa: SLF001
         _SourceFactories.type_lookup = type_lookup_copy
 
 
 @pytest.fixture(scope="function")
 def empty_sources(context_sources_cleanup) -> _SourceFactories:
-    _SourceFactories._SourceFactories__crud_registry.clear()
+    _SourceFactories._SourceFactories__crud_registry.clear()  # noqa: SLF001
     _SourceFactories.type_lookup.clear()
     assert not _SourceFactories.type_lookup
     yield context_sources_cleanup
@@ -263,12 +265,12 @@ class TestMetaDatasource:
             def execution_engine_type(self) -> Type[ExecutionEngine]:
                 return DummyExecutionEngine
 
-        print(f" type_lookup ->\n{pf(FooBarDatasource._type_lookup)}\n")
+        print(f" type_lookup ->\n{pf(FooBarDatasource._type_lookup)}\n")  # noqa: SLF001
         asset_types = FooBarDatasource.asset_types
         assert asset_types, "No asset types have been declared"
 
         registered_type_names = [
-            FooBarDatasource._type_lookup.get(t) for t in asset_types
+            FooBarDatasource._type_lookup.get(t) for t in asset_types  # noqa: SLF001
         ]
         for type_, name in zip(asset_types, registered_type_names):
             print(f"`{type_.__name__}` registered as '{name}'")

--- a/tests/datasource/fluent/test_pandas_azure_blob_storage_datasource.py
+++ b/tests/datasource/fluent/test_pandas_azure_blob_storage_datasource.py
@@ -79,7 +79,7 @@ def _build_pandas_abs_datasource(
         name="pandas_abs_datasource",
         azure_options=azure_options or {},
     )
-    pandas_abs_datasource._azure_client = azure_client
+    pandas_abs_datasource._azure_client = azure_client  # noqa: SLF001
     return pandas_abs_datasource
 
 
@@ -131,9 +131,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: AzureBlobStorageDataConnector = cast(
-        AzureBlobStorageDataConnector, csv_asset._data_connector
+        AzureBlobStorageDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file belonging to account "{csv_asset.datasource._account_name}" in container "{data_connector._container}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset}"."""
+    test_connection_error_message = f"""No file belonging to account "{csv_asset.datasource._account_name}" in container "{data_connector._container}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -146,7 +146,9 @@ def test_construct_pandas_abs_datasource_with_account_url_and_credential():
             "credential": "my_credential",
         },
     )
-    azure_client: azure.BlobServiceClient = pandas_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        pandas_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert pandas_abs_datasource.name == "pandas_abs_datasource"
 
@@ -166,7 +168,7 @@ def test_construct_pandas_abs_datasource_with_account_url_and_config_credential(
     )
 
     # attach data_context to enable config substitution
-    pandas_abs_datasource._data_context = empty_file_context
+    pandas_abs_datasource._data_context = empty_file_context  # noqa: SLF001
 
     credential = pandas_abs_datasource.azure_options["credential"]
     assert isinstance(credential, ConfigStr)
@@ -175,7 +177,9 @@ def test_construct_pandas_abs_datasource_with_account_url_and_config_credential(
         == "my_secret_credential"
     )
 
-    azure_client: azure.BlobServiceClient = pandas_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        pandas_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert pandas_abs_datasource.name == "pandas_abs_datasource"
 
@@ -189,7 +193,9 @@ def test_construct_pandas_abs_datasource_with_conn_str_and_credential():
             "credential": "my_credential",
         },
     )
-    azure_client: azure.BlobServiceClient = pandas_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        pandas_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert pandas_abs_datasource.name == "pandas_abs_datasource"
 
@@ -203,7 +209,9 @@ def test_construct_pandas_abs_datasource_with_valid_account_url_assigns_account_
             "credential": "my_credential",
         },
     )
-    azure_client: azure.BlobServiceClient = pandas_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        pandas_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert pandas_abs_datasource.name == "pandas_abs_datasource"
 
@@ -217,7 +225,9 @@ def test_construct_pandas_abs_datasource_with_valid_conn_str_assigns_account_nam
             "credential": "my_credential",
         },
     )
-    azure_client: azure.BlobServiceClient = pandas_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        pandas_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert pandas_abs_datasource.name == "pandas_abs_datasource"
 
@@ -234,7 +244,7 @@ def test_construct_pandas_abs_datasource_with_multiple_auth_methods_raises_error
                 "credential": "my_credential",
             },
         )
-        _ = pandas_abs_datasource._get_azure_client()
+        _ = pandas_abs_datasource._get_azure_client()  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -456,20 +466,22 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = pandas_abs_datasource
+    csv_asset._datasource = pandas_abs_datasource  # noqa: SLF001
     pandas_abs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = AzureBlobStorageDataConnector(
+    csv_asset._data_connector = AzureBlobStorageDataConnector(  # noqa: SLF001
         datasource_name=pandas_abs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
-        azure_client=pandas_abs_datasource._azure_client,
-        account_name=csv_asset.datasource._account_name,
+        azure_client=pandas_abs_datasource._azure_client,  # noqa: SLF001
+        account_name=csv_asset.datasource._account_name,  # noqa: SLF001
         container="my_container",
         file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_HTTPS_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         pandas_abs_datasource.test_connection()

--- a/tests/datasource/fluent/test_pandas_datasource.py
+++ b/tests/datasource/fluent/test_pandas_datasource.py
@@ -137,7 +137,7 @@ class TestDynamicPandasAssets:
         }
         print(asset_class_names)
 
-        assert type_name in PandasDatasource._type_lookup
+        assert type_name in PandasDatasource._type_lookup  # noqa: SLF001
         assert type_name in asset_class_names
 
     @pytest.mark.parametrize("asset_class", _DYNAMIC_ASSET_TYPES)
@@ -490,7 +490,9 @@ def test_cloud_get_csv_asset_not_in_memory(valid_file_path: pathlib.Path):
     csv_asset = datasource.get_asset(asset_name=csv_asset_name)
     csv_asset.build_batch_request()
 
-    assert csv_asset_name not in context.datasources._in_memory_data_assets
+    assert (
+        csv_asset_name not in context.datasources._in_memory_data_assets  # noqa: SLF001
+    )
 
 
 @pytest.mark.filesystem

--- a/tests/datasource/fluent/test_pandas_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_pandas_dbfs_datasource.py
@@ -81,7 +81,7 @@ def pandas_dbfs_datasource(
         name="pandas_dbfs_datasource",
         base_directory=pathlib.Path(base_directory),
     )
-    pandas_dbfs_datasource._data_context = empty_data_context
+    pandas_dbfs_datasource._data_context = empty_data_context  # noqa: SLF001
 
     return pandas_dbfs_datasource
 
@@ -101,9 +101,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: DBFSDataConnector = cast(
-        DBFSDataConnector, csv_asset._data_connector
+        DBFSDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file at base_directory path "{data_connector._base_directory.resolve()}" matched regular expressions pattern "{data_connector._batching_regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_asset"."""
+    test_connection_error_message = f"""No file at base_directory path "{data_connector._base_directory.resolve()}" matched regular expressions pattern "{data_connector._batching_regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_asset"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -188,11 +188,11 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = pandas_dbfs_datasource
+    csv_asset._datasource = pandas_dbfs_datasource  # noqa: SLF001
     pandas_dbfs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = DBFSDataConnector(
+    csv_asset._data_connector = DBFSDataConnector(  # noqa: SLF001
         datasource_name=pandas_dbfs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
@@ -201,7 +201,9 @@ def test_test_connection_failures(
         glob_directive="*.csv",
         file_path_template_map_fn=DBFSPath.convert_to_file_semantics_version,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         pandas_dbfs_datasource.test_connection()

--- a/tests/datasource/fluent/test_pandas_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_pandas_filesystem_datasource.py
@@ -61,7 +61,7 @@ def pandas_filesystem_datasource(empty_data_context) -> PandasFilesystemDatasour
         name="pandas_filesystem_datasource",
         base_directory=base_directory_abs_path,
     )
-    pandas_filesystem_datasource._data_context = empty_data_context
+    pandas_filesystem_datasource._data_context = empty_data_context  # noqa: SLF001
     return pandas_filesystem_datasource
 
 
@@ -730,18 +730,18 @@ def datasource_test_connection_error_messages(
         name="csv_asset",
         batching_regex=batching_regex,
     )
-    csv_asset._datasource = pandas_filesystem_datasource
+    csv_asset._datasource = pandas_filesystem_datasource  # noqa: SLF001
     pandas_filesystem_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = FilesystemDataConnector(
+    csv_asset._data_connector = FilesystemDataConnector(  # noqa: SLF001
         datasource_name=pandas_filesystem_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=batching_regex,
         base_directory=pandas_filesystem_datasource.base_directory,
         data_context_root_directory=pandas_filesystem_datasource.data_context_root_directory,
     )
-    csv_asset._test_connection_error_message = test_connection_error
+    csv_asset._test_connection_error_message = test_connection_error  # noqa: SLF001
     return pandas_filesystem_datasource, test_connection_error
 
 
@@ -769,7 +769,7 @@ def test_csv_asset_batch_metadata(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     my_config_variables = {"pipeline_filename": __file__}
-    pandas_filesystem_datasource._data_context.config_variables.update(  # type: ignore[union-attr] # `_data_context`
+    pandas_filesystem_datasource._data_context.config_variables.update(  # type: ignore[union-attr] # `_data_context`  # noqa: SLF001
         my_config_variables
     )
 

--- a/tests/datasource/fluent/test_pandas_google_cloud_storage_datasource.py
+++ b/tests/datasource/fluent/test_pandas_google_cloud_storage_datasource.py
@@ -67,7 +67,7 @@ def _build_pandas_gcs_datasource(
         bucket_or_name="test_bucket",
         gcs_options=gcs_options or {},
     )
-    pandas_gcs_datasource._gcs_client = gcs_client
+    pandas_gcs_datasource._gcs_client = gcs_client  # noqa: SLF001
     return pandas_gcs_datasource
 
 
@@ -118,9 +118,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: GoogleCloudStorageDataConnector = cast(
-        GoogleCloudStorageDataConnector, csv_asset._data_connector
+        GoogleCloudStorageDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket_or_name}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""
+    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket_or_name}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -135,7 +135,7 @@ def test_construct_pandas_gcs_datasource_without_gcs_options():
         bucket_or_name="test_bucket",
         gcs_options={},
     )
-    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
@@ -157,7 +157,7 @@ def test_construct_pandas_gcs_datasource_with_filename_in_gcs_options(
             "filename": "my_filename.csv",
         },
     )
-    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
@@ -179,7 +179,7 @@ def test_construct_pandas_gcs_datasource_with_info_in_gcs_options(
             "info": "{my_csv: my_content,}",
         },
     )
-    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = pandas_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
@@ -395,19 +395,21 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = pandas_gcs_datasource
+    csv_asset._datasource = pandas_gcs_datasource  # noqa: SLF001
     pandas_gcs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = GoogleCloudStorageDataConnector(
+    csv_asset._data_connector = GoogleCloudStorageDataConnector(  # noqa: SLF001
         datasource_name=pandas_gcs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
-        gcs_client=pandas_gcs_datasource._gcs_client,
+        gcs_client=pandas_gcs_datasource._gcs_client,  # noqa: SLF001
         bucket_or_name=pandas_gcs_datasource.bucket_or_name,
         file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         pandas_gcs_datasource.test_connection()

--- a/tests/datasource/fluent/test_pandas_s3_datasource.py
+++ b/tests/datasource/fluent/test_pandas_s3_datasource.py
@@ -112,7 +112,7 @@ def pandas_s3_datasource(
         name="pandas_s3_datasource",
         bucket=s3_bucket,
     )
-    pandas_s3_datasource._data_context = empty_data_context
+    pandas_s3_datasource._data_context = empty_data_context  # noqa: SLF001
 
     return pandas_s3_datasource
 
@@ -131,8 +131,10 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
     regex = re.compile(
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
-    data_connector: S3DataConnector = cast(S3DataConnector, csv_asset._data_connector)
-    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""
+    data_connector: S3DataConnector = cast(
+        S3DataConnector, csv_asset._data_connector  # noqa: SLF001
+    )
+    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -395,11 +397,11 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = pandas_s3_datasource
+    csv_asset._datasource = pandas_s3_datasource  # noqa: SLF001
     pandas_s3_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = S3DataConnector(
+    csv_asset._data_connector = S3DataConnector(  # noqa: SLF001
         datasource_name=pandas_s3_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
@@ -407,7 +409,9 @@ def test_test_connection_failures(
         bucket=pandas_s3_datasource.bucket,
         file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         pandas_s3_datasource.test_connection()

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -94,7 +94,7 @@ def _source(
             create_temp_table=create_temp_table,
         )
         if data_context:
-            postgres_datasource._data_context = data_context
+            postgres_datasource._data_context = data_context  # noqa: SLF001
         yield postgres_datasource
     finally:
         PostgresDatasource.execution_engine_override = original_override  # type: ignore[misc]
@@ -230,7 +230,7 @@ def test_construct_table_asset_directly_with_no_splitter(create_source):
         validate_batch_spec=lambda _: None, dialect="postgresql"
     ) as source:
         asset = TableAsset(name="my_asset", table_name="my_table")
-        asset._datasource = source
+        asset._datasource = source  # noqa: SLF001
         assert_batch_request(
             asset.build_batch_request(), "my_datasource", "my_asset", {}
         )
@@ -248,7 +248,7 @@ def create_and_add_table_asset_without_testing_connection(
         splitter=splitter,
     )
     # TODO: asset custom init
-    table_asset._datasource = source
+    table_asset._datasource = source  # noqa: SLF001
     source.assets.append(table_asset)
     return source, table_asset
 
@@ -1422,7 +1422,7 @@ def test_create_temp_table(empty_data_context, create_source):
         assert source.create_temp_table is False
         asset = source.add_query_asset(name="query_asset", query="SELECT * from table")
         _ = asset.get_batch_list_from_batch_request(asset.build_batch_request())
-        assert source._execution_engine._create_temp_table is False
+        assert source._execution_engine._create_temp_table is False  # noqa: SLF001
 
 
 @pytest.mark.postgresql

--- a/tests/datasource/fluent/test_snowflake_datasource.py
+++ b/tests/datasource/fluent/test_snowflake_datasource.py
@@ -64,7 +64,7 @@ def test_valid_config(
     my_sf_ds_1 = SnowflakeDatasource(name="my_sf_ds_1", **config_kwargs)
     assert my_sf_ds_1
 
-    my_sf_ds_1._data_context = (
+    my_sf_ds_1._data_context = (  # noqa: SLF001
         empty_file_context  # attach to enable config substitution
     )
     sql_engine = my_sf_ds_1.get_engine()

--- a/tests/datasource/fluent/test_spark_azure_blob_storage_datasource.py
+++ b/tests/datasource/fluent/test_spark_azure_blob_storage_datasource.py
@@ -64,7 +64,7 @@ def _build_spark_abs_datasource(
         name="spark_abs_datasource",
         azure_options=azure_options or {},
     )
-    spark_abs_datasource._azure_client = azure_client
+    spark_abs_datasource._azure_client = azure_client  # noqa: SLF001
     return spark_abs_datasource
 
 
@@ -116,9 +116,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: AzureBlobStorageDataConnector = cast(
-        AzureBlobStorageDataConnector, csv_asset._data_connector
+        AzureBlobStorageDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file belonging to account "{csv_asset.datasource._account_name}" in container "{data_connector._container}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset}"."""
+    test_connection_error_message = f"""No file belonging to account "{csv_asset.datasource._account_name}" in container "{data_connector._container}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -132,7 +132,9 @@ def test_construct_spark_abs_datasource_with_account_url_and_credential():
         },
     )
     # noinspection PyUnresolvedReferences
-    azure_client: azure.BlobServiceClient = spark_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        spark_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert spark_abs_datasource.name == "spark_abs_datasource"
 
@@ -147,7 +149,9 @@ def test_construct_spark_abs_datasource_with_conn_str_and_credential():
         },
     )
     # noinspection PyUnresolvedReferences
-    azure_client: azure.BlobServiceClient = spark_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        spark_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert spark_abs_datasource.name == "spark_abs_datasource"
 
@@ -162,7 +166,9 @@ def test_construct_spark_abs_datasource_with_valid_account_url_assigns_account_n
         },
     )
     # noinspection PyUnresolvedReferences
-    azure_client: azure.BlobServiceClient = spark_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        spark_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert spark_abs_datasource.name == "spark_abs_datasource"
 
@@ -177,7 +183,9 @@ def test_construct_spark_abs_datasource_with_valid_conn_str_assigns_account_name
         },
     )
     # noinspection PyUnresolvedReferences
-    azure_client: azure.BlobServiceClient = spark_abs_datasource._get_azure_client()
+    azure_client: azure.BlobServiceClient = (
+        spark_abs_datasource._get_azure_client()  # noqa: SLF001
+    )
     assert azure_client is not None
     assert spark_abs_datasource.name == "spark_abs_datasource"
 
@@ -195,7 +203,7 @@ def test_construct_spark_abs_datasource_with_multiple_auth_methods_raises_error(
             },
         )
         # noinspection PyUnresolvedReferences
-        _ = spark_abs_datasource._get_azure_client()
+        _ = spark_abs_datasource._get_azure_client()  # noqa: SLF001
 
 
 # noinspection PyUnusedLocal
@@ -423,20 +431,22 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = spark_abs_datasource
+    csv_asset._datasource = spark_abs_datasource  # noqa: SLF001
     spark_abs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = AzureBlobStorageDataConnector(
+    csv_asset._data_connector = AzureBlobStorageDataConnector(  # noqa: SLF001
         datasource_name=spark_abs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
-        azure_client=spark_abs_datasource._azure_client,  # type: ignore[arg-type] # _azure_client could be None
-        account_name=csv_asset.datasource._account_name,
+        azure_client=spark_abs_datasource._azure_client,  # type: ignore[arg-type] # _azure_client could be None  # noqa: SLF001
+        account_name=csv_asset.datasource._account_name,  # noqa: SLF001
         container="my_container",
         file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_HTTPS_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         spark_abs_datasource.test_connection()

--- a/tests/datasource/fluent/test_spark_dbfs_datasource.py
+++ b/tests/datasource/fluent/test_spark_dbfs_datasource.py
@@ -86,9 +86,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: DBFSDataConnector = cast(
-        DBFSDataConnector, csv_asset._data_connector
+        DBFSDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file at base_directory path "{data_connector._base_directory.resolve()}" matched regular expressions pattern "{data_connector._batching_regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_asset"."""
+    test_connection_error_message = f"""No file at base_directory path "{data_connector._base_directory.resolve()}" matched regular expressions pattern "{data_connector._batching_regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_asset"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -182,11 +182,11 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = spark_dbfs_datasource
+    csv_asset._datasource = spark_dbfs_datasource  # noqa: SLF001
     spark_dbfs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = DBFSDataConnector(
+    csv_asset._data_connector = DBFSDataConnector(  # noqa: SLF001
         datasource_name=spark_dbfs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
@@ -195,7 +195,9 @@ def test_test_connection_failures(
         glob_directive="*.csv",
         file_path_template_map_fn=DBFSPath.convert_to_protocol_version,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         spark_dbfs_datasource.test_connection()

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -67,7 +67,7 @@ def spark_filesystem_datasource(
         name="spark_filesystem_datasource",
         base_directory=base_directory_abs_path,
     )
-    spark_filesystem_datasource._data_context = empty_data_context
+    spark_filesystem_datasource._data_context = empty_data_context  # noqa: SLF001
     return spark_filesystem_datasource
 
 
@@ -421,7 +421,7 @@ def test__get_reader_options_include(
     """Make sure options are in fields."""
     fields = set(asset_type.__fields__.keys())
     asset = asset_type.validate(required_fields)
-    for option in asset._get_reader_options_include():
+    for option in asset._get_reader_options_include():  # noqa: SLF001
         assert option in fields
 
 
@@ -1046,18 +1046,18 @@ def datasource_test_connection_error_messages(
         name="csv_asset",
         batching_regex=batching_regex,
     )
-    csv_asset._datasource = spark_filesystem_datasource
+    csv_asset._datasource = spark_filesystem_datasource  # noqa: SLF001
     spark_filesystem_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = FilesystemDataConnector(
+    csv_asset._data_connector = FilesystemDataConnector(  # noqa: SLF001
         datasource_name=spark_filesystem_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=batching_regex,
         base_directory=spark_filesystem_datasource.base_directory,
         data_context_root_directory=spark_filesystem_datasource.data_context_root_directory,
     )
-    csv_asset._test_connection_error_message = test_connection_error
+    csv_asset._test_connection_error_message = test_connection_error  # noqa: SLF001
     return spark_filesystem_datasource, test_connection_error
 
 

--- a/tests/datasource/fluent/test_spark_google_cloud_storage_datasource.py
+++ b/tests/datasource/fluent/test_spark_google_cloud_storage_datasource.py
@@ -58,7 +58,7 @@ def _build_spark_gcs_datasource(
         bucket_or_name="test_bucket",
         gcs_options=gcs_options or {},
     )
-    spark_gcs_datasource._gcs_client = gcs_client
+    spark_gcs_datasource._gcs_client = gcs_client  # noqa: SLF001
     return spark_gcs_datasource
 
 
@@ -109,9 +109,9 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
     data_connector: GoogleCloudStorageDataConnector = cast(
-        GoogleCloudStorageDataConnector, csv_asset._data_connector
+        GoogleCloudStorageDataConnector, csv_asset._data_connector  # noqa: SLF001
     )
-    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket_or_name}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""
+    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket_or_name}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -127,7 +127,7 @@ def test_construct_spark_gcs_datasource_without_gcs_options():
         gcs_options={},
     )
     # noinspection PyUnresolvedReferences
-    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
@@ -150,7 +150,7 @@ def test_construct_spark_gcs_datasource_with_filename_in_gcs_options(
         },
     )
     # noinspection PyUnresolvedReferences
-    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
@@ -173,7 +173,7 @@ def test_construct_spark_gcs_datasource_with_info_in_gcs_options(
         },
     )
     # noinspection PyUnresolvedReferences
-    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()
+    gcs_client: google.Client = spark_gcs_datasource._get_gcs_client()  # noqa: SLF001
     assert gcs_client is not None
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
@@ -395,19 +395,21 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = spark_gcs_datasource
+    csv_asset._datasource = spark_gcs_datasource  # noqa: SLF001
     spark_gcs_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = GoogleCloudStorageDataConnector(
+    csv_asset._data_connector = GoogleCloudStorageDataConnector(  # noqa: SLF001
         datasource_name=spark_gcs_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
-        gcs_client=spark_gcs_datasource._gcs_client,
+        gcs_client=spark_gcs_datasource._gcs_client,  # noqa: SLF001
         bucket_or_name=spark_gcs_datasource.bucket_or_name,
         file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         spark_gcs_datasource.test_connection()

--- a/tests/datasource/fluent/test_spark_s3_datasource.py
+++ b/tests/datasource/fluent/test_spark_s3_datasource.py
@@ -111,8 +111,10 @@ def bad_regex_config(csv_asset: CSVAsset) -> tuple[re.Pattern, str]:
     regex = re.compile(
         r"(?P<name>.+)_(?P<ssn>\d{9})_(?P<timestamp>.+)_(?P<price>\d{4})\.csv"
     )
-    data_connector: S3DataConnector = cast(S3DataConnector, csv_asset._data_connector)
-    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""
+    data_connector: S3DataConnector = cast(
+        S3DataConnector, csv_asset._data_connector  # noqa: SLF001
+    )
+    test_connection_error_message = f"""No file in bucket "{csv_asset.datasource.bucket}" with prefix "{data_connector._prefix}" matched regular expressions pattern "{regex.pattern}" using delimiter "{data_connector._delimiter}" for DataAsset "{csv_asset.name}"."""  # noqa: SLF001
     return regex, test_connection_error_message
 
 
@@ -285,11 +287,11 @@ def test_test_connection_failures(
         name="csv_asset",
         batching_regex=regex,
     )
-    csv_asset._datasource = spark_s3_datasource
+    csv_asset._datasource = spark_s3_datasource  # noqa: SLF001
     spark_s3_datasource.assets = [
         csv_asset,
     ]
-    csv_asset._data_connector = S3DataConnector(
+    csv_asset._data_connector = S3DataConnector(  # noqa: SLF001
         datasource_name=spark_s3_datasource.name,
         data_asset_name=csv_asset.name,
         batching_regex=re.compile(regex),
@@ -297,7 +299,9 @@ def test_test_connection_failures(
         bucket=spark_s3_datasource.bucket,
         file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
     )
-    csv_asset._test_connection_error_message = test_connection_error_message
+    csv_asset._test_connection_error_message = (  # noqa: SLF001
+        test_connection_error_message
+    )
 
     with pytest.raises(TestConnectionError) as e:
         spark_s3_datasource.test_connection()

--- a/tests/datasource/fluent/test_sqlite_datasource.py
+++ b/tests/datasource/fluent/test_sqlite_datasource.py
@@ -104,7 +104,7 @@ def _create_sqlite_source(
             create_temp_table=create_temp_table,
         )
         if data_context:
-            sqlite_datasource._data_context = data_context
+            sqlite_datasource._data_context = data_context  # noqa: SLF001
         yield sqlite_datasource
     finally:
         SqliteDatasource.execution_engine_override = original_override  # type: ignore[misc]
@@ -196,4 +196,4 @@ def test_create_temp_table(empty_data_context, create_sqlite_source):
         assert source.create_temp_table is False
         asset = source.add_query_asset(name="query_asset", query="SELECT * from table")
         _ = asset.get_batch_list_from_batch_request(asset.build_batch_request())
-        assert source._execution_engine._create_temp_table is False
+        assert source._execution_engine._create_temp_table is False  # noqa: SLF001

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -78,7 +78,7 @@ def test_fluent_simple_validate_workflow(seeded_file_context: FileDataContext):
 @pytest.mark.filesystem
 def test_save_project_does_not_break(seeded_file_context: FileDataContext):
     print(seeded_file_context.fluent_config)
-    seeded_file_context._save_project_config()
+    seeded_file_context._save_project_config()  # noqa: SLF001
 
 
 @pytest.mark.filesystem
@@ -103,7 +103,7 @@ def test_save_datacontext_persists_fluent_config(
     )
 
     context.fluent_config = fluent_only_config
-    context._save_project_config()
+    context._save_project_config()  # noqa: SLF001
 
     final_yaml = config_file.read_text()
     diff = difflib.ndiff(initial_yaml.splitlines(), final_yaml.splitlines())

--- a/tests/datasource/test_datasource_anonymizer.py
+++ b/tests/datasource/test_datasource_anonymizer.py
@@ -36,7 +36,7 @@ class CustomDatasource(Datasource):
 
 
 def test_datasource_anonymizer(datasource_anonymizer: DatasourceAnonymizer):
-    n1 = datasource_anonymizer._anonymize_datasource_info(
+    n1 = datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
         name="test_datasource",
         config={
             "name": "test_datasource",
@@ -56,7 +56,7 @@ def test_datasource_anonymizer(datasource_anonymizer: DatasourceAnonymizer):
         "anonymized_name": "04bf89e1fb7495b0904bbd5ae478fbe0",
         "parent_class": "Datasource",
     }
-    n2 = datasource_anonymizer._anonymize_datasource_info(
+    n2 = datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
         name="test_datasource",
         config={
             "name": "test_datasource",
@@ -69,7 +69,7 @@ def test_datasource_anonymizer(datasource_anonymizer: DatasourceAnonymizer):
         },
     )
     datasource_anonymizer_2 = DatasourceAnonymizer(aggregate_anonymizer=Anonymizer())
-    n3 = datasource_anonymizer_2._anonymize_datasource_info(
+    n3 = datasource_anonymizer_2._anonymize_datasource_info(  # noqa: SLF001
         name="test_datasource",
         config={
             "name": "test_datasource",
@@ -88,7 +88,7 @@ def test_datasource_anonymizer(datasource_anonymizer: DatasourceAnonymizer):
     assert n2["anonymized_class"] != n3["anonymized_class"]
 
     # Same anonymizer *does* produce the same result
-    n4 = datasource_anonymizer._anonymize_datasource_info(
+    n4 = datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
         name="test_datasource",
         config={
             "name": "test_datasource",
@@ -121,8 +121,10 @@ data_connectors:
         module_name: great_expectations.datasource.data_connector
 """
     config: CommentedMap = yaml.load(yaml_config)
-    anonymized_datasource = datasource_anonymizer._anonymize_datasource_info(
-        name=name, config=config
+    anonymized_datasource = (
+        datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
+            name=name, config=config
+        )
     )
     assert anonymized_datasource == {
         "anonymized_data_connectors": [
@@ -158,8 +160,10 @@ data_connectors:
         module_name: great_expectations.datasource.data_connector
 """
     config: CommentedMap = yaml.load(yaml_config)
-    anonymized_datasource = datasource_anonymizer._anonymize_datasource_info(
-        name=name, config=config
+    anonymized_datasource = (
+        datasource_anonymizer._anonymize_datasource_info(  # noqa: SLF001
+            name=name, config=config
+        )
     )
     assert anonymized_datasource == {
         "anonymized_name": "2642802d79d90ce6d147b0f9f61c3569",
@@ -194,7 +198,7 @@ introspection:
 """
     config: CommentedMap = yaml.load(yaml_config)
     anonymized_datasource = (
-        datasource_anonymizer._anonymize_simple_sqlalchemy_datasource(
+        datasource_anonymizer._anonymize_simple_sqlalchemy_datasource(  # noqa: SLF001
             name=name, config=config
         )
     )
@@ -226,7 +230,7 @@ introspection:
 """
     config: CommentedMap = yaml.load(yaml_config)
     anonymized_datasource = (
-        datasource_anonymizer._anonymize_simple_sqlalchemy_datasource(
+        datasource_anonymizer._anonymize_simple_sqlalchemy_datasource(  # noqa: SLF001
             name=name, config=config
         )
     )

--- a/tests/datasource/test_datasource_serialization.py
+++ b/tests/datasource/test_datasource_serialization.py
@@ -162,7 +162,7 @@ class TestDatasourceConfigSerialization:
     ):
         observed_dump = datasourceConfigSchema.dump(datasource_config)
 
-        round_tripped = DatasourceConfig._dict_round_trip(
+        round_tripped = DatasourceConfig._dict_round_trip(  # noqa: SLF001
             datasourceConfigSchema, observed_dump
         )
 

--- a/tests/datasource/test_pandas_datasource.py
+++ b/tests/datasource/test_pandas_datasource.py
@@ -172,7 +172,7 @@ def test_pandas_datasource_custom_data_asset(
     data_context_parameterized_expectation_suite.add_expectation_suite(
         expectation_suite_name="test"
     )
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         expectation_suite_name="test",
         batch_kwargs=data_context_parameterized_expectation_suite.build_batch_kwargs(
             datasource=name,
@@ -207,7 +207,7 @@ def test_pandas_source_read_csv(
     data_context_parameterized_expectation_suite.add_expectation_suite(
         expectation_suite_name="unicode"
     )
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         data_context_parameterized_expectation_suite.build_batch_kwargs(
             "mysource", "subdir_reader", "unicode"
         ),
@@ -228,7 +228,7 @@ def test_pandas_source_read_csv(
         },
     )
 
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         data_context_parameterized_expectation_suite.build_batch_kwargs(
             "mysource2", "subdir_reader", "unicode"
         ),
@@ -250,11 +250,13 @@ def test_pandas_source_read_csv(
     )
 
     with pytest.raises(UnicodeError, match="UTF-16 stream does not start with BOM"):
-        batch = data_context_parameterized_expectation_suite._get_batch_v2(
-            data_context_parameterized_expectation_suite.build_batch_kwargs(
-                "mysource3", "subdir_reader", "unicode"
-            ),
-            "unicode",
+        batch = (
+            data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
+                data_context_parameterized_expectation_suite.build_batch_kwargs(
+                    "mysource3", "subdir_reader", "unicode"
+                ),
+                "unicode",
+            )
         )
 
     with pytest.raises(LookupError, match="unknown encoding: blarg"):
@@ -262,12 +264,14 @@ def test_pandas_source_read_csv(
             "mysource3", "subdir_reader", "unicode"
         )
         batch_kwargs.update({"reader_options": {"encoding": "blarg"}})
-        batch = data_context_parameterized_expectation_suite._get_batch_v2(
-            batch_kwargs=batch_kwargs, expectation_suite_name="unicode"
+        batch = (
+            data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
+                batch_kwargs=batch_kwargs, expectation_suite_name="unicode"
+            )
         )
 
     with pytest.raises(LookupError, match="unknown encoding: blarg"):
-        batch = data_context_parameterized_expectation_suite._get_batch_v2(
+        batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
             expectation_suite_name="unicode",
             batch_kwargs=data_context_parameterized_expectation_suite.build_batch_kwargs(
                 "mysource",
@@ -277,7 +281,7 @@ def test_pandas_source_read_csv(
             ),
         )
 
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         batch_kwargs=data_context_parameterized_expectation_suite.build_batch_kwargs(
             "mysource2",
             "subdir_reader",
@@ -422,6 +426,8 @@ def test_pandas_datasource_processes_dataset_options(
 def test_infer_default_options_partial_functions(reader_fn):
     datasource = PandasDatasource()
     reader_fn_partial = partial(reader_fn)
-    assert datasource._infer_default_options(
+    assert datasource._infer_default_options(  # noqa: SLF001
         reader_fn_partial, {}
-    ) == datasource._infer_default_options(reader_fn, {})
+    ) == datasource._infer_default_options(  # noqa: SLF001
+        reader_fn, {}
+    )

--- a/tests/datasource/test_sparkdf_datasource.py
+++ b/tests/datasource/test_sparkdf_datasource.py
@@ -89,7 +89,7 @@ def test_sparkdf_datasource_custom_data_asset(
         name, "subdir_reader", "test"
     )
     batch_kwargs["reader_options"] = {"header": True, "inferSchema": True}
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         batch_kwargs=batch_kwargs,
         expectation_suite_name="test_sparkdf_datasource.default",
     )
@@ -135,7 +135,7 @@ def test_force_reuse_spark_context(
     df = spark.read.format("parquet").load(tmp_parquet_filename)
     batch_kwargs = {"dataset": df, "datasource": dataset_name}
     _ = data_context_parameterized_expectation_suite.add_expectation_suite(dataset_name)
-    batch = data_context_parameterized_expectation_suite._get_batch_v2(
+    batch = data_context_parameterized_expectation_suite._get_batch_v2(  # noqa: SLF001
         batch_kwargs=batch_kwargs, expectation_suite_name=dataset_name
     )
     results = batch.expect_column_max_to_be_between("col1", min_value=1, max_value=100)
@@ -443,4 +443,4 @@ def test_spark_datasource_processes_dataset_options(
     )
     dataset = validator.get_dataset()
     assert dataset.caching is False
-    assert dataset._persist is False
+    assert dataset._persist is False  # noqa: SLF001

--- a/tests/execution_engine/split_and_sample/test_sparkdf_execution_engine_splitting.py
+++ b/tests/execution_engine/split_and_sample/test_sparkdf_execution_engine_splitting.py
@@ -375,7 +375,7 @@ def test_get_batch_with_split_on_whole_table_s3(
         return mocked_reader_function
 
     spark_engine = basic_spark_df_execution_engine
-    spark_engine._get_reader_fn = mocked_get_reader_function
+    spark_engine._get_reader_fn = mocked_get_reader_function  # noqa: SLF001
 
     test_sparkdf = spark_engine.get_batch_data(
         S3BatchSpec(
@@ -412,7 +412,7 @@ def test_get_batch_with_split_on_whole_table_azure(
         return mocked_reader_function
 
     spark_engine = basic_spark_df_execution_engine
-    spark_engine._get_reader_fn = mocked_get_reader_function
+    spark_engine._get_reader_fn = mocked_get_reader_function  # noqa: SLF001
 
     test_sparkdf = spark_engine.get_batch_data(
         AzureBatchSpec(
@@ -449,7 +449,7 @@ def test_get_batch_with_split_on_whole_table_gcs(
         return mocked_reader_function
 
     spark_engine = basic_spark_df_execution_engine
-    spark_engine._get_reader_fn = mocked_get_reader_function
+    spark_engine._get_reader_fn = mocked_get_reader_function  # noqa: SLF001
 
     test_sparkdf = spark_engine.get_batch_data(
         GCSBatchSpec(

--- a/tests/execution_engine/test_pandas_execution_engine.py
+++ b/tests/execution_engine/test_pandas_execution_engine.py
@@ -40,19 +40,19 @@ def test_reader_fn():
     engine = PandasExecutionEngine()
 
     # Testing that can recognize basic excel file
-    fn = engine._get_reader_fn(path="myfile.xlsx")
+    fn = engine._get_reader_fn(path="myfile.xlsx")  # noqa: SLF001
     assert "<function read_excel" in str(fn)
 
     # Testing that can recognize basic sas7bdat file
-    fn_read_sas7bdat = engine._get_reader_fn(path="myfile.sas7bdat")
+    fn_read_sas7bdat = engine._get_reader_fn(path="myfile.sas7bdat")  # noqa: SLF001
     assert "<function read_sas" in str(fn_read_sas7bdat)
 
     # Testing that can recognize basic SAS xpt file
-    fn_read_xpt = engine._get_reader_fn(path="myfile.xpt")
+    fn_read_xpt = engine._get_reader_fn(path="myfile.xpt")  # noqa: SLF001
     assert "<function read_sas" in str(fn_read_xpt)
 
     # Ensuring that other way around works as well - reader_method should always override path
-    fn_new = engine._get_reader_fn(reader_method="read_csv")
+    fn_new = engine._get_reader_fn(reader_method="read_csv")  # noqa: SLF001
     assert "<function" in str(fn_new)
 
 
@@ -598,7 +598,7 @@ def test_get_batch_data_with_azure_batch_spec(
 def test_get_batch_with_no_azure_configured(azure_batch_spec):
     # if Azure BlobServiceClient was not configured
     execution_engine_no_azure = PandasExecutionEngine()
-    execution_engine_no_azure._azure = None
+    execution_engine_no_azure._azure = None  # noqa: SLF001
 
     # Raises error due the connection object not being set
     with pytest.raises(gx_exceptions.ExecutionEngineError):

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -35,11 +35,15 @@ pytestmark = pytest.mark.spark
 def test_reader_fn(spark_session, basic_spark_df_execution_engine):
     engine = basic_spark_df_execution_engine
     # Testing that can recognize basic csv file
-    fn = engine._get_reader_fn(reader=spark_session.read, path="myfile.csv")
+    fn = engine._get_reader_fn(  # noqa: SLF001
+        reader=spark_session.read, path="myfile.csv"
+    )
     assert "<bound method DataFrameReader.csv" in str(fn)
 
     # Ensuring that other way around works as well - reader_method should always override path
-    fn_new = engine._get_reader_fn(reader=spark_session.read, reader_method="csv")
+    fn_new = engine._get_reader_fn(  # noqa: SLF001
+        reader=spark_session.read, reader_method="csv"
+    )
     assert "<bound method DataFrameReader.csv" in str(fn_new)
 
 
@@ -55,7 +59,9 @@ def test_reader_fn_parameters(
     )
     test_df_small_csv_path = base_directory + "/test-A.csv"
     engine = basic_spark_df_execution_engine
-    fn = engine._get_reader_fn(reader=spark_session.read, path=test_df_small_csv_path)
+    fn = engine._get_reader_fn(  # noqa: SLF001
+        reader=spark_session.read, path=test_df_small_csv_path
+    )
     assert "<bound method DataFrameReader.csv" in str(fn)
 
     test_sparkdf_with_no_header_param = basic_spark_df_execution_engine.get_batch_data(

--- a/tests/execution_engine/test_sqlalchemy_batch_data.py
+++ b/tests/execution_engine/test_sqlalchemy_batch_data.py
@@ -172,7 +172,10 @@ def test_instantiation_with_temp_table_schema():
         create_temp_table=True,
         temp_table_schema_name="test_schema",
     )
-    (query_to_create_temp_table, temp_table_name) = batch_data._create_temporary_table(
+    (
+        query_to_create_temp_table,
+        temp_table_name,
+    ) = batch_data._create_temporary_table(  # noqa: SLF001
         dialect=GXSqlDialect.SQLITE,
         query="test_query",
         temp_table_schema_name="test_schema",
@@ -191,7 +194,7 @@ def test_instantiation_with_temp_table_schema():
         (
             query_to_create_temp_table,
             temp_table_name,
-        ) = batch_data._create_temporary_table(
+        ) = batch_data._create_temporary_table(  # noqa: SLF001
             dialect=GXSqlDialect.SQLITE,
             query="test_query",
             temp_table_schema_name="test_schema",

--- a/tests/expectations/metrics/column_map_metrics/test_column_values_in_set.py
+++ b/tests/expectations/metrics/column_map_metrics/test_column_values_in_set.py
@@ -29,7 +29,9 @@ def test_sqlalchemy_impl_bigquery_bool(value_set: List[Optional[bool]]):
     column_name = "my_bool_col"
     column = sqlalchemy.column(column_name)
     kwargs = _make_sqlalchemy_kwargs(column_name, sqlalchemy_bigquery)
-    predicate = ColumnValuesInSet._sqlalchemy_impl(column, value_set, **kwargs)
+    predicate = ColumnValuesInSet._sqlalchemy_impl(  # noqa: SLF001
+        column, value_set, **kwargs
+    )
     # If a value in value_set is None we expect "column_name is null" otherwise we expect
     # "column_name = value"
     expected_predicates = [
@@ -51,7 +53,9 @@ def test_sqlalchemy_impl_not_bigquery_bool(
     column_name = "my_bool_col"
     column = sqlalchemy.column(column_name)
     kwargs = _make_sqlalchemy_kwargs(column_name, dialect)
-    predicate = ColumnValuesInSet._sqlalchemy_impl(column, value_set, **kwargs)
+    predicate = ColumnValuesInSet._sqlalchemy_impl(  # noqa: SLF001
+        column, value_set, **kwargs
+    )
     expected_predicates = ", ".join(
         ["null" if value is None else str(value) for value in value_set]
     ).lower()

--- a/tests/expectations/metrics/table_metrics/test_table_head.py
+++ b/tests/expectations/metrics/table_metrics/test_table_head.py
@@ -147,7 +147,7 @@ def test_table_head_sqlite(
 ):
     engine = request.getfixturevalue(execution_engine)
     table_head = TableHead()
-    res = table_head._sqlalchemy(
+    res = table_head._sqlalchemy(  # noqa: SLF001
         execution_engine=engine,
         metric_domain_kwargs={},
         metric_value_kwargs={"n_rows": n_rows, "fetch_all": fetch_all},
@@ -193,7 +193,7 @@ def test_limit_included_in_head_query(
     with mock.patch(
         "great_expectations.compatibility.sqlalchemy_and_pandas.pd.read_sql"
     ) as mock_node:
-        table_head._sqlalchemy(
+        table_head._sqlalchemy(  # noqa: SLF001
             execution_engine=engine,
             metric_domain_kwargs={},
             metric_value_kwargs={"n_rows": n_rows, "fetch_all": fetch_all},

--- a/tests/expectations/metrics/test_metric_providers.py
+++ b/tests/expectations/metrics/test_metric_providers.py
@@ -45,7 +45,7 @@ def mock_registry(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         registry,
         "_registered_metrics",
-        copy.deepcopy(registry._registered_metrics),
+        copy.deepcopy(registry._registered_metrics),  # noqa: SLF001
         raising=True,
     )
     yield registry
@@ -53,7 +53,9 @@ def mock_registry(monkeypatch: pytest.MonkeyPatch):
 
 def test__base_metric_provider__registration(mock_registry):
     """This tests whether the MetricProvider class registers the correct metrics."""
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "custom_metric" not in key
 
@@ -99,15 +101,17 @@ def test__base_metric_provider__registration(mock_registry):
     CustomMetricProvider()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 1
     )
-    assert "custom_metric" in mock_registry._registered_metrics.keys()
+    assert "custom_metric" in mock_registry._registered_metrics.keys()  # noqa: SLF001
 
 
 def test__table_metric_provider__registration(mock_registry):
     """This tests whether the TableMetricProvider class registers the correct metrics."""
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "table.custom_metric" not in key
 
@@ -152,10 +156,13 @@ def test__table_metric_provider__registration(mock_registry):
     CustomTableMetricProvider()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 1
     )
-    assert "table.custom_metric" in mock_registry._registered_metrics.keys()
+    assert (
+        "table.custom_metric"
+        in mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
 
 
 def test__column_map_metric__registration(mock_registry):
@@ -165,7 +172,9 @@ def test__column_map_metric__registration(mock_registry):
 
     Since _register_metric_functions is private, we don't want to test it directly. Instead, we declare a custom ColumnMapMetricProvider, and test that the correct metrics are registered.
     """
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "column_values.equal_seven" not in key
 
@@ -190,7 +199,7 @@ def test__column_map_metric__registration(mock_registry):
     CustomColumnValuesEqualSeven()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 8
     )
 
@@ -205,12 +214,14 @@ def test__column_map_metric__registration(mock_registry):
         "column_values.equal_seven.unexpected_count.aggregate_fn",
     ]
     for key in new_keys:
-        assert key in mock_registry._registered_metrics.keys()
+        assert key in mock_registry._registered_metrics.keys()  # noqa: SLF001
 
 
 def test__column_pair_map_metric__registration(mock_registry):
     """This tests whether the ColumnPairMapMetricProvider class registers the correct metrics."""
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "column_pair_values.equal_seven" not in key
 
@@ -234,11 +245,11 @@ def test__column_pair_map_metric__registration(mock_registry):
     CustomColumnPairValuesEqualSeven()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 7
     )
 
-    for key in mock_registry._registered_metrics.keys():
+    for key in mock_registry._registered_metrics.keys():  # noqa: SLF001
         if "column_pair_values.equal_seven" in key:
             print(key)
 
@@ -252,12 +263,14 @@ def test__column_pair_map_metric__registration(mock_registry):
         "column_pair_values.equal_seven.filtered_row_count",
     ]
     for key in new_keys:
-        assert key in mock_registry._registered_metrics.keys()
+        assert key in mock_registry._registered_metrics.keys()  # noqa: SLF001
 
 
 def test__multicolumn_map_metric__registration(mock_registry):
     """This tests whether the MultiColumnMapMetricProvider class registers the correct metrics."""
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "multicolumn_values.equal_seven" not in key
 
@@ -291,7 +304,7 @@ def test__multicolumn_map_metric__registration(mock_registry):
     CustomMultiColumnValuesEqualSeven()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 7
     )
 
@@ -305,12 +318,14 @@ def test__multicolumn_map_metric__registration(mock_registry):
         "multicolumn_values.equal_seven.filtered_row_count",
     ]
     for key in new_keys:
-        assert key in mock_registry._registered_metrics.keys()
+        assert key in mock_registry._registered_metrics.keys()  # noqa: SLF001
 
 
 def test__query_metric_provider__registration(mock_registry):
     """This tests whether the QueryMetricProvider class registers the correct metrics."""
-    registered_metric_keys = list(mock_registry._registered_metrics.keys())
+    registered_metric_keys = list(
+        mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )
     for key in registered_metric_keys:
         assert "query.custom_metric" not in key
 
@@ -344,7 +359,10 @@ def test__query_metric_provider__registration(mock_registry):
     CustomQueryMetricProvider()
 
     assert (
-        len(mock_registry._registered_metrics.keys())
+        len(mock_registry._registered_metrics.keys())  # noqa: SLF001
         == prev_registered_metric_key_count + 1
     )
-    assert "query.custom_metric" in mock_registry._registered_metrics.keys()
+    assert (
+        "query.custom_metric"
+        in mock_registry._registered_metrics.keys()  # noqa: SLF001
+    )

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -97,7 +97,7 @@ def test_multicolumn_expectation_has_default_mostly(fake_expectation_cls, config
             False
         ), "Validate configuration threw an error when testing default mostly value"
     assert (
-        fake_expectation._get_success_kwargs().get("mostly") == 1
+        fake_expectation._get_success_kwargs().get("mostly") == 1  # noqa: SLF001
     ), "Default mostly success ratio is not 1"
 
 
@@ -140,7 +140,8 @@ def test_multicolumn_expectation_has_default_mostly(fake_expectation_cls, config
 def test_expectation_succeeds_with_valid_mostly(fake_expectation_cls, config):
     fake_expectation = fake_expectation_cls(**config.kwargs)
     assert (
-        fake_expectation._get_success_kwargs().get("mostly") == config.kwargs["mostly"]
+        fake_expectation._get_success_kwargs().get("mostly")  # noqa: SLF001
+        == config.kwargs["mostly"]
     ), "Default mostly success ratio is not 1"
 
 
@@ -185,7 +186,7 @@ def test_validate_dependencies_against_available_metrics_success(metrics_dict):
             "column": "i_exist",
         },
     )
-    expectation._validate_dependencies_against_available_metrics(
+    expectation._validate_dependencies_against_available_metrics(  # noqa: SLF001
         validation_dependencies=metric_config_list,
         metrics=metrics_dict,
     )
@@ -201,7 +202,7 @@ def test_validate_dependencies_against_available_metrics_failure(metrics_dict):
         },
     )
     with pytest.raises(InvalidExpectationConfigurationError):
-        expectation._validate_dependencies_against_available_metrics(
+        expectation._validate_dependencies_against_available_metrics(  # noqa: SLF001
             validation_dependencies=metric_config_list,
             metrics=metrics_dict,
         )

--- a/tests/expectations/test_expectation_arguments.py
+++ b/tests/expectations/test_expectation_arguments.py
@@ -812,11 +812,11 @@ def test_in_memory_runtime_context_configured_with_usage_stats_handler(
     # manually set usage statistics handler
     handler = UsageStatisticsHandler(
         data_context=context,
-        data_context_id=context._data_context_id,
+        data_context_id=context._data_context_id,  # noqa: SLF001
         oss_id=None,
         usage_statistics_url="http://fakeendpoint.com",
     )
-    context._usage_statistics_handler = handler
+    context._usage_statistics_handler = handler  # noqa: SLF001
 
     catch_exceptions: bool = False  # expect exceptions to be raised
     result_format: dict = {

--- a/tests/expectations/test_expectation_diagnostics.py
+++ b/tests/expectations/test_expectation_diagnostics.py
@@ -145,7 +145,7 @@ edr = ExpectationDiagnostics(
 
 def test__convert_checks_into_output_message():
     assert (
-        edr._convert_checks_into_output_message(
+        edr._convert_checks_into_output_message(  # noqa: SLF001
             class_name="ExpectColumnValuesToEqualThree",
             maturity_level="EXPERIMENTAL",
             maturity_messages=edr.maturity_checklist,
@@ -188,7 +188,7 @@ def test__count_unexpected_test_cases___with_everything_passing():
             error_diagnostics=None,
         ),
     ]
-    assert edr._count_unexpected_test_cases(tests) == 0
+    assert edr._count_unexpected_test_cases(tests) == 0  # noqa: SLF001
 
 
 def test__count_unexpected_test_cases__with_one_failure():
@@ -218,7 +218,7 @@ def test__count_unexpected_test_cases__with_one_failure():
             error_diagnostics=None,
         ),
     ]
-    assert edr._count_unexpected_test_cases(tests) == 1
+    assert edr._count_unexpected_test_cases(tests) == 1  # noqa: SLF001
 
 
 def test__count_unexpected_test_cases__with_an_error():
@@ -264,17 +264,17 @@ def test__count_unexpected_test_cases__with_an_error():
             error_diagnostics=None,
         ),
     ]
-    assert edr._count_unexpected_test_cases(tests) == 3
+    assert edr._count_unexpected_test_cases(tests) == 3  # noqa: SLF001
 
 
 def test__count_positive_and_negative_example_cases():
-    assert edr._count_positive_and_negative_example_cases(
+    assert edr._count_positive_and_negative_example_cases(  # noqa: SLF001
         [expectation_test_data_case]
     ) == (1, 1)
 
 
 def test__check_example_cases__with_enough_test_cases_but_all_failing():
-    assert ExpectationDiagnostics._check_example_cases(
+    assert ExpectationDiagnostics._check_example_cases(  # noqa: SLF001
         examples=[expectation_test_data_case],
         tests=[
             ExpectationTestDiagnostics(
@@ -303,7 +303,7 @@ def test__check_example_cases__with_enough_test_cases_but_all_failing():
 
 
 def test__check_example_cases__with_enough_test_cases_but_some_failing():
-    assert ExpectationDiagnostics._check_example_cases(
+    assert ExpectationDiagnostics._check_example_cases(  # noqa: SLF001
         examples=[expectation_test_data_case],
         tests=[
             ExpectationTestDiagnostics(
@@ -332,7 +332,7 @@ def test__check_example_cases__with_enough_test_cases_but_some_failing():
 
 
 def test__check_example_cases__with_enough_test_cases_and_no_failing():
-    assert ExpectationDiagnostics._check_example_cases(
+    assert ExpectationDiagnostics._check_example_cases(  # noqa: SLF001
         examples=[expectation_test_data_case],
         tests=[
             ExpectationTestDiagnostics(
@@ -387,7 +387,7 @@ def test__check_example_cases__with_enough_not_enough_test_cases_but_no_failing(
         ],
     )
 
-    assert ExpectationDiagnostics._check_example_cases(
+    assert ExpectationDiagnostics._check_example_cases(  # noqa: SLF001
         examples=[expectation_test_data_case],
         tests=[
             ExpectationTestDiagnostics(

--- a/tests/expectations/test_registry.py
+++ b/tests/expectations/test_registry.py
@@ -23,7 +23,10 @@ def test_registry_from_configuration():
         expectation_type="expect_column_values_to_be_in_set",
         kwargs={"column": "PClass", "value_set": [1, 2, 3]},
     )
-    assert configuration._get_expectation_impl() == ExpectColumnValuesToBeInSet
+    assert (
+        configuration._get_expectation_impl()  # noqa: SLF001
+        == ExpectColumnValuesToBeInSet
+    )
 
 
 def test_registry_raises_error_when_invalid_expectation_requested():

--- a/tests/expectations/test_run_diagnostics.py
+++ b/tests/expectations/test_run_diagnostics.py
@@ -354,24 +354,30 @@ def test_expectation__get_renderers():
     #     expectation_name,
     #     _registered_renderers,
     # )
-    examples = my_expectation._get_examples()
-    my_expectation_config = my_expectation._get_expectation_configuration_from_examples(
-        examples
+    examples = my_expectation._get_examples()  # noqa: SLF001
+    my_expectation_config = (
+        my_expectation._get_expectation_configuration_from_examples(  # noqa: SLF001
+            examples
+        )
     )
-    my_metric_diagnostics_list = my_expectation._get_metric_diagnostics_list(
-        expectation_config=my_expectation_config
+    my_metric_diagnostics_list = (
+        my_expectation._get_metric_diagnostics_list(  # noqa: SLF001
+            expectation_config=my_expectation_config
+        )
     )
-    my_execution_engine_diagnostics = my_expectation._get_execution_engine_diagnostics(
-        metric_diagnostics_list=my_metric_diagnostics_list,
-        registered_metrics=_registered_metrics,
+    my_execution_engine_diagnostics = (
+        my_expectation._get_execution_engine_diagnostics(  # noqa: SLF001
+            metric_diagnostics_list=my_metric_diagnostics_list,
+            registered_metrics=_registered_metrics,
+        )
     )
-    my_test_results = my_expectation._get_test_results(
+    my_test_results = my_expectation._get_test_results(  # noqa: SLF001
         expectation_type=expectation_name,
         test_data_cases=examples,
         execution_engine_diagnostics=my_execution_engine_diagnostics,
         raise_exceptions_for_backends=False,
     )
-    renderer_diagnostics = my_expectation._get_renderer_diagnostics(
+    renderer_diagnostics = my_expectation._get_renderer_diagnostics(  # noqa: SLF001
         expectation_type=expectation_name,
         test_diagnostics=my_test_results,
         registered_renderers=_registered_renderers,
@@ -415,24 +421,30 @@ def test_expectation__get_renderers():
     #     expectation_name,
     #     _registered_renderers,
     # )
-    examples = my_expectation._get_examples()
-    my_expectation_config = my_expectation._get_expectation_configuration_from_examples(
-        examples
+    examples = my_expectation._get_examples()  # noqa: SLF001
+    my_expectation_config = (
+        my_expectation._get_expectation_configuration_from_examples(  # noqa: SLF001
+            examples
+        )
     )
-    my_metric_diagnostics_list = my_expectation._get_metric_diagnostics_list(
-        expectation_config=my_expectation_config
+    my_metric_diagnostics_list = (
+        my_expectation._get_metric_diagnostics_list(  # noqa: SLF001
+            expectation_config=my_expectation_config
+        )
     )
-    my_execution_engine_diagnostics = my_expectation._get_execution_engine_diagnostics(
-        metric_diagnostics_list=my_metric_diagnostics_list,
-        registered_metrics=_registered_metrics,
+    my_execution_engine_diagnostics = (
+        my_expectation._get_execution_engine_diagnostics(  # noqa: SLF001
+            metric_diagnostics_list=my_metric_diagnostics_list,
+            registered_metrics=_registered_metrics,
+        )
     )
-    my_test_results = my_expectation._get_test_results(
+    my_test_results = my_expectation._get_test_results(  # noqa: SLF001
         expectation_type=expectation_name,
         test_data_cases=examples,
         execution_engine_diagnostics=my_execution_engine_diagnostics,
         raise_exceptions_for_backends=False,
     )
-    renderer_diagnostics = my_expectation._get_renderer_diagnostics(
+    renderer_diagnostics = my_expectation._get_renderer_diagnostics(  # noqa: SLF001
         expectation_type=expectation_name,
         test_diagnostics=my_test_results,
         registered_renderers=_registered_renderers,
@@ -466,24 +478,30 @@ def test_expectation__get_renderers():
     #     expectation_name,
     #     _registered_renderers,
     # )
-    examples = my_expectation._get_examples()
-    my_expectation_config = my_expectation._get_expectation_configuration_from_examples(
-        examples
+    examples = my_expectation._get_examples()  # noqa: SLF001
+    my_expectation_config = (
+        my_expectation._get_expectation_configuration_from_examples(  # noqa: SLF001
+            examples
+        )
     )
-    my_metric_diagnostics_list = my_expectation._get_metric_diagnostics_list(
-        expectation_config=my_expectation_config
+    my_metric_diagnostics_list = (
+        my_expectation._get_metric_diagnostics_list(  # noqa: SLF001
+            expectation_config=my_expectation_config
+        )
     )
-    my_execution_engine_diagnostics = my_expectation._get_execution_engine_diagnostics(
-        metric_diagnostics_list=my_metric_diagnostics_list,
-        registered_metrics=_registered_metrics,
+    my_execution_engine_diagnostics = (
+        my_expectation._get_execution_engine_diagnostics(  # noqa: SLF001
+            metric_diagnostics_list=my_metric_diagnostics_list,
+            registered_metrics=_registered_metrics,
+        )
     )
-    my_test_results = my_expectation._get_test_results(
+    my_test_results = my_expectation._get_test_results(  # noqa: SLF001
         expectation_type=expectation_name,
         test_data_cases=examples,
         execution_engine_diagnostics=my_execution_engine_diagnostics,
         raise_exceptions_for_backends=False,
     )
-    renderer_diagnostics = my_expectation._get_renderer_diagnostics(
+    renderer_diagnostics = my_expectation._get_renderer_diagnostics(  # noqa: SLF001
         expectation_type=expectation_name,
         test_diagnostics=my_test_results,
         registered_renderers=_registered_renderers,

--- a/tests/expectations/test_run_diagnostics_supporting_methods.py
+++ b/tests/expectations/test_run_diagnostics_supporting_methods.py
@@ -21,7 +21,7 @@ from tests.expectations.fixtures.expect_column_values_to_equal_three import (
 
 @pytest.mark.unit
 def test__get_augmented_library_metadata_on_a_class_with_no_library_metadata_object():
-    augmented_library_metadata = ExpectColumnValuesToEqualThree(
+    augmented_library_metadata = ExpectColumnValuesToEqualThree(  # noqa: SLF001
         column="values"
     )._get_augmented_library_metadata()
     assert augmented_library_metadata == AugmentedLibraryMetadata(
@@ -38,9 +38,11 @@ def test__get_augmented_library_metadata_on_a_class_with_no_library_metadata_obj
 
 @pytest.mark.unit
 def test__get_augmented_library_metadata_on_a_class_with_a_basic_library_metadata_object():
-    augmented_library_metadata = ExpectColumnValuesToEqualThree__SecondIteration(
-        column="values"
-    )._get_augmented_library_metadata()
+    augmented_library_metadata = (
+        ExpectColumnValuesToEqualThree__SecondIteration(  # noqa: SLF001
+            column="values"
+        )._get_augmented_library_metadata()
+    )
     assert augmented_library_metadata == AugmentedLibraryMetadata(
         maturity="EXPERIMENTAL",
         tags=["tag", "other_tag"],
@@ -57,12 +59,14 @@ def test__get_augmented_library_metadata_on_a_class_with_a_basic_library_metadat
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_no_examples():
-    assert ExpectColumnValuesToEqualThree(column="values")._get_examples() == []
+    expectation = ExpectColumnValuesToEqualThree(column="values")
+    examples = expectation._get_examples()  # noqa: SLF001
+    assert examples == []
 
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_some_examples():
-    examples = ExpectColumnValuesToEqualThree__SecondIteration(
+    examples = ExpectColumnValuesToEqualThree__SecondIteration(  # noqa: SLF001
         column="values"
     )._get_examples()
     assert len(examples) == 1
@@ -77,7 +81,7 @@ def test__get_examples_from_a_class_with_some_examples():
 
 @pytest.mark.unit
 def test__get_examples_from_a_class_with_return_only_gallery_examples_equals_false():
-    examples = ExpectColumnValuesToEqualThree__SecondIteration(
+    examples = ExpectColumnValuesToEqualThree__SecondIteration(  # noqa: SLF001
         column="values"
     )._get_examples(return_only_gallery_examples=False)
     assert len(examples) == 1
@@ -101,7 +105,7 @@ def test__get_description_diagnostics():
         It has more to it.
         """
 
-    description_diagnostics = ExpectColumnValuesToBeAwesome(
+    description_diagnostics = ExpectColumnValuesToBeAwesome(  # noqa: SLF001
         column="values"
     )._get_description_diagnostics()
     assert description_diagnostics == ExpectationDescriptionDiagnostics(
@@ -119,7 +123,7 @@ def test__get_description_diagnostics():
 @pytest.mark.unit
 def test__get_metric_diagnostics_list_on_a_class_without_metrics():
     _config = None
-    metric_diagnostics_list = ExpectColumnValuesToEqualThree(
+    metric_diagnostics_list = ExpectColumnValuesToEqualThree(  # noqa: SLF001
         column="values"
     )._get_metric_diagnostics_list(expectation_config=_config)
     assert len(metric_diagnostics_list) == 0
@@ -132,9 +136,11 @@ def test__get_metric_diagnostics_list_on_a_class_without_metrics():
 @pytest.mark.unit
 def test__get_metric_diagnostics_list_on_a_class_with_metrics():
     _config = None
-    metric_diagnostics_list = ExpectColumnValuesToEqualThree__ThirdIteration(
-        column="values"
-    )._get_metric_diagnostics_list(expectation_config=_config)
+    metric_diagnostics_list = (
+        ExpectColumnValuesToEqualThree__ThirdIteration(  # noqa: SLF001
+            column="values"
+        )._get_metric_diagnostics_list(expectation_config=_config)
+    )
     assert len(metric_diagnostics_list) == 0
     ExpectationMetricDiagnostics(
         name="column_values.something",
@@ -152,7 +158,7 @@ Metrics could be used to make inferences, but they'd never provide comparably co
 )
 @pytest.mark.unit
 def test__get_execution_engine_diagnostics_with_no_metrics_diagnostics():
-    assert ExpectColumnValuesToEqualThree__ThirdIteration._get_execution_engine_diagnostics(
+    assert ExpectColumnValuesToEqualThree__ThirdIteration._get_execution_engine_diagnostics(  # noqa: SLF001
         metric_diagnostics_list=[],
         registered_metrics={},
     ) == ExpectationExecutionEngineDiagnostics(
@@ -180,7 +186,7 @@ def test__get_execution_engine_diagnostics_with_one_metrics_diagnostics():
     registered_metrics = {
         "colum_values.something": {"providers": ["PandasExecutionEngine"]}
     }
-    assert ExpectColumnValuesToEqualThree__ThirdIteration._get_execution_engine_diagnostics(
+    assert ExpectColumnValuesToEqualThree__ThirdIteration._get_execution_engine_diagnostics(  # noqa: SLF001
         metric_diagnostics_list=metrics_diagnostics_list,
         registered_metrics=registered_metrics,
     ) == ExpectationExecutionEngineDiagnostics(
@@ -196,11 +202,11 @@ def test__get_execution_engine_diagnostics_with_one_metrics_diagnostics():
 )
 @pytest.mark.all_backends
 def test__get_test_results():
-    test_results = ExpectColumnValuesToEqualThree__ThirdIteration(
+    test_results = ExpectColumnValuesToEqualThree__ThirdIteration(  # noqa: SLF001
         column="values"
     )._get_test_results(
         expectation_type="expect_column_values_to_equal_three",
-        test_data_cases=ExpectColumnValuesToEqualThree__ThirdIteration(
+        test_data_cases=ExpectColumnValuesToEqualThree__ThirdIteration(  # noqa: SLF001
             column="values"
         )._get_examples(return_only_gallery_examples=False),
         execution_engine_diagnostics=ExpectationExecutionEngineDiagnostics(
@@ -213,11 +219,11 @@ def test__get_test_results():
     for result in test_results:
         assert result.test_passed
 
-    test_results = ExpectColumnValuesToEqualThree__ThirdIteration(
+    test_results = ExpectColumnValuesToEqualThree__ThirdIteration(  # noqa: SLF001
         column="values"
     )._get_test_results(
         expectation_type="expect_column_values_to_equal_three",
-        test_data_cases=ExpectColumnValuesToEqualThree__ThirdIteration(
+        test_data_cases=ExpectColumnValuesToEqualThree__ThirdIteration(  # noqa: SLF001
             column="values"
         )._get_examples(return_only_gallery_examples=False),
         execution_engine_diagnostics=ExpectationExecutionEngineDiagnostics(

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -61,10 +61,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store._session = Mock()  # noqa: SLF001
+        cloud_data_store._session.post = Mock()  # noqa: SLF001
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock  # noqa: SLF001
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -91,7 +91,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":[0.25,0.5,0.75],"exception":null,"column":"column","quantiles":[0.25,0.5,0.75],"allow_relative_error":0.001,"value_type":"list[float]","metric_type":"ColumnQuantileValuesMetric"}]}}}'
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(  # noqa: SLF001
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -115,10 +115,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store._session = Mock()  # noqa: SLF001
+        cloud_data_store._session.post = Mock()  # noqa: SLF001
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock  # noqa: SLF001
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -143,7 +143,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":null,"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(  # noqa: SLF001
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -169,10 +169,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store._session = Mock()  # noqa: SLF001
+        cloud_data_store._session.post = Mock()  # noqa: SLF001
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock  # noqa: SLF001
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -200,7 +200,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":1,"exception":{"type":"exception type","message":"exception message"},"column":"column","value_type":"int","metric_type":"ColumnMetric"}]}}}'
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(  # noqa: SLF001
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )
@@ -224,10 +224,10 @@ class TestCloudDataStoreMetricRun:
                 )
             ],
         )
-        cloud_data_store._session = Mock()
-        cloud_data_store._session.post = Mock()
+        cloud_data_store._session = Mock()  # noqa: SLF001
+        cloud_data_store._session.post = Mock()  # noqa: SLF001
         response_mock = Mock()
-        cloud_data_store._session.post.return_value = response_mock
+        cloud_data_store._session.post.return_value = response_mock  # noqa: SLF001
 
         response_metric_run_id = uuid.uuid4()
         response_metric_id = uuid.uuid4()
@@ -252,7 +252,7 @@ class TestCloudDataStoreMetricRun:
 
         expected_data = '{"data":{"type":"metric-run","attributes":{"data_asset_id":"4469ed3b-61d4-421f-9635-8339d2558b0f","metrics":[{"batch_id":"batch_id","metric_name":"metric_name","value":2.5,"exception":null,"column":"column","value_type":"float64","metric_type":"ColumnMetric"}]}}}'
 
-        cloud_data_store._session.post.assert_called_once_with(
+        cloud_data_store._session.post.assert_called_once_with(  # noqa: SLF001
             url="https://app.greatexpectations.fake.io/organizations/12345678-1234-5678-1234-567812345678/metric-runs",
             data=expected_data,
         )

--- a/tests/integration/cloud/rest_contracts/unit_test_mocks/conftest.py
+++ b/tests/integration/cloud/rest_contracts/unit_test_mocks/conftest.py
@@ -58,7 +58,7 @@ def _get_mock_response_from_pact_response_body(
     )
     mock_response = requests.Response()
     mock_response.status_code = status_code
-    mock_response._content = json.dumps(response_body).encode("utf-8")
+    mock_response._content = json.dumps(response_body).encode("utf-8")  # noqa: SLF001
     return mock_response
 
 

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -199,7 +199,7 @@ def test_alice_columnar_table_single_batch_batches_are_accessible(
     ]
 
     assert (
-        data_connector._get_data_reference_list_from_cache_by_data_asset_name(
+        data_connector._get_data_reference_list_from_cache_by_data_asset_name(  # noqa: SLF001
             data_asset_name=data_asset_name
         )
         == file_list
@@ -291,7 +291,7 @@ def test_alice_profiler_user_workflow_single_batch(
     )
 
     # noinspection PyUnresolvedReferences
-    expected_profiler_run_event: mock._Call = mock.call(
+    expected_profiler_run_event: mock._Call = mock.call(  # noqa: SLF001
         {
             "event_payload": {
                 "anonymized_name": "0481bcf98600fd04aa24df03d05cdcf5",
@@ -442,7 +442,7 @@ def test_bobby_columnar_table_multi_batch_batches_are_accessible(
     ]
 
     assert (
-        data_connector._get_data_reference_list_from_cache_by_data_asset_name(
+        data_connector._get_data_reference_list_from_cache_by_data_asset_name(  # noqa: SLF001
             data_asset_name=data_asset_name
         )
         == file_list
@@ -642,7 +642,7 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
     )
 
     # noinspection PyUnresolvedReferences
-    expected_profiler_run_event: mock._Call = mock.call(
+    expected_profiler_run_event: mock._Call = mock.call(  # noqa: SLF001
         {
             "event_payload": {
                 "anonymized_name": "43c8704c864dd10feed13219062f0228",
@@ -884,7 +884,7 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
     )
 
     # noinspection PyUnresolvedReferences
-    expected_profiler_run_event: mock._Call = mock.call(
+    expected_profiler_run_event: mock._Call = mock.call(  # noqa: SLF001
         {
             "event_payload": {
                 "anonymized_name": "510b23dfd19c492f33d114b184f245e8",
@@ -1035,7 +1035,7 @@ def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
     )
 
     # noinspection PyUnresolvedReferences
-    expected_profiler_run_event: mock._Call = mock.call(
+    expected_profiler_run_event: mock._Call = mock.call(  # noqa: SLF001
         {
             "event_payload": {
                 "anonymized_name": "0592a9cacfa4ce642536161869d1ba19",

--- a/tests/integration/profiling/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/integration/profiling/rule_based_profiler/test_rule_based_profiler.py
@@ -50,7 +50,7 @@ def test_batches_are_accessible(
     )
 
     assert (
-        data_connector._get_data_reference_list_from_cache_by_data_asset_name(
+        data_connector._get_data_reference_list_from_cache_by_data_asset_name(  # noqa: SLF001
             data_asset_name=asset_name
         )
         == file_list
@@ -182,7 +182,7 @@ def test_profile_includes_citations(
     )
 
     # noinspection PyUnresolvedReferences
-    actual_events: list[mock._Call] = mock_emit.call_args_list
+    actual_events: list[mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert actual_events[-1][0][0]["event"] == UsageStatsEvents.RULE_BASED_PROFILER_RUN
 
 
@@ -235,7 +235,7 @@ def test_profile_get_expectation_suite(
     assert mock_emit.call_count == 44
 
     # noinspection PyUnresolvedReferences
-    actual_events: list[mock._Call] = mock_emit.call_args_list
+    actual_events: list[mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert (
         actual_events[-1][0][0]["event"]
         == UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -43,7 +43,7 @@ def test_spark_config_datasource(spark_session_v012):
     )
     spark_session: pyspark.SparkSession = source.spark
     # noinspection PyProtectedMember
-    sc_stopped: bool = spark_session.sparkContext._jsc.sc().isStopped()
+    sc_stopped: bool = spark_session.sparkContext._jsc.sc().isStopped()  # noqa: SLF001
     assert not sc_stopped
 
     # Test that our values were set
@@ -66,7 +66,9 @@ def test_spark_config_execution_engine(spark_session):
     new_spark_session: pyspark.SparkSession = execution_engine.spark
 
     # noinspection PyProtectedMember
-    sc_stopped: bool = new_spark_session.sparkContext._jsc.sc().isStopped()
+    sc_stopped: bool = (
+        new_spark_session.sparkContext._jsc.sc().isStopped()  # noqa: SLF001
+    )
 
     assert not sc_stopped
 

--- a/tests/integration/usage_statistics/instantiate_context_with_usage_statistics.py
+++ b/tests/integration/usage_statistics/instantiate_context_with_usage_statistics.py
@@ -70,7 +70,7 @@ def main(
     print("Building a suite and validating.")
     df = pd.DataFrame({"a": [1, 2, 3]})
     context.add_expectation_suite("testing.batch")
-    batch = context._get_batch_v2(
+    batch = context._get_batch_v2(  # noqa: SLF001
         batch_kwargs={"datasource": "pandas", "dataset": df},
         expectation_suite_name="testing.batch",
     )

--- a/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
+++ b/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
@@ -91,10 +91,10 @@ def test_common_usage_stats_are_sent_no_mocking(
     context = get_context(in_memory_data_context_config_usage_stats_enabled)
 
     # Note, we lose the `data_context.__init__` event because it was emitted before closing the worker
-    context._usage_statistics_handler._close_worker()
+    context._usage_statistics_handler._close_worker()  # noqa: SLF001
 
     # Make sure usage stats are enabled
-    assert context._is_usage_stats_enabled()
+    assert context._is_usage_stats_enabled()  # noqa: SLF001
     assert context.anonymous_usage_statistics.enabled
     assert context.anonymous_usage_statistics.data_context_id == DATA_CONTEXT_ID
 
@@ -184,7 +184,9 @@ def test_common_usage_stats_are_sent_no_mocking(
 
     assert not usage_stats_exceptions_exist(messages=caplog.messages)
 
-    message_queue = context._usage_statistics_handler._message_queue.queue
+    message_queue = (
+        context._usage_statistics_handler._message_queue.queue  # noqa: SLF001
+    )
     events = [event["event"] for event in message_queue]
 
     # Note: expected events does not contain the `data_context.__init__` event

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -160,7 +160,7 @@ def test_BasicDatasetProfiler_with_context(filesystem_csv_data_context):
         "datasource": "rad_datasource",
         "path": os.path.join(base_dir, "f1.csv"),  # noqa: PTH118
     }
-    batch = context._get_batch_v2(batch_kwargs, "default")
+    batch = context._get_batch_v2(batch_kwargs, "default")  # noqa: SLF001
     expectation_suite, validation_results = BasicDatasetProfiler.profile(batch)
 
     assert expectation_suite.expectation_suite_name == "default"

--- a/tests/profile/test_user_configurable_profiler_v3_batch_request.py
+++ b/tests/profile/test_user_configurable_profiler_v3_batch_request.py
@@ -472,9 +472,9 @@ def test_build_suite_with_semantic_types_dict(
     assert mock_emit.call_count == 1
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[mock._Call]
+    expected_events: List[mock._Call]  # noqa: SLF001
     # noinspection PyUnresolvedReferences
-    actual_events: List[mock._Call]
+    actual_events: List[mock._Call]  # noqa: SLF001
 
     expected_events = [
         mock.call(
@@ -531,9 +531,9 @@ def test_build_suite_when_suite_already_exists(
     assert mock_emit.call_count == 2
 
     # noinspection PyUnresolvedReferences
-    expected_events: List[mock._Call]
+    expected_events: List[mock._Call]  # noqa: SLF001
     # noinspection PyUnresolvedReferences
-    actual_events: List[mock._Call]
+    actual_events: List[mock._Call]  # noqa: SLF001
 
     expected_events = [
         mock.call(

--- a/tests/render/conftest.py
+++ b/tests/render/conftest.py
@@ -35,7 +35,9 @@ def titanic_profiled_name_column_evrs():
             json.load(infile)
         )
 
-    evrs_by_column = Renderer()._group_evrs_by_column(titanic_profiled_evrs_1)
+    evrs_by_column = Renderer()._group_evrs_by_column(  # noqa: SLF001
+        titanic_profiled_evrs_1
+    )
     name_column_evrs = evrs_by_column["Name"]
 
     return name_column_evrs

--- a/tests/render/renderer/test_other_section_renderer.py
+++ b/tests/render/renderer/test_other_section_renderer.py
@@ -27,7 +27,7 @@ def test_ProfilingResultsOverviewSectionRenderer_render_variable_types(
     for datetime. Other types would be useful to test for as well."""
 
     content_blocks = []
-    ProfilingResultsOverviewSectionRenderer._render_variable_types(
+    ProfilingResultsOverviewSectionRenderer._render_variable_types(  # noqa: SLF001
         datetime_column_evrs, content_blocks
     )
     assert len(content_blocks) == 1

--- a/tests/render/test_EmailRenderer.py
+++ b/tests/render/test_EmailRenderer.py
@@ -130,9 +130,15 @@ def test_EmailRenderer_get_report_element():
     email_renderer = EmailRenderer()
 
     # these should all be caught
-    assert email_renderer._get_report_element(docs_link=None) is None
-    assert email_renderer._get_report_element(docs_link=1) is None
-    assert email_renderer._get_report_element(docs_link=email_renderer) is None
+    assert email_renderer._get_report_element(docs_link=None) is None  # noqa: SLF001
+    assert email_renderer._get_report_element(docs_link=1) is None  # noqa: SLF001
+    assert (
+        email_renderer._get_report_element(docs_link=email_renderer)  # noqa: SLF001
+        is None
+    )
 
     # this should work
-    assert email_renderer._get_report_element(docs_link="i_should_work") is not None
+    assert (
+        email_renderer._get_report_element(docs_link="i_should_work")  # noqa: SLF001
+        is not None
+    )

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -344,12 +344,18 @@ def test_SlackRenderer_get_report_element():
     slack_renderer = SlackRenderer()
 
     # these should all be caught
-    assert slack_renderer._get_report_element(docs_link=None) is None
-    assert slack_renderer._get_report_element(docs_link=1) is None
-    assert slack_renderer._get_report_element(docs_link=slack_renderer) is None
+    assert slack_renderer._get_report_element(docs_link=None) is None  # noqa: SLF001
+    assert slack_renderer._get_report_element(docs_link=1) is None  # noqa: SLF001
+    assert (
+        slack_renderer._get_report_element(docs_link=slack_renderer)  # noqa: SLF001
+        is None
+    )
 
     # this should work
-    assert slack_renderer._get_report_element(docs_link="i_should_work") is not None
+    assert (
+        slack_renderer._get_report_element(docs_link="i_should_work")  # noqa: SLF001
+        is not None
+    )
 
 
 def test_SlackRenderer_get_failed_expectation_domain_table():

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -151,7 +151,7 @@ def test_ProfilingResultsColumnSectionRenderer_render_header(
     titanic_profiled_name_column_evrs,
 ):
     content_block = (
-        ProfilingResultsColumnSectionRenderer()
+        ProfilingResultsColumnSectionRenderer()  # noqa: SLF001
         ._render_header(evrs=titanic_profiled_name_column_evrs, column_type=None)
         .to_json_dict()
     )
@@ -213,10 +213,12 @@ def test_ProfilingResultsColumnSectionRenderer_render_header_with_unescaped_doll
         ),
     )
 
-    content_block = ProfilingResultsColumnSectionRenderer._render_header(
-        [evr_with_unescaped_dollar_sign],
-        column_type=[],
-    ).to_json_dict()
+    content_block = (
+        ProfilingResultsColumnSectionRenderer._render_header(  # noqa: SLF001
+            [evr_with_unescaped_dollar_sign],
+            column_type=[],
+        ).to_json_dict()
+    )
     print(content_block)
     assert content_block == {
         "content_block_type": "header",
@@ -285,7 +287,7 @@ def test_ProfilingResultsColumnSectionRenderer_render_bar_chart_table(
     content_blocks = []
     for evr in distinct_values_evrs:
         content_blocks.append(
-            ProfilingResultsColumnSectionRenderer()
+            ProfilingResultsColumnSectionRenderer()  # noqa: SLF001
             ._render_value_counts_bar_chart(distinct_values_evrs)
             .to_json_dict()
         )
@@ -310,7 +312,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_header(
     (
         remaining_expectations,
         content_blocks,
-    ) = ExpectationSuiteColumnSectionRenderer._render_header(
+    ) = ExpectationSuiteColumnSectionRenderer._render_header(  # noqa: SLF001
         titanic_profiled_name_column_expectations,
     )
 
@@ -353,7 +355,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_header(
     (
         remaining_expectations,
         content_blocks,
-    ) = ExpectationSuiteColumnSectionRenderer._render_header(
+    ) = ExpectationSuiteColumnSectionRenderer._render_header(  # noqa: SLF001
         [expectation_with_unescaped_dollar_sign],
     )
 
@@ -1178,7 +1180,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_bullet_list(
     (
         remaining_expectations,
         content_block,
-    ) = ExpectationSuiteColumnSectionRenderer()._render_bullet_list(
+    ) = ExpectationSuiteColumnSectionRenderer()._render_bullet_list(  # noqa: SLF001
         titanic_profiled_name_column_expectations,
     )
 
@@ -1202,7 +1204,7 @@ def test_ValidationResultsColumnSectionRenderer_render_header(
     (
         remaining_evrs,
         content_block,
-    ) = ValidationResultsColumnSectionRenderer._render_header(
+    ) = ValidationResultsColumnSectionRenderer._render_header(  # noqa: SLF001
         validation_results=titanic_profiled_name_column_evrs,
     )
     print(content_block.to_json_dict())
@@ -1258,7 +1260,7 @@ def test_ValidationResultsColumnSectionRenderer_render_header_evr_with_unescaped
     (
         remaining_evrs,
         content_block,
-    ) = ValidationResultsColumnSectionRenderer._render_header(
+    ) = ValidationResultsColumnSectionRenderer._render_header(  # noqa: SLF001
         validation_results=[evr_with_unescaped_dollar_sign],
     )
     print(content_block.to_json_dict())
@@ -1288,7 +1290,7 @@ def test_ValidationResultsColumnSectionRenderer_render_table(
     (
         remaining_evrs,
         content_block,
-    ) = ValidationResultsColumnSectionRenderer()._render_table(
+    ) = ValidationResultsColumnSectionRenderer()._render_table(  # noqa: SLF001
         validation_results=titanic_profiled_name_column_evrs,
     )
 

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -56,10 +56,10 @@ def assert_how_to_buttons(
     }
 
     data_docs_site_dir = os.path.join(  # noqa: PTH118
-        context._context_root_directory,
-        context._project_config.data_docs_sites["local_site"]["store_backend"][
-            "base_directory"
-        ],
+        context._context_root_directory,  # noqa: SLF001
+        context._project_config.data_docs_sites["local_site"][  # noqa: SLF001
+            "store_backend"
+        ]["base_directory"],
     )
 
     page_paths_dict = {
@@ -103,7 +103,9 @@ def test_site_builder_with_custom_site_section_builders_config(tmp_path_factory)
         str(os.path.join(project_dir, FileDataContext.GX_YML)),  # noqa: PTH118
     )
     context = get_context(context_root_dir=project_dir)
-    local_site_config = context._project_config.data_docs_sites.get("local_site")
+    local_site_config = context._project_config.data_docs_sites.get(  # noqa: SLF001
+        "local_site"
+    )
 
     module_name = "great_expectations.render.renderer.site_builder"
     site_builder = instantiate_class_from_config(

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -25,9 +25,13 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
     empty_data_context,
 ):
     context = empty_data_context
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test", meta={"notes": "*hi*"}, data_context=context
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={"notes": "*hi*"},
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -36,11 +40,13 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
         "*hi*",
     ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={"notes": ["*alpha*", "_bravo_", "charlie"]},
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={"notes": ["*alpha*", "_bravo_", "charlie"]},
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -51,16 +57,18 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
         "charlie",
     ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={
-                "notes": {
-                    "format": MetaNotesFormat.STRING,
-                    "content": ["*alpha*", "_bravo_", "charlie"],
-                }
-            },
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={
+                    "notes": {
+                        "format": MetaNotesFormat.STRING,
+                        "content": ["*alpha*", "_bravo_", "charlie"],
+                    }
+                },
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -71,11 +79,15 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
         "charlie",
     ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={"notes": {"format": MetaNotesFormat.MARKDOWN, "content": "*alpha*"}},
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={
+                    "notes": {"format": MetaNotesFormat.MARKDOWN, "content": "*alpha*"}
+                },
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -96,16 +108,18 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
             "*alpha*",
         ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={
-                "notes": {
-                    "format": MetaNotesFormat.MARKDOWN,
-                    "content": ["*alpha*", "_bravo_", "charlie"],
-                }
-            },
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={
+                    "notes": {
+                        "format": MetaNotesFormat.MARKDOWN,
+                        "content": ["*alpha*", "_bravo_", "charlie"],
+                    }
+                },
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -143,12 +157,14 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
     empty_data_context,
 ):
     context: ExpectationSuite = empty_data_context
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={},
-            expectations=None,
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={},
+                expectations=None,
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -156,11 +172,13 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
         "This Expectation suite currently contains 0 total Expectations across 0 columns."
     ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={"notes": {"format": MetaNotesFormat.MARKDOWN, "content": ["hi"]}},
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={"notes": {"format": MetaNotesFormat.MARKDOWN, "content": ["hi"]}},
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
@@ -181,23 +199,27 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
             "hi",
         ]
 
-    result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(
-            expectation_suite_name="test",
-            meta={},
-            expectations=[
-                ExpectationConfiguration(
-                    expectation_type="expect_table_row_count_to_be_between",
-                    kwargs={"min_value": 0, "max_value": None},
-                ),
-                ExpectationConfiguration(
-                    expectation_type="expect_column_to_exist", kwargs={"column": "x"}
-                ),
-                ExpectationConfiguration(
-                    expectation_type="expect_column_to_exist", kwargs={"column": "y"}
-                ),
-            ],
-            data_context=context,
+    result = (
+        ExpectationSuitePageRenderer._render_expectation_suite_notes(  # noqa: SLF001
+            ExpectationSuite(
+                expectation_suite_name="test",
+                meta={},
+                expectations=[
+                    ExpectationConfiguration(
+                        expectation_type="expect_table_row_count_to_be_between",
+                        kwargs={"min_value": 0, "max_value": None},
+                    ),
+                    ExpectationConfiguration(
+                        expectation_type="expect_column_to_exist",
+                        kwargs={"column": "x"},
+                    ),
+                    ExpectationConfiguration(
+                        expectation_type="expect_column_to_exist",
+                        kwargs={"column": "y"},
+                    ),
+                ],
+                data_context=context,
+            )
         )
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text)[0])
@@ -216,9 +238,11 @@ def test_ProfilingResultsPageRenderer(titanic_profiled_evrs_1):
 def test_ValidationResultsPageRenderer_render_validation_header(
     titanic_profiled_evrs_1,
 ):
-    validation_header = ValidationResultsPageRenderer._render_validation_header(
-        titanic_profiled_evrs_1
-    ).to_json_dict()
+    validation_header = (
+        ValidationResultsPageRenderer._render_validation_header(  # noqa: SLF001
+            titanic_profiled_evrs_1
+        ).to_json_dict()
+    )
 
     expected_validation_header = {
         "content_block_type": "header",
@@ -271,9 +295,11 @@ def test_ValidationResultsPageRenderer_render_validation_header(
 
 
 def test_ValidationResultsPageRenderer_render_validation_info(titanic_profiled_evrs_1):
-    validation_info = ValidationResultsPageRenderer._render_validation_info(
-        titanic_profiled_evrs_1
-    ).to_json_dict()
+    validation_info = (
+        ValidationResultsPageRenderer._render_validation_info(  # noqa: SLF001
+            titanic_profiled_evrs_1
+        ).to_json_dict()
+    )
     print(validation_info)
 
     expected_validation_info = {
@@ -308,9 +334,11 @@ def test_ValidationResultsPageRenderer_render_validation_info(titanic_profiled_e
 def test_ValidationResultsPageRenderer_render_validation_statistics(
     titanic_profiled_evrs_1,
 ):
-    validation_statistics = ValidationResultsPageRenderer._render_validation_statistics(
-        titanic_profiled_evrs_1
-    ).to_json_dict()
+    validation_statistics = (
+        ValidationResultsPageRenderer._render_validation_statistics(  # noqa: SLF001
+            titanic_profiled_evrs_1
+        ).to_json_dict()
+    )
     print(validation_statistics)
     expected_validation_statistics = {
         "content_block_type": "table",
@@ -350,9 +378,11 @@ def test_ValidationResultsPageRenderer_render_nested_table_from_dict():
         "datasource": "Titanic",
         "reader_options": {"sep": None, "engine": "python"},
     }
-    batch_kwargs_table = ValidationResultsPageRenderer._render_nested_table_from_dict(
-        batch_kwargs, header="Batch Kwargs"
-    ).to_json_dict()
+    batch_kwargs_table = (
+        ValidationResultsPageRenderer._render_nested_table_from_dict(  # noqa: SLF001
+            batch_kwargs, header="Batch Kwargs"
+        ).to_json_dict()
+    )
     print(batch_kwargs_table)
 
     expected_batch_kwarg_table = {

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -250,13 +250,17 @@ def test_ValidationResultsTableContentBlockRenderer_render(
 
 def test_ValidationResultsTableContentBlockRenderer_get_custom_columns(evr_success):
     assert (
-        ValidationResultsTableContentBlockRenderer._get_custom_columns([evr_success])
+        ValidationResultsTableContentBlockRenderer._get_custom_columns(  # noqa: SLF001
+            [evr_success]
+        )
         == []
     )
 
     evr_success.expectation_config.kwargs["meta_properties_to_render"] = {}
     assert (
-        ValidationResultsTableContentBlockRenderer._get_custom_columns([evr_success])
+        ValidationResultsTableContentBlockRenderer._get_custom_columns(  # noqa: SLF001
+            [evr_success]
+        )
         == []
     )
 
@@ -264,13 +268,16 @@ def test_ValidationResultsTableContentBlockRenderer_get_custom_columns(evr_succe
         "doesntmatterone": "doesntmatter",
         "doesntmattertwo": "doesntmatter",
     }
-    assert ValidationResultsTableContentBlockRenderer._get_custom_columns(
-        [evr_success]
-    ) == ["doesntmatterone", "doesntmattertwo"]
+    assert (
+        ValidationResultsTableContentBlockRenderer._get_custom_columns(  # noqa: SLF001
+            [evr_success]
+        )
+        == ["doesntmatterone", "doesntmattertwo"]
+    )
 
 
 def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn(evr_success):
-    content_block_fn = ValidationResultsTableContentBlockRenderer._get_content_block_fn(
+    content_block_fn = ValidationResultsTableContentBlockRenderer._get_content_block_fn(  # noqa: SLF001
         "expect_table_row_count_to_be_between"
     )
     content_block_fn_output = content_block_fn(result=evr_success)
@@ -551,7 +558,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn_with_v2
         ),
     )
 
-    content_block_fn = ValidationResultsTableContentBlockRendererWithV2ApiStyleCustomExpectations._get_content_block_fn(
+    content_block_fn = ValidationResultsTableContentBlockRendererWithV2ApiStyleCustomExpectations._get_content_block_fn(  # noqa: SLF001
         "expect_custom_expectation_written_in_v2_api_style"
     )
     content_block_fn_output = content_block_fn(result=evr)

--- a/tests/render/test_renderer.py
+++ b/tests/render/test_renderer.py
@@ -42,14 +42,14 @@ def test_render():
 @pytest.mark.unit
 def test__find_evr_by_type(titanic_profiled_evrs_1):
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evr = Renderer()._find_evr_by_type(
+    found_evr = Renderer()._find_evr_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results, "expect_column_to_exist"
     )
     print(found_evr)
     assert found_evr is None
 
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evr = Renderer()._find_evr_by_type(
+    found_evr = Renderer()._find_evr_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results, "expect_column_distinct_values_to_be_in_set"
     )
     print(found_evr)
@@ -84,21 +84,21 @@ def test__find_evr_by_type(titanic_profiled_evrs_1):
 @pytest.mark.unit
 def test__find_all_evrs_by_type(titanic_profiled_evrs_1):
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evrs = Renderer()._find_all_evrs_by_type(
+    found_evrs = Renderer()._find_all_evrs_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results, "expect_column_to_exist", column_=None
     )
     print(found_evrs)
     assert found_evrs == []
 
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evrs = Renderer()._find_all_evrs_by_type(
+    found_evrs = Renderer()._find_all_evrs_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results, "expect_column_to_exist", column_="SexCode"
     )
     print(found_evrs)
     assert found_evrs == []
 
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evrs = Renderer()._find_all_evrs_by_type(
+    found_evrs = Renderer()._find_all_evrs_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results,
         "expect_column_distinct_values_to_be_in_set",
         column_=None,
@@ -107,7 +107,7 @@ def test__find_all_evrs_by_type(titanic_profiled_evrs_1):
     assert len(found_evrs) == 4
 
     # TODO: _find_all_evrs_by_type should accept an ValidationResultSuite, not ValidationResultSuite.results
-    found_evrs = Renderer()._find_all_evrs_by_type(
+    found_evrs = Renderer()._find_all_evrs_by_type(  # noqa: SLF001
         titanic_profiled_evrs_1.results,
         "expect_column_distinct_values_to_be_in_set",
         column_="SexCode",
@@ -118,7 +118,9 @@ def test__find_all_evrs_by_type(titanic_profiled_evrs_1):
 
 @pytest.mark.unit
 def test__get_column_list_from_evrs(titanic_profiled_evrs_1):
-    column_list = Renderer()._get_column_list_from_evrs(titanic_profiled_evrs_1)
+    column_list = Renderer()._get_column_list_from_evrs(  # noqa: SLF001
+        titanic_profiled_evrs_1
+    )
     print(column_list)
     assert column_list == [
         "Unnamed: 0",

--- a/tests/rule_based_profiler/data_assistant/test_column_value_missing_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_column_value_missing_data_assistant.py
@@ -50,7 +50,9 @@ def test_single_batch_multiple_columns(ephemeral_context_with_defaults):
     )
     batch_request = asset.build_batch_request(dataframe=df)
 
-    context.assistants._register("my_data_assistant", ColumnValueMissingDataAssistant)
+    context.assistants._register(  # noqa: SLF001
+        "my_data_assistant", ColumnValueMissingDataAssistant
+    )
     result = context.assistants.my_data_assistant.run(batch_request=batch_request)
 
     assert len(result.expectation_configurations) == 3

--- a/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
+++ b/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
@@ -26,13 +26,15 @@ def test_get_chart_titles():
     assert layer_b.title == title_text
     assert layered_chart.title == alt.Undefined
 
-    chart_titles: List[str] = DataAssistantResult._get_chart_titles(
+    chart_titles: List[str] = DataAssistantResult._get_chart_titles(  # noqa: SLF001
         charts=[layered_chart]
     )
     assert len(chart_titles) == 1
     assert chart_titles[0] == title_text
 
-    chart_title: Optional[str] = DataAssistantResult._get_chart_layer_title(
+    chart_title: Optional[
+        str
+    ] = DataAssistantResult._get_chart_layer_title(  # noqa: SLF001
         layer=layered_chart
     )
     assert chart_title == title_text
@@ -41,20 +43,22 @@ def test_get_chart_titles():
     layer_b: alt.Chart = alt.Chart(data=df, title=alt.TitleParams(text=title_text))
     assert layer_b.title.text == title_text
 
-    chart_titles: List[str] = DataAssistantResult._get_chart_titles(
+    chart_titles: List[str] = DataAssistantResult._get_chart_titles(  # noqa: SLF001
         charts=[layered_chart]
     )
     assert len(chart_titles) == 1
     assert chart_titles[0] == title_text
 
-    chart_title: Optional[str] = DataAssistantResult._get_chart_layer_title(
+    chart_title: Optional[
+        str
+    ] = DataAssistantResult._get_chart_layer_title(  # noqa: SLF001
         layer=layered_chart
     )
     assert chart_title == title_text
 
     # case where no title exists
     with pytest.raises(gx_exceptions.DataAssistantResultExecutionError) as e:
-        DataAssistantResult._get_chart_titles(charts=[layer_a])
+        DataAssistantResult._get_chart_titles(charts=[layer_a])  # noqa: SLF001
 
     assert e.value.message == "All DataAssistantResult charts must have a title."
 

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1351,7 +1351,7 @@ def quentin_expected_expectation_suite(
 
         expectation_configuration: ExpectationConfiguration
         for expectation_configuration in expected_expectation_configurations:
-            expected_expectation_suite._add_expectation(
+            expected_expectation_suite._add_expectation(  # noqa: SLF001
                 expectation_configuration=expectation_configuration,
                 send_usage_event=False,
             )
@@ -1699,7 +1699,7 @@ def test_volume_data_assistant_result_get_expectation_suite(
     assert mock_emit.call_count == 1
 
     # noinspection PyUnresolvedReferences
-    actual_events: List[mock._Call] = mock_emit.call_args_list
+    actual_events: List[mock._Call] = mock_emit.call_args_list  # noqa: SLF001
     assert (
         actual_events[-1][0][0]["event"]
         == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE
@@ -1717,7 +1717,7 @@ def test_volume_data_assistant_result_batch_id_to_batch_identifier_display_name_
     parameter_node: ParameterNode
     batch_id: str
     assert all(
-        bobby_volume_data_assistant_result._batch_id_to_batch_identifier_display_name_map[
+        bobby_volume_data_assistant_result._batch_id_to_batch_identifier_display_name_map[  # noqa: SLF001
             batch_id
         ]
         is not None

--- a/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
+++ b/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
@@ -122,7 +122,7 @@ def test_sanitize_parameter_name(
     )
     assert sanitized_name == "table_head_444fc52627dde82ad1d5c4fe290bfa6b"
 
-    table_head_metric_config._metric_value_kwargs = IDDict({})
+    table_head_metric_config._metric_value_kwargs = IDDict({})  # noqa: SLF001
     sanitized_name = sanitize_parameter_name(
         name=table_head_metric_config.metric_name,
         suffix=table_head_metric_config.metric_value_kwargs_id,
@@ -272,7 +272,7 @@ def test_sanitize_metric_computation(metric_name: str, metric_values_by_batch_id
     )
     if metric_name == "my_metric_6":
         with pytest.raises(gx_exceptions.ProfilerExecutionError) as excinfo:
-            metric_multi_batch_parameter_builder._sanitize_metric_computation(
+            metric_multi_batch_parameter_builder._sanitize_metric_computation(  # noqa: SLF001
                 parameter_builder=metric_multi_batch_parameter_builder,
                 metric_name=metric_name,
                 attributed_resolved_metrics=attributed_resolved_metrics,
@@ -289,7 +289,7 @@ def test_sanitize_metric_computation(metric_name: str, metric_values_by_batch_id
         )
     else:
         try:
-            metric_multi_batch_parameter_builder._sanitize_metric_computation(
+            metric_multi_batch_parameter_builder._sanitize_metric_computation(  # noqa: SLF001
                 parameter_builder=metric_multi_batch_parameter_builder,
                 metric_name=metric_name,
                 attributed_resolved_metrics=attributed_resolved_metrics,

--- a/tests/rule_based_profiler/parameter_builder/test_simple_date_format_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_simple_date_format_string_parameter_builder.py
@@ -99,7 +99,7 @@ def test_simple_date_format_parameter_builder_alice(
     )
 
     assert date_format_string_parameter.candidate_strings == DEFAULT_CANDIDATE_STRINGS
-    assert date_format_string_parameter._threshold == 1.0
+    assert date_format_string_parameter._threshold == 1.0  # noqa: SLF001
 
     domain = Domain(
         domain_type=MetricDomainTypes.COLUMN,
@@ -230,8 +230,10 @@ def test_simple_date_format_parameter_builder_bobby(
         )
     )
 
-    assert date_format_string_parameter._candidate_strings == set(candidate_strings)
-    assert date_format_string_parameter._threshold == 0.9
+    assert date_format_string_parameter._candidate_strings == set(  # noqa: SLF001
+        candidate_strings
+    )
+    assert date_format_string_parameter._threshold == 0.9  # noqa: SLF001
 
     domain = Domain(
         domain_type=MetricDomainTypes.COLUMN,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -816,7 +816,7 @@ def clean_up_tables_with_prefix(connection_string: str, table_prefix: str) -> Li
         },
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},
     )
-    introspection_output = data_connector._introspect_db()
+    introspection_output = data_connector._introspect_db()  # noqa: SLF001
 
     tables_to_drop: List[str] = []
     tables_dropped: List[str] = []

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -270,7 +270,7 @@ def test_parse_validation_graph(
     (
         ready_metrics,
         needed_metrics,
-    ) = expect_column_value_z_scores_to_be_less_than_expectation_validation_graph._parse(
+    ) = expect_column_value_z_scores_to_be_less_than_expectation_validation_graph._parse(  # noqa: SLF001
         metrics=available_metrics
     )
     assert len(ready_metrics) == 2 and len(needed_metrics) == 9
@@ -280,7 +280,7 @@ def test_parse_validation_graph(
     (
         ready_metrics,
         needed_metrics,
-    ) = expect_column_value_z_scores_to_be_less_than_expectation_validation_graph._parse(
+    ) = expect_column_value_z_scores_to_be_less_than_expectation_validation_graph._parse(  # noqa: SLF001
         metrics=available_metrics
     )
     assert len(ready_metrics) == 2 and len(needed_metrics) == 9

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -70,7 +70,7 @@ def yellow_trip_pandas_data_context(
                 "integration",
                 "fixtures",
                 "yellow_tripdata_pandas_fixture",
-                FileDataContext._LEGACY_GX_DIR,
+                FileDataContext._LEGACY_GX_DIR,  # noqa: SLF001
                 FileDataContext.GX_YML,
             ),
         ),
@@ -309,7 +309,7 @@ def multi_batch_taxi_validator_ge_cloud_mode(
     yellow_trip_pandas_data_context,
 ) -> Validator:
     context = yellow_trip_pandas_data_context
-    context._cloud_mode = True
+    context._cloud_mode = True  # noqa: SLF001
 
     suite = ExpectationSuite(
         expectation_suite_name="validating_taxi_data",


### PR DESCRIPTION



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
