### PR TITLE
[CONTRIB] ExpectColumnValuesToBePresentInOtherTable - Wording update

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -164,7 +164,9 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
         final_value = metrics.get("query.template_values")[0]["COUNT(1)"]
         return ExpectationValidationResult(
             success=(final_value == 0),
-            result={"observed_value": f"{final_value} missing item{'s' if final_value != 1 else ''}"}
+            result={
+                "observed_value": f"{final_value} missing item{'s' if final_value != 1 else ''}"
+            },
         )
 
     examples = [

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -111,7 +111,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
 
         template_dict = configuration.kwargs.get("template_dict")
 
-        template_str = "All values in column $foreign_key_column are present in column $primary_key_column_in_foreign_table of  table $foreign_table."
+        template_str = "All values in column $foreign_key_column are present in column $primary_key_column_in_foreign_table of table $foreign_table."
 
         params = {
             "foreign_key_column": template_dict["foreign_key_column"],

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -164,7 +164,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
         final_value = metrics.get("query.template_values")[0]["COUNT(1)"]
         return ExpectationValidationResult(
             success=(final_value == 0),
-            result={"observed_value": f"{final_value} missing items"},
+            result={"observed_value": f"{final_value} missing item{'s' if final_value != 1 else ''}"}
         )
 
     examples = [

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -163,7 +163,8 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
         self._validate_template_dict(configuration)
         final_value = metrics.get("query.template_values")[0]["COUNT(1)"]
         return ExpectationValidationResult(
-            success=(final_value == 0), result={"observed_value": final_value}
+            success=(final_value == 0),
+            result={"observed_value": f"{final_value} missing items."},
         )
 
     examples = [

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -111,7 +111,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
 
         template_dict = configuration.kwargs.get("template_dict")
 
-        template_str = "All values in column $foreign_key_column are present in column $primary_key_column_in_foreign_table of  table $foreign_table. (Observed Value is the number of missing values)."
+        template_str = "All values in column $foreign_key_column are present in column $primary_key_column_in_foreign_table of  table $foreign_table."
 
         params = {
             "foreign_key_column": template_dict["foreign_key_column"],

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -164,7 +164,7 @@ class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
         final_value = metrics.get("query.template_values")[0]["COUNT(1)"]
         return ExpectationValidationResult(
             success=(final_value == 0),
-            result={"observed_value": f"{final_value} missing items."},
+            result={"observed_value": f"{final_value} missing items"},
         )
 
     examples = [


### PR DESCRIPTION
Wording of Expectation Rendering update after review in Product channel. 
![Screenshot 2023-12-20 at 4 17 52 PM](https://github.com/great-expectations/great_expectations/assets/25670697/56c69d59-c01f-4530-b9d9-ed46b8f4767e)
![Screenshot 2023-12-20 at 4 17 24 PM](https://github.com/great-expectations/great_expectations/assets/25670697/e3314b72-199e-421c-9f00-2235f534afb7)

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated