### PR TITLE
[BUGFIX] v1 - `QueryAsset` works with `create_temp_table=False`

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -172,7 +172,7 @@ class SqlAlchemyBatchData(BatchData):
                 )
             )
         elif query:
-            self._selectable = self._generate_selectable_from_query(
+            self._selectable = self._generate_selectable_from_query(  # type: ignore[call-overload] # https://github.com/python/mypy/issues/14764
                 query, dialect, create_temp_table, temp_table_schema_name
             )
         else:

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -357,7 +357,7 @@ class SqlAlchemyBatchData(BatchData):
     def _generate_selectable_from_query(
         self,
         query: str,
-        dialect: GXSqlDialect | None,
+        dialect: GXSqlDialect,
         create_temp_table: Literal[False],
         temp_table_schema_name: Optional[str] = ...,
     ) -> sqlalchemy.TextClause:
@@ -366,7 +366,7 @@ class SqlAlchemyBatchData(BatchData):
     def _generate_selectable_from_query(
         self,
         query: str,
-        dialect: GXSqlDialect | None,
+        dialect: GXSqlDialect,
         create_temp_table: bool,
         temp_table_schema_name: Optional[str] = None,
     ) -> sqlalchemy.Table | sqlalchemy.TextClause:

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Tuple, overload
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, overload
 
 from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.sqlalchemy import (
@@ -345,13 +345,33 @@ class SqlAlchemyBatchData(BatchData):
             schema=schema_name,
         )
 
+    @overload
+    def _generate_selectable_from_query(
+        self,
+        query: str,
+        dialect: GXSqlDialect,
+        create_temp_table: Literal[True],
+        temp_table_schema_name: Optional[str] = ...,
+    ) -> sqlalchemy.Table:
+        ...
+
+    @overload
+    def _generate_selectable_from_query(
+        self,
+        query: str,
+        dialect: GXSqlDialect,
+        create_temp_table: Literal[False],
+        temp_table_schema_name: Optional[str] = ...,
+    ) -> sqlalchemy.TextClause:
+        ...
+
     def _generate_selectable_from_query(
         self,
         query: str,
         dialect: GXSqlDialect,
         create_temp_table: bool,
         temp_table_schema_name: Optional[str] = None,
-    ) -> sqlalchemy.Table:
+    ) -> sqlalchemy.Table | sqlalchemy.TextClause:
         """Helper method to generate Selectable from query string.
 
         Args:

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -180,9 +180,6 @@ class SqlAlchemyBatchData(BatchData):
                 )
             )
         elif query_is_present:
-            # NOTE: we could go down this path for query but there's logic in here that relies on `Selectable`
-            # implementing __bool__ which it doesn't.
-            # This should be easy to deal with though if it fixes the other query issues.
             self._selectable = self._generate_selectable_from_query(
                 query, dialect, create_temp_table, temp_table_schema_name
             )

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -96,7 +96,7 @@ class SqlAlchemyBatchData(BatchData):
         source_table_name: Optional[str] = None,
     ) -> None:
         """A Constructor used to initialize and SqlAlchemy Batch, create an id for it, and verify that all necessary
-        parameters have been provided. If a Query is given, also builds a temporary table for this query
+        parameters have been provided. Builds a temporary table for the `query` if `create_temp_table=True`.
 
             Args:
                 engine (SqlAlchemy Engine): \

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -377,11 +377,11 @@ class SqlAlchemyBatchData(BatchData):
         Args:
             query (str): query passed in as RuntimeBatchRequest.
             dialect (GXSqlDialect): Needed for _create_temporary_table, since different backends name temp_tables differently.
-            create_temp_table (bool): Should we create a temp_table?
+            create_temp_table (bool): Should we create a temp_table? If not a `TextClause` will be returned instead of a Table.
             temp_table_schema_name (Optional[str], optional): Optional string for temp_table schema.  Defaults to None.
 
         Returns:
-            sqlalchemy.Table: SqlAlchemy Table that is Selectable.
+            sqlalchemy.Table: SqlAlchemy Table that is Selectable or a TextClause.
         """
         if not create_temp_table:
             return sa.text(query)

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -174,6 +174,9 @@ class SqlAlchemyBatchData(BatchData):
                 )
             )
         elif query:
+            # NOTE: we could go down this path for query but there's logic in here that relies on `Selectable`
+            # implementing __bool__ which it doesn't.
+            # This should be easy to deal with though if it fixes the other query issues.
             self._selectable = self._generate_selectable_from_query(
                 query, dialect, create_temp_table, temp_table_schema_name
             )

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1317,7 +1317,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             # Query is a valid SELECT query that begins with r"\w+select\w"
             # TODO:? strip `;` from the end of the query??
             selectable = sa.select(
-                sa.text(query.lstrip()[6:].lstrip().rstrip(";"))
+                sa.text(query.lstrip()[6:].strip().rstrip(";").rstrip())
             ).subquery()
 
         return selectable

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1315,6 +1315,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             if not isinstance(query, str):
                 raise ValueError(f"SQL query should be a str but got {query}")
             # Query is a valid SELECT query that begins with r"\w+select\w"
+            # TODO:? strip `;` from the end of the query??
             selectable = sa.select(sa.text(query.lstrip()[6:].lstrip())).subquery()
 
         return selectable

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1324,7 +1324,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
     @override
     def get_batch_data_and_markers(
         self, batch_spec: BatchSpec
-    ) -> Tuple[Any, BatchMarkers]:
+    ) -> Tuple[SqlAlchemyBatchData | None, BatchMarkers]:
         if not isinstance(
             batch_spec, (SqlAlchemyDatasourceBatchSpec, RuntimeQueryBatchSpec)
         ):

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,22 +1360,21 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
+        selectable: Union[
+            sqlalchemy.Selectable, str
+        ] = self._build_selectable_from_batch_spec(batch_spec=batch_spec)
         # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly
         # instead of doing an instance check
         if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
-            query: str = batch_spec.query
 
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
-                query=query,
+                selectable=selectable,
                 temp_table_schema_name=temp_table_schema_name,
                 create_temp_table=create_temp_table,
             )
         elif isinstance(batch_spec, SqlAlchemyDatasourceBatchSpec):
-            selectable: Union[
-                sqlalchemy.Selectable, str
-            ] = self._build_selectable_from_batch_spec(batch_spec=batch_spec)
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
                 selectable=selectable,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1373,7 +1373,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
-                selectable=selectable,
+                query=selectable,
                 temp_table_schema_name=temp_table_schema_name,
                 create_temp_table=create_temp_table,
             )

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1360,6 +1360,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
+        # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly
+        # instead of doing an instance check
         if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
             query: str = batch_spec.query

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1315,7 +1315,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             if not isinstance(query, str):
                 raise ValueError(f"SQL query should be a str but got {query}")
             # Query is a valid SELECT query that begins with r"\w+select\w"
-            # TODO:? strip `;` from the end of the query??
             selectable = sa.select(
                 sa.text(query.lstrip()[6:].strip().rstrip(";").rstrip())
             ).subquery()

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1316,7 +1316,9 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                 raise ValueError(f"SQL query should be a str but got {query}")
             # Query is a valid SELECT query that begins with r"\w+select\w"
             # TODO:? strip `;` from the end of the query??
-            selectable = sa.select(sa.text(query.lstrip()[6:].lstrip())).subquery()
+            selectable = sa.select(
+                sa.text(query.lstrip()[6:].lstrip().rstrip(";"))
+            ).subquery()
 
         return selectable
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1248,7 +1248,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
     def _build_selectable_from_batch_spec(
         self, batch_spec: BatchSpec
-    ) -> Union[sqlalchemy.Selectable, str]:
+    ) -> sqlalchemy.Selectable:
         if (
             batch_spec.get("query") is not None
             and batch_spec.get("sampling_method") is not None
@@ -1363,9 +1363,9 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
-        selectable: Union[
-            sqlalchemy.Selectable, str
-        ] = self._build_selectable_from_batch_spec(batch_spec=batch_spec)
+        selectable: sqlalchemy.Selectable = self._build_selectable_from_batch_spec(
+            batch_spec=batch_spec
+        )
         # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly
         # instead of doing an instance check
         if isinstance(batch_spec, RuntimeQueryBatchSpec):

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1324,7 +1324,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
     @override
     def get_batch_data_and_markers(
         self, batch_spec: BatchSpec
-    ) -> Tuple[SqlAlchemyBatchData | None, BatchMarkers]:
+    ) -> Tuple[SqlAlchemyBatchData, BatchMarkers]:
         if not isinstance(
             batch_spec, (SqlAlchemyDatasourceBatchSpec, RuntimeQueryBatchSpec)
         ):

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -100,18 +100,24 @@ def pandas_data(
 
 
 def sqlite_datasource(
-    context: AbstractDataContext, db_filename: str
+    context: AbstractDataContext, db_filename: str | pathlib.Path
 ) -> SqliteDatasource:
-    relative_path = pathlib.Path(
-        "..",
-        "..",
-        "..",
-        "test_sets",
-        "taxi_yellow_tripdata_samples",
-        "sqlite",
-        db_filename,
-    )
-    db_file = pathlib.Path(__file__).parent.joinpath(relative_path).resolve(strict=True)
+    db_file_path = pathlib.Path(db_filename)
+    if db_file_path.is_absolute():
+        db_file = db_file_path.resolve(strict=True)
+    else:
+        relative_path = pathlib.Path(
+            "..",
+            "..",
+            "..",
+            "test_sets",
+            "taxi_yellow_tripdata_samples",
+            "sqlite",
+            db_filename,
+        )
+        db_file = (
+            pathlib.Path(__file__).parent.joinpath(relative_path).resolve(strict=True)
+        )
     datasource = context.sources.add_sqlite(
         name="test_datasource",
         connection_string=f"sqlite:///{db_file}",

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -115,7 +115,7 @@ def sqlite_datasource(
     datasource = context.sources.add_sqlite(
         name="test_datasource",
         connection_string=f"sqlite:///{db_file}",
-        create_temp_table=True,
+        # don't set `create_temp_table` so that we can test the default behavior
     )
     return datasource
 

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -102,22 +102,16 @@ def pandas_data(
 def sqlite_datasource(
     context: AbstractDataContext, db_filename: str | pathlib.Path
 ) -> SqliteDatasource:
-    db_file_path = pathlib.Path(db_filename)
-    if db_file_path.is_absolute():
-        db_file = db_file_path.resolve(strict=True)
-    else:
-        relative_path = pathlib.Path(
-            "..",
-            "..",
-            "..",
-            "test_sets",
-            "taxi_yellow_tripdata_samples",
-            "sqlite",
-            db_filename,
-        )
-        db_file = (
-            pathlib.Path(__file__).parent.joinpath(relative_path).resolve(strict=True)
-        )
+    relative_path = pathlib.Path(
+        "..",
+        "..",
+        "..",
+        "test_sets",
+        "taxi_yellow_tripdata_samples",
+        "sqlite",
+        db_filename,
+    )
+    db_file = pathlib.Path(__file__).parent.joinpath(relative_path).resolve(strict=True)
     datasource = context.sources.add_sqlite(
         name="test_datasource",
         connection_string=f"sqlite:///{db_file}",

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -100,27 +100,47 @@ def test_batch_head(
 
 
 @pytest.mark.sqlite
-def test_sql_query_data_asset(empty_data_context):
-    context = empty_data_context
-    datasource = sqlite_datasource(context, "yellow_tripdata.db")
-    passenger_count_value = 5
-    asset = (
-        datasource.add_query_asset(
-            name="query_asset",
-            query=f"   SELECT * from yellow_tripdata_sample_2019_02 WHERE passenger_count = {passenger_count_value}",
+class TestQueryAssets:
+    def test_success_with_splitters(self, empty_data_context):
+        context = empty_data_context
+        datasource = sqlite_datasource(context, "yellow_tripdata.db")
+        passenger_count_value = 5
+        asset = (
+            datasource.add_query_asset(
+                name="query_asset",
+                query=f"   SELECT * from yellow_tripdata_sample_2019_02 WHERE passenger_count = {passenger_count_value}",
+            )
+            .add_splitter_year_and_month(column_name="pickup_datetime")
+            .add_sorters(["year"])
         )
-        .add_splitter_year_and_month(column_name="pickup_datetime")
-        .add_sorters(["year"])
-    )
-    validator = context.get_validator(
-        batch_request=asset.build_batch_request({"year": 2019})
-    )
-    result = validator.expect_column_distinct_values_to_equal_set(
-        column="passenger_count",
-        value_set=[passenger_count_value],
-        result_format={"result_format": "BOOLEAN_ONLY"},
-    )
-    assert result.success
+        validator = context.get_validator(
+            batch_request=asset.build_batch_request({"year": 2019})
+        )
+        result = validator.expect_column_distinct_values_to_equal_set(
+            column="passenger_count",
+            value_set=[passenger_count_value],
+            result_format={"result_format": "BOOLEAN_ONLY"},
+        )
+        assert result.success
+
+    def test_splitter_filtering(self, empty_data_context):
+        context = empty_data_context
+        datasource = sqlite_datasource(
+            context, "../../test_cases_for_sql_data_connector.db"
+        )
+
+        asset = datasource.add_query_asset(
+            name="trip_asset_split_by_event_type",
+            query="SELECT * FROM table_partitioned_by_date_column__A",
+        ).add_splitter_column_value("event_type")
+        batch_request = asset.build_batch_request({"event_type": "start"})
+        validator = context.get_validator(batch_request=batch_request)
+
+        # All rows returned by head have the start event_type.
+        result = validator.execution_engine.batch_manager.active_batch.head(n_rows=50)
+        unique_event_types = set(result.data["event_type"].unique())
+        print(f"{unique_event_types=}")
+        assert unique_event_types == {"start"}
 
 
 @pytest.mark.filesystem

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -10,7 +10,6 @@ import logging
 import os
 import pathlib
 import shutil
-import sys
 from typing import List
 
 import pkg_resources
@@ -518,14 +517,12 @@ def pytest_parsed_arguments(request):
 
 @flaky(rerun_filter=delay_rerun, max_runs=3, min_passes=1)
 @pytest.mark.parametrize("integration_test_fixture", docs_test_matrix, ids=idfn)
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 def test_docs(integration_test_fixture, tmp_path, pytest_parsed_arguments):
     _check_for_skipped_tests(pytest_parsed_arguments, integration_test_fixture)
     _execute_integration_test(integration_test_fixture, tmp_path)
 
 
 @pytest.mark.parametrize("test_configuration", integration_test_matrix, ids=idfn)
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 @pytest.mark.slow  # 79.77s
 def test_integration_tests(test_configuration, tmp_path, pytest_parsed_arguments):
     _check_for_skipped_tests(pytest_parsed_arguments, test_configuration)

--- a/tests/validator/test_v1_validator.py
+++ b/tests/validator/test_v1_validator.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from pprint import pformat as pf
+
 import pytest
 
 from great_expectations.core.batch_config import BatchConfig
@@ -176,7 +180,7 @@ def test_validate_expectation_with_batch_asset_options(
             value_set=[desired_event_type],
         )
     )
-
+    print(f"Result dict ->\n{pf(result)}")
     assert result.success
 
 


### PR DESCRIPTION
Applying the `0.18.x` fix to `develop.
- https://github.com/great-expectations/great_expectations/pull/9148

Discovered that the `0.18.x`/`0.18.6` temp table QueryAsset fix caused splitter logic not to be applied to the queries.
Fixed this by re-compiling the query after the splitter logic was applied in the `selectable`.