### PR TITLE
[DOCS] Remove Holiday Support Message from GX Cloud Support Topic

### DIFF
--- a/docs/docusaurus/docs/cloud/about_gx.md
+++ b/docs/docusaurus/docs/cloud/about_gx.md
@@ -137,12 +137,6 @@ A session is the period of time that you’re signed in to your GX Cloud account
 
 ## Get support
 
-:::note Support during the holiday season
-
-Customer support is not available from December 25 to December 29, 2023. If you request support after December 25, we will respond the first week of January 2024.
-
-:::
-
 If you can't find what you need in the documentation, we're here to help! You can 
 email us at [support@greatexpectations.io](mailto:support@greatexpectations.io) or create a ticket on our [support portal](https://support.greatexpectations.io).
 


### PR DESCRIPTION
During the holidays, a message was added to the [GX Cloud support topic](https://docs.greatexpectations.io/docs/cloud/about_gx#get-support) informing users of the support schedule for the holiday season. The holiday season is over, and the OOO message is no longer relevant or accurate. This PR removed the message. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated

FYI: @joshzzheng 