### PR TITLE
[MAINTENANCE] Improved error message for `expect_column_values_to_be_in_type_list`

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -504,11 +504,14 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         column_name = configuration.kwargs.get("column")
         expected_types_list = configuration.kwargs.get("type_list")
         actual_column_types_list = metrics.get("table.column_types")
-        actual_column_type = [
-            type_dict["type"]
-            for type_dict in actual_column_types_list
-            if type_dict["name"] == column_name
-        ][0]
+        try:
+            actual_column_type = next(
+                type_dict["type"]
+                for type_dict in actual_column_types_list
+                if type_dict["name"] == column_name
+            )
+        except StopIteration as e:
+            raise ValueError(f'No column named "{column_name}"') from e
 
         if isinstance(execution_engine, PandasExecutionEngine):
             # only PandasExecutionEngine supports map version of expectation and


### PR DESCRIPTION
- Improved error message for `expect_column_values_to_be_in_type_list`

Before:
<img width="847" alt="Screenshot 2023-12-15 at 5 02 24 PM" src="https://github.com/great-expectations/great_expectations/assets/17692467/fe68ad00-9c24-4a39-9ba6-aa994fe1bc8f">

After:
<img width="865" alt="Screenshot 2023-12-15 at 5 02 36 PM" src="https://github.com/great-expectations/great_expectations/assets/17692467/d0f98cbb-79ab-4ae6-a5d8-e014d2e3b2f7">
