### PR TITLE
[BUGFIX] Fix QueryAsset with `create_temp_table=False`

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -28,7 +28,11 @@ from great_expectations.compatibility.pydantic import Field
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core._docs_decorators import public_api
-from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
+from great_expectations.core.batch_spec import (
+    BatchSpec,
+    RuntimeQueryBatchSpec,
+    SqlAlchemyDatasourceBatchSpec,
+)
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,
@@ -688,7 +692,7 @@ class _SQLAsset(DataAsset):
             # Creating the batch_spec is our hook into the execution engine.
             # TODO: if it's a QueryAsset use RuntimeQueryBatchSpec? or...
             # change how we get batch data inside of SqlAlchemyExecutionEngine.get_batch_data_and_markers()
-            batch_spec = SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
+            batch_spec = self._create_batch_spec(batch_spec_kwargs)
             execution_engine: SqlAlchemyExecutionEngine = (
                 self.datasource.get_execution_engine()
             )
@@ -792,12 +796,18 @@ class _SQLAsset(DataAsset):
             )
 
     def _create_batch_spec_kwargs(self) -> dict[str, Any]:
-        """Creates batch_spec_kwargs used to instantiate a SqlAlchemyDatasourceBatchSpec
+        """Creates batch_spec_kwargs used to instantiate a SqlAlchemyDatasourceBatchSpec or RuntimeQueryBatchSpec
 
         This is called by get_batch_list_from_batch_request to generate the batches.
 
         Returns:
-            A dictionary that will be passed to SqlAlchemyDatasourceBatchSpec(**returned_dict)
+            A dictionary that will be passed to self._create_batch_spec(**returned_dict)
+        """
+        raise NotImplementedError
+
+    def _create_batch_spec(self, batch_spec_kwargs: dict) -> BatchSpec:
+        """
+        Instantiates a SqlAlchemyDatasourceBatchSpec or RuntimeQueryBatchSpec.
         """
         raise NotImplementedError
 
@@ -839,6 +849,10 @@ class QueryAsset(_SQLAsset):
             "temp_table_schema_name": None,
             "batch_identifiers": {},
         }
+
+    @override
+    def _create_batch_spec(self, batch_spec_kwargs: dict) -> RuntimeQueryBatchSpec:
+        return RuntimeQueryBatchSpec(**batch_spec_kwargs)
 
 
 @public_api
@@ -952,6 +966,12 @@ class TableAsset(_SQLAsset):
             "schema_name": self.schema_name,
             "batch_identifiers": {},
         }
+
+    @override
+    def _create_batch_spec(
+        self, batch_spec_kwargs: dict
+    ) -> SqlAlchemyDatasourceBatchSpec:
+        return SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
 
     @staticmethod
     def _is_bracketed_by_quotes(target: str) -> bool:

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -686,6 +686,8 @@ class _SQLAsset(DataAsset):
                     )
                 )
             # Creating the batch_spec is our hook into the execution engine.
+            # TODO: if it's a QueryAsset use RuntimeQueryBatchSpec? or...
+            # change how we get batch data inside of SqlAlchemyExecutionEngine.get_batch_data_and_markers()
             batch_spec = SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
             execution_engine: SqlAlchemyExecutionEngine = (
                 self.datasource.get_execution_engine()

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -690,8 +690,6 @@ class _SQLAsset(DataAsset):
                     )
                 )
             # Creating the batch_spec is our hook into the execution engine.
-            # TODO: if it's a QueryAsset use RuntimeQueryBatchSpec? or...
-            # change how we get batch data inside of SqlAlchemyExecutionEngine.get_batch_data_and_markers()
             batch_spec = self._create_batch_spec(batch_spec_kwargs)
             execution_engine: SqlAlchemyExecutionEngine = (
                 self.datasource.get_execution_engine()

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,11 +1360,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
-        query: Optional[str] = batch_spec.get("query")
+        # TODO: clean this up
+        # fix this when building the batch spec or stop doing instance checks at all
+        # and check for the presence of the query key
+        query: Optional[str] = batch_spec.get(
+            "query", getattr(batch_spec, "query", None)
+        )
         if isinstance(batch_spec, RuntimeQueryBatchSpec) or query:
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
-            query: str = query or batch_spec.query
-
+            assert query
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
                 query=query,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1363,9 +1363,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         # TODO: clean this up
         # fix this when building the batch spec or stop doing instance checks at all
         # and check for the presence of the query key
-        query: Optional[str] = batch_spec.get(
-            "query", getattr(batch_spec, "query", None)
-        )
+        query: Optional[str] = getattr(batch_spec, "query", batch_spec.get("query"))
         if isinstance(batch_spec, RuntimeQueryBatchSpec) or query:
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
             assert query

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1361,7 +1361,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "create_temp_table", self._create_temp_table
         )
         query: Optional[str] = batch_spec.get("query")
-        if isinstance(batch_spec, RuntimeQueryBatchSpec) or batch_spec.get("query"):
+        if isinstance(batch_spec, RuntimeQueryBatchSpec) or query:
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
             query: str = query or batch_spec.query
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,7 +1360,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
-        # TODO: what's being checked here is the presence of a `query` attribute, we could check this directly
+        # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly
         # instead of doing an instance check
         if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,9 +1360,10 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
-        if isinstance(batch_spec, RuntimeQueryBatchSpec):
+        query: Optional[str] = batch_spec.get("query")
+        if isinstance(batch_spec, RuntimeQueryBatchSpec) or batch_spec.get("query"):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
-            query: str = batch_spec.query
+            query: str = query or batch_spec.query
 
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,13 +1360,12 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
-        # TODO: clean this up
-        # fix this when building the batch spec or stop doing instance checks at all
-        # and check for the presence of the query key
-        query: Optional[str] = getattr(batch_spec, "query", batch_spec.get("query"))
-        if isinstance(batch_spec, RuntimeQueryBatchSpec) or query:
+        # TODO: what's being checked here is the presence of a `query` attribute, we could check this directly
+        # instead of doing an instance check
+        if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
-            assert query
+            query: str = batch_spec.query
+
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
                 query=query,

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -122,7 +122,7 @@ def sqlite_datasource(
     datasource = context.sources.add_sqlite(
         name="test_datasource",
         connection_string=f"sqlite:///{db_file}",
-        create_temp_table=True,
+        # don't set `create_temp_table` so that we can test the default behavior
     )
     return datasource
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_postgresql_data.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_postgresql_data.py
@@ -65,7 +65,6 @@ my_connection_string = PG_CONNECTION_STRING
 datasource = context.sources.add_postgres(
     name=datasource_name,
     connection_string=my_connection_string,
-    create_temp_table=True,
 )
 # </snippet>
 

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data_using_a_query.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_sql_data_using_a_query.py
@@ -29,9 +29,7 @@ connection_string = f"sqlite:///{sqlite_database_path}"
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=GxDatasourceWarning)
     datasource = context.sources.add_sql(
-        name="my_datasource",
-        connection_string=connection_string,
-        create_temp_table=True,
+        name="my_datasource", connection_string=connection_string
     )
 
 # Python

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -10,7 +10,6 @@ import logging
 import os
 import pathlib
 import shutil
-import sys
 from typing import List
 
 import pkg_resources
@@ -545,14 +544,12 @@ def pytest_parsed_arguments(request):
 
 @flaky(rerun_filter=delay_rerun, max_runs=3, min_passes=1)
 @pytest.mark.parametrize("integration_test_fixture", docs_test_matrix, ids=idfn)
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 def test_docs(integration_test_fixture, tmp_path, pytest_parsed_arguments):
     _check_for_skipped_tests(pytest_parsed_arguments, integration_test_fixture)
     _execute_integration_test(integration_test_fixture, tmp_path)
 
 
 @pytest.mark.parametrize("test_configuration", integration_test_matrix, ids=idfn)
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 @pytest.mark.slow  # 79.77s
 def test_integration_tests(test_configuration, tmp_path, pytest_parsed_arguments):
     _check_for_skipped_tests(pytest_parsed_arguments, test_configuration)


### PR DESCRIPTION
Fix the metric calculation and lookup error that occurs when `create_temp_table=False` with a fluent `QueryAsset`.

~Fix is applied inside `SQLAlchemyExecutionEngine.get_batch_data_and_markers()`.~
Fix is applied by building a `RuntimeQueryBatchSpec` inside of `QueryAsset.get_batch_list_from_batch_request()`
QueryAsset batch spec needs to follow the same path as a `RuntimeQueryBatchSpec` instead of a `SqlAlchemyDatasourceBatchSpec`.

`RuntimeQueryBatchSpec` is `IDDict` & `BatchSpec`.
It's a dictionary with a `query` and `batch_data` convenience properties.

https://github.com/great-expectations/great_expectations/blob/93ffeaf96f26928ec351821e8c5496e8c3d8e9f6/great_expectations/core/batch_spec.py#L202-L215

`SqlAlchemyDatasourceBatchSpec` has `limt`, `schema` and `batch_data`convenience properties.