### PR TITLE
[MAINTENANCE] Update logging call used in Expectation logic

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1083,7 +1083,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         if field is not None:
             return field.default if not field.required else None
         else:
-            logger.warning(
+            logger.info(
                 f"_get_default_value called with key {key}, but it is not a known field"
             )
             return None

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1084,7 +1084,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             return field.default if not field.required else None
         else:
             logger.info(
-                f'_get_default_value called with key "{key}"", but it is not a known field'
+                f'_get_default_value called with key "{key}", but it is not a known field'
             )
             return None
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1084,7 +1084,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             return field.default if not field.required else None
         else:
             logger.info(
-                f"_get_default_value called with key {key}, but it is not a known field"
+                f'_get_default_value called with key "{key}"", but it is not a known field'
             )
             return None
 


### PR DESCRIPTION
This gets logged a decent bit so we should lower from warning to info

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
