### PR TITLE
[CONTRIB] ExpectColumnValuesToBePresentInOtherTable - Referential Integrity (0.18 branch)

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -111,7 +111,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
 
         template_dict = configuration.kwargs.get("template_dict")
 
-        template_str = "$foreign_key_column values exist in table $foreign_table 's $primary_key_column_in_foreign_table column."
+        template_str = "All values in column $foreign_key_column are present in column $primary_key_column_in_foreign_table of  table $foreign_table. (Observed Value is the number of missing values)."
 
         params = {
             "foreign_key_column": template_dict["foreign_key_column"],

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -1,0 +1,188 @@
+from typing import Optional, Union
+
+from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    ExpectationValidationResult,
+    QueryExpectation,
+)
+from great_expectations.expectations.expectation_configuration import (
+    ExpectationConfiguration,
+)
+
+
+class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
+    """Expect the values in a column to be present in another table.
+
+     This is an Expectation that allows for the validation of referential integrity, that a foreign key exists in another table.
+
+     In the following example, order table has a foreign key to customer table, and referential integrity is preserved, because all of
+     the values of CUSTOMER_ID in order_table_1 are present in the CUSTOMER_ID column of customer_table.
+
+    "order_table_1": {
+         "ORDER_ID": ["aaa", "bbb", "ccc"],
+         "CUSTOMER_ID": [1, 1, 3],
+     }
+     "customer_table": {
+         "CUSTOMER_ID": [1, 2, 3],
+
+     }
+
+     However, in the second example, referential integrity is not preserved, because there are two values (4 and 5) in the CUSTOMER_ID
+     column of order_table_2 that are not present in the CUSTOMER_ID column of customer_table.
+
+     "order_table_2": {
+         "ORDER_ID": ["ddd", "eee", "fff"],
+         "CUSTOMER_ID": [1, 4, 5],
+     }
+     "customer_table": {
+         "CUSTOMER_ID": [1, 2, 3],
+
+     }
+     ExpectColumnValuesToBePresentInAnotherTable will PASS for example 1 and FAIL for example 2.
+
+     Args:
+         template_dict: dict containing the following keys:
+             foreign_key_column: foreign key-column of current table that we want to validate.
+             foreign_table: foreign table.
+             primary_key_column_in_foreign_table: key column for primary key in foreign table.
+    """
+
+    library_metadata = {
+        "maturity": "experimental",
+        "tags": ["table expectation", "multi-table expectation", "query-based"],
+        "contributors": [
+            "@great_expectations",
+        ],
+        "requirements": [
+            "sqlalchemy",
+            "snowflake-sqlalchemy",
+            "snowflake-connector-python",
+        ],
+        "has_full_test_suite": False,
+        "manually_reviewed_code": True,
+    }
+
+    metric_dependencies = ("query.template_values",)
+    template_dict: dict
+    query = """
+        SELECT count(1) FROM (
+        SELECT a.{foreign_key_column}
+        FROM {active_batch} a
+        LEFT JOIN {foreign_table} b
+            ON a.{foreign_key_column} = b.{primary_key_column_in_foreign_table}
+        WHERE b.{primary_key_column_in_foreign_table} is NULL)
+        """
+    success_keys = (
+        "template_dict",
+        "query",
+    )
+    domain_keys = ("query", "batch_id", "row_condition", "condition_parser")
+
+    default_kwarg_values = {
+        "catch_exceptions": False,
+        "meta": None,
+        "query": query,
+    }
+
+    def _validate_template_dict(
+        self, configuration: Optional[ExpectationConfiguration] = None
+    ) -> None:
+        template_dict = configuration.kwargs.get("template_dict")
+        if not isinstance(template_dict, dict):
+            raise TypeError("template_dict must be supplied as a dict")
+        if not all(
+            [
+                "foreign_key_column" in template_dict,
+                "foreign_table" in template_dict,
+                "primary_key_column_in_foreign_table" in template_dict,
+            ]
+        ):
+            raise KeyError(
+                "The following keys have to be in the template dict: id, foreign_table, foreign_key_column"
+            )
+
+    def _validate(
+        self,
+        metrics: dict,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
+    ) -> Union[ExpectationValidationResult, dict]:
+        configuration = self.configuration
+        self._validate_template_dict(configuration)
+        final_value = metrics.get("query.template_values")[0]["COUNT(1)"]
+        return ExpectationValidationResult(
+            success=(final_value == 0), result={"unexpected_count": final_value}
+        )
+
+    examples = [
+        {
+            "data": [
+                {
+                    "dataset_name": "order_table_1",
+                    "data": {
+                        "ORDER_ID": ["aaa", "bbb", "ccc"],
+                        "CUSTOMER_ID": [1, 1, 3],
+                    },
+                },
+                {
+                    "dataset_name": "customer_table",
+                    "data": {
+                        "CUSTOMER_ID": [1, 2, 3],
+                    },
+                },
+            ],
+            "only_for": ["snowflake", "sqlite"],
+            "tests": [
+                {
+                    "title": "basic_positive_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "template_dict": {
+                            "foreign_key_column": "CUSTOMER_ID",
+                            "foreign_table": "customer_table",
+                            "primary_key_column_in_foreign_table": "CUSTOMER_ID",
+                        }
+                    },
+                    "out": {"success": True},
+                },
+            ],
+        },
+        {
+            "data": [
+                {
+                    "dataset_name": "order_table_2",
+                    "data": {
+                        "ORDER_ID": ["aaa", "bbb", "ccc"],
+                        "CUSTOMER_ID": [1, 5, 6],
+                    },
+                },
+                {
+                    "dataset_name": "customer_table",
+                    "data": {
+                        "CUSTOMER_ID": [1, 2, 3],
+                    },
+                },
+            ],
+            "only_for": ["snowflake", "sqlite"],
+            "tests": [
+                {
+                    "title": "basic_negative_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "template_dict": {
+                            "foreign_key_column": "CUSTOMER_ID",
+                            "foreign_table": "customer_table",
+                            "primary_key_column_in_foreign_table": "CUSTOMER_ID",
+                        },
+                    },
+                    "out": {"success": False, "unexpected_count": 2},
+                },
+            ],
+        },
+    ]
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesToBePresentInAnotherTable().print_diagnostic_checklist()

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -1,12 +1,12 @@
 from typing import Optional, Union
 
+from great_expectations.core import (
+    ExpectationConfiguration,
+)
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     ExpectationValidationResult,
     QueryExpectation,
-)
-from great_expectations.expectations.expectation_configuration import (
-    ExpectationConfiguration,
 )
 
 
@@ -103,6 +103,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
 
     def _validate(
         self,
+        configuration: ExpectationConfiguration,
         metrics: dict,
         runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -16,22 +16,23 @@ from great_expectations.render.renderer.renderer import renderer
 class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
     """Expect the values in a column to be present in another table.
 
-     This is an Expectation that allows for the validation of referential integrity, that a foreign key exists in another table.
+    This is an Expectation that allows for the validation of referential integrity, that a foreign key exists in
+    another table.
 
-     In the following example, order table has a foreign key to customer table, and referential integrity is preserved, because all of
-     the values of CUSTOMER_ID in order_table_1 are present in the CUSTOMER_ID column of customer_table.
+    In the following example, order table has a foreign key to customer table, and referential integrity is preserved,
+    because all the values of CUSTOMER_ID in order_table_1 are present in the CUSTOMER_ID column of customer_table.
 
     "order_table_1": {
          "ORDER_ID": ["aaa", "bbb", "ccc"],
          "CUSTOMER_ID": [1, 1, 3],
-     }
-     "customer_table": {
-         "CUSTOMER_ID": [1, 2, 3],
+    }
+    "customer_table": {
+        "CUSTOMER_ID": [1, 2, 3],
 
-     }
+    }
 
-     However, in the second example, referential integrity is not preserved, because there are two values (4 and 5) in the CUSTOMER_ID
-     column of order_table_2 that are not present in the CUSTOMER_ID column of customer_table.
+    However, in the second example, referential integrity is not preserved, because there are two values (4 and 5) in
+    the CUSTOMER_ID column of order_table_2 that are not present in the CUSTOMER_ID column of customer_table.
 
      "order_table_2": {
          "ORDER_ID": ["ddd", "eee", "fff"],
@@ -41,7 +42,16 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
          "CUSTOMER_ID": [1, 2, 3],
 
      }
-     ExpectColumnValuesToBePresentInAnotherTable will PASS for example 1 and FAIL for example 2.
+    ExpectColumnValuesToBePresentInAnotherTable will PASS for example 1 and FAIL for example 2.
+
+    Also, the `template_dict` parameter we would use for the Expectation on `order_table_1` and `order_table_2` would
+    look like the following:
+
+    "template_dict" = {
+        "foreign_key_column": "CUSTOMER_ID",
+        "foreign_table": "customer_table",
+        "primary_key_column_in_foreign_table": "CUSTOMER_ID",
+    }
 
      Args:
          template_dict: dict containing the following keys:
@@ -68,12 +78,12 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
     metric_dependencies = ("query.template_values",)
     template_dict: dict
     query = """
-        SELECT count(1) FROM (
+        SELECT COUNT(1) FROM (
         SELECT a.{foreign_key_column}
         FROM {active_batch} a
         LEFT JOIN {foreign_table} b
             ON a.{foreign_key_column} = b.{primary_key_column_in_foreign_table}
-        WHERE b.{primary_key_column_in_foreign_table} is NULL)
+        WHERE b.{primary_key_column_in_foreign_table} IS NULL)
         """
     success_keys = (
         "template_dict",
@@ -136,7 +146,10 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
             ]
         ):
             raise KeyError(
-                "The following keys have to be in the template dict: id, foreign_table, foreign_key_column"
+                f"The following keys are missing from the template dict: "
+                f"{'foreign_key_column ' if 'foreign_key_column' not in template_dict else ''} "
+                f"{'foreign_table ' if 'foreign_table' not in template_dict else ''} "
+                f"{'primary_key_column_in_foreign_table ' if 'primary_key_column_in_foreign_table' not in template_dict else ''}"
             )
 
     def _validate(

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -101,7 +101,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
 
         template_dict = configuration.kwargs.get("template_dict")
 
-        template_str = "No values in the column $foreign_key_column are expected to be missing in table $foreign_table 's $primary_key_column_in_foreign_table column."
+        template_str = "$foreign_key_column values exist in table $foreign_table 's $primary_key_column_in_foreign_table column."
 
         params = {
             "foreign_key_column": template_dict["foreign_key_column"],

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -9,6 +9,28 @@ from great_expectations.expectations.metrics.query_metrics.query_template_values
 
 
 @pytest.mark.unit
+def test_query_template_get_query_function_with_str():
+    """Simple test to ensure that `get_query()` method for QueryTemplateValue can handle strings"""
+    query: str = """
+        SELECT {column_name}
+        FROM {active_batch}
+        WHERE {condition}
+    """
+    selectable = sa.Table("gx_temp_aaa", sa.MetaData(), schema=None)
+    template_dict: dict = {"column_name": "aaa", "condition": "is_open"}
+    metric_ob: QueryTemplateValues = QueryTemplateValues()
+    formatted_query: str = metric_ob.get_query(query, template_dict, selectable)
+    assert (
+        formatted_query
+        == """
+        SELECT aaa
+        FROM gx_temp_aaa
+        WHERE is_open
+    """
+    )
+
+
+@pytest.mark.unit
 def test_query_template_get_query_function_with_int():
     """Simple test to ensure that the `get_query()` method for QueryTemplateValue can handle integer value"""
     query: str = """

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -10,7 +10,7 @@ from great_expectations.expectations.metrics.query_metrics.query_template_values
 
 @pytest.mark.unit
 def test_query_template_get_query_function_with_str():
-    """Simple test to ensure that `get_query()` method for QueryTemplateValue can handle strings"""
+    """Simple test to ensure that `get_query()` method for QueryTemplateValue can handle strings."""
     query: str = """
         SELECT {column_name}
         FROM {active_batch}


### PR DESCRIPTION
# What does this PR do? 
* update to #9117 so that we are merging into the `0.18.x` branch for release

* Adds Core Logic for `ExpectColumnValuesToBePresentInOtherTable` which tests referential integrity. 
* Added Renderers: 

### Success
![Screenshot 2023-12-19 at 5 22 43 PM](https://github.com/great-expectations/great_expectations/assets/25670697/0a487993-2da5-49cf-97ae-455b870118bf)

### Failure
![Screenshot 2023-12-19 at 5 22 06 PM](https://github.com/great-expectations/great_expectations/assets/25670697/dc54c3ec-1004-4347-91a8-64c45ee9ecb7)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!