### PR TITLE
[BUGFIX] 0.18.x - Apply `QueryAsset` splitting fix

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1248,7 +1248,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
     def _build_selectable_from_batch_spec(
         self, batch_spec: BatchSpec
-    ) -> Union[sqlalchemy.Selectable, str]:
+    ) -> sqlalchemy.Selectable:
         if (
             batch_spec.get("query") is not None
             and batch_spec.get("sampling_method") is not None
@@ -1315,14 +1315,16 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             if not isinstance(query, str):
                 raise ValueError(f"SQL query should be a str but got {query}")
             # Query is a valid SELECT query that begins with r"\w+select\w"
-            selectable = sa.select(sa.text(query.lstrip()[6:].lstrip())).subquery()
+            selectable = sa.select(
+                sa.text(query.lstrip()[6:].strip().rstrip(";").rstrip())
+            ).subquery()
 
         return selectable
 
     @override
     def get_batch_data_and_markers(
         self, batch_spec: BatchSpec
-    ) -> Tuple[Any, BatchMarkers]:
+    ) -> Tuple[SqlAlchemyBatchData, BatchMarkers]:
         if not isinstance(
             batch_spec, (SqlAlchemyDatasourceBatchSpec, RuntimeQueryBatchSpec)
         ):
@@ -1360,22 +1362,27 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = batch_spec.get(
             "create_temp_table", self._create_temp_table
         )
+        # this is where splitter components are added to the selectable
+        selectable: sqlalchemy.Selectable = self._build_selectable_from_batch_spec(
+            batch_spec=batch_spec
+        )
         # NOTE: what's being checked here is the presence of a `query` attribute, we could check this directly
         # instead of doing an instance check
         if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
-            query: str = batch_spec.query
-
+            # re-compile the query to include any new parameters
+            compiled_query = selectable.compile(
+                dialect=self.engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+            query_str = str(compiled_query)
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
-                query=query,
+                query=query_str,
                 temp_table_schema_name=temp_table_schema_name,
                 create_temp_table=create_temp_table,
             )
         elif isinstance(batch_spec, SqlAlchemyDatasourceBatchSpec):
-            selectable: Union[
-                sqlalchemy.Selectable, str
-            ] = self._build_selectable_from_batch_spec(batch_spec=batch_spec)
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
                 selectable=selectable,

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -106,8 +106,7 @@ def pandas_data(
 
 
 def sqlite_datasource(
-    context: AbstractDataContext,
-    db_filename: str,
+    context: AbstractDataContext, db_filename: str | pathlib.Path
 ) -> SqliteDatasource:
     relative_path = pathlib.Path(
         "..",

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -110,27 +110,47 @@ def test_batch_head(
 
 
 @pytest.mark.sqlite
-def test_sql_query_data_asset(empty_data_context):
-    context = empty_data_context
-    datasource = sqlite_datasource(context, "yellow_tripdata.db")
-    passenger_count_value = 5
-    asset = (
-        datasource.add_query_asset(
-            name="query_asset",
-            query=f"   SELECT * from yellow_tripdata_sample_2019_02 WHERE passenger_count = {passenger_count_value}",
+class TestQueryAssets:
+    def test_success_with_splitters(self, empty_data_context):
+        context = empty_data_context
+        datasource = sqlite_datasource(context, "yellow_tripdata.db")
+        passenger_count_value = 5
+        asset = (
+            datasource.add_query_asset(
+                name="query_asset",
+                query=f"   SELECT * from yellow_tripdata_sample_2019_02 WHERE passenger_count = {passenger_count_value}",
+            )
+            .add_splitter_year_and_month(column_name="pickup_datetime")
+            .add_sorters(["year"])
         )
-        .add_splitter_year_and_month(column_name="pickup_datetime")
-        .add_sorters(["year"])
-    )
-    validator = context.get_validator(
-        batch_request=asset.build_batch_request({"year": 2019})
-    )
-    result = validator.expect_column_distinct_values_to_equal_set(
-        column="passenger_count",
-        value_set=[passenger_count_value],
-        result_format={"result_format": "BOOLEAN_ONLY"},
-    )
-    assert result.success
+        validator = context.get_validator(
+            batch_request=asset.build_batch_request({"year": 2019})
+        )
+        result = validator.expect_column_distinct_values_to_equal_set(
+            column="passenger_count",
+            value_set=[passenger_count_value],
+            result_format={"result_format": "BOOLEAN_ONLY"},
+        )
+        assert result.success
+
+    def test_splitter_filtering(self, empty_data_context):
+        context = empty_data_context
+        datasource = sqlite_datasource(
+            context, "../../test_cases_for_sql_data_connector.db"
+        )
+
+        asset = datasource.add_query_asset(
+            name="trip_asset_split_by_event_type",
+            query="SELECT * FROM table_partitioned_by_date_column__A",
+        ).add_splitter_column_value("event_type")
+        batch_request = asset.build_batch_request({"event_type": "start"})
+        validator = context.get_validator(batch_request=batch_request)
+
+        # All rows returned by head have the start event_type.
+        result = validator.execution_engine.batch_manager.active_batch.head(n_rows=50)
+        unique_event_types = set(result.data["event_type"].unique())
+        print(f"{unique_event_types=}")
+        assert unique_event_types == {"start"}
 
 
 @pytest.mark.filesystem


### PR DESCRIPTION
The PR See below was applying the `create_temp_table` fix that was already in `0.18.x` but additionally solved the problem of splitters not being respected.
- https://github.com/great-expectations/great_expectations/pull/9150
