### PR TITLE
[DOCS] Correct Why GX Cloud Topic Formatting

### DIFF
--- a/docs/docusaurus/docs/cloud/gx_cloud_lp.md
+++ b/docs/docusaurus/docs/cloud/gx_cloud_lp.md
@@ -11,10 +11,10 @@ displayed_sidebar: gx_cloud
 import LinkCardGrid from '/docs/components/LinkCardGrid';
 import LinkCard from '/docs/components/LinkCard';
 
-<p class="DocItem__header-description">GX Cloud is the fastest and most reliable way to validate your data. Connect, test, and validate Data Assets in a web-based UI. 
-
+<p class="DocItem__header-description">GX Cloud is the fastest and most reliable way to validate your data. Connect, test, and validate Data Assets in a web-based UI.
+<br /> 
 To learn how its fast setup, collaboration-forward approach, and accessibility to technical and nontechnical stakeholders could be the perfect solution for your organization, see <a href='/docs/cloud/why_gx_cloud'>Why GX Cloud</a>.
-
+<br />
 If you're ready to get started and using Snowflake to store your data, try the <a href='/docs/cloud/quickstarts/snowflake_quickstart'>Quickstart for GX Cloud and Snowflake</a>.
 </p>
 

--- a/docs/docusaurus/docs/cloud/gx_cloud_lp.md
+++ b/docs/docusaurus/docs/cloud/gx_cloud_lp.md
@@ -11,11 +11,11 @@ displayed_sidebar: gx_cloud
 import LinkCardGrid from '/docs/components/LinkCardGrid';
 import LinkCard from '/docs/components/LinkCard';
 
-<p class="DocItem__header-description">GX Cloud is the answer when you need proactive data quality.
-<br />
-<a href='/docs/cloud/why_gx_cloud'>Learn how its fast setup, collaboration-forward approach, and accessibility to technical and nontechnical stakeholders alike helps you build data quality that lasts</a>, or <a href='https://greatexpectations.io/cloud'>request a GX Cloud Beta account</a> to try it out yourself.
-< br/>
-If you're ready to get started and are connecting a Snowflake table, try the <a href='/docs/cloud/quickstarts/snowflake_quickstart'>Quickstart for GX Cloud and Snowflake</a>.
+<p class="DocItem__header-description">GX Cloud is the fastest and most reliable way to validate your data. Connect, test, and validate Data Assets in a web-based UI. 
+
+To learn how its fast setup, collaboration-forward approach, and accessibility to technical and nontechnical stakeholders could be the perfect solution for your organization, see <a href='/docs/cloud/why_gx_cloud'>Why GX Cloud</a>.
+
+If you're ready to get started and using Snowflake to store your data, try the <a href='/docs/cloud/quickstarts/snowflake_quickstart'>Quickstart for GX Cloud and Snowflake</a>.
 </p>
 
 ### Get started

--- a/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
+++ b/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
@@ -12,9 +12,9 @@ If you’ve made it this far, you know that you need a data quality framework—
 
 Proactive data quality lets you catch issues before they can become problems downstream. And with GX Cloud, you can have your first proactive data quality tests in place today.
 
-GX Cloud makes it easy to [**set up your first data quality checks** automatically](/docs/cloud/expectation_suites/manage_expectation_suites#automatically-create-an-expectation-suite-that-tests-for-missing-data). Even a dataset you’ve never seen before can be brought under test in minutes.
+GX Cloud makes it easy to [set up your first data quality checks automatically](/docs/cloud/expectation_suites/manage_expectation_suites#automatically-create-an-expectation-suite-that-tests-for-missing-data). Even a dataset you’ve never seen before can be brought under test in minutes.
 
-# Expect great things
+## Expect great things
 
 An Expectation is a simple, verifiable assertion about the way your data should be. 
 
@@ -26,7 +26,7 @@ Plus, [Expectations are reusable](/docs/cloud/checkpoints/manage_checkpoints) an
 
 Expectations in GX Cloud tell you exactly what they’re for **using plain language, start to finish**. Self-explanatory names and results expressed in full sentences mean anyone can understand an Expectation and Expectation Suite on first look.
 
-# Collaboration upgrades
+## Collaboration upgrades
 
 To build a culture of organizational trust in your data, you need the experience, insights, and buy-in of other technical teams in your organization, plus that of your nontechnical stakeholders.
 
@@ -42,7 +42,7 @@ GX Cloud’s business-friendly visualizations of test results lets stakeholders 
 
 Because GX Cloud **empowers stakeholders to contribute and understand independently**, stakeholders finally feel like the data quality process is backed by a transparency that fosters maximum trust.
 
-# Clear, central communication
+## Clear, central communication
 
 Building a shared understanding of your data quality is hard enough already without misunderstandings or lost-in-translation moments cropping up. GX Cloud makes it easy for everyone to stay on the same page: 
 
@@ -57,9 +57,10 @@ Historical results are displayed with **trend visualizations** accessible to tec
 
 <img align ='left' width='50%' src={require('/docs/cloud/why_gx_cloud_images/trend_visualizations.png').default}/>
 
-Effective communication is easier when everyone shares a single source of reliable information. GX Cloud’s **clear visual UI organically fosters standardized processes**. Your team members will naturally build similar perspectives even before they directly interact—making communication smoother from the start. 
+Effective communication is easier when everyone shares a single source of reliable information. GX Cloud’s **clear visual UI organically fosters standardized processes**. Your team members will naturally build similar perspectives even before they directly interact—making communication smoother from the start.
+ 
 
-# Sustainable growth
+## Sustainable growth
 
 A cornerstone of growing an effective data quality framework is to **embrace iteration**. GX Cloud is built to support that.
 
@@ -67,13 +68,13 @@ A cornerstone of growing an effective data quality framework is to **embrace ite
 
 There’s nowhere the need for iteration is more constant than when it comes to creating and configuring your data quality tests: as you uncover more nuances of your data, your operational needs change, or your data stack evolves, you’ll need to continue updating your Expectations. 
 
-Your testing feedback loop stays short and responsive in GX Cloud. Its visual GUI for Expectation editing makes it [**a snap to create and edit** them for nontechnical teams, while data engineers can use the power of GX Cloud’s API](/docs/cloud/expectations/manage_expectations#add-an-expectation). 
+Your testing feedback loop stays short and responsive in GX Cloud. Its visual GUI for Expectation editing makes it [a snap to create and edit them for nontechnical teams, while data engineers can use the power of GX Cloud’s API](/docs/cloud/expectations/manage_expectations#add-an-expectation). 
 
 And you can make those changes with confidence that you won’t disrupt your view of your historical results: **GX Cloud captures every change to an Expectation** within your test result’s historical charts and visualizations, so you can see your Validation Results in context with your evolving understanding of your data. 
 
 <br clear="left" />
 
-# But you don't have to take our word for it
+## Don't have to take our word for it
 
 GX Cloud’s free tier has plenty of power. Give it a try and see for yourself how GX Cloud can help you build a proactive, collaboration-ready data quality framework.
 

--- a/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
+++ b/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
@@ -58,7 +58,7 @@ Historical results are displayed with **trend visualizations** accessible to tec
 <img align ='left' width='50%' src={require('/docs/cloud/why_gx_cloud_images/trend_visualizations.png').default}/>
 
 Effective communication is easier when everyone shares a single source of reliable information. GX Cloud’s **clear visual UI organically fosters standardized processes**. Your team members will naturally build similar perspectives even before they directly interact—making communication smoother from the start.
- 
+
 
 ## Sustainable growth
 
@@ -72,9 +72,7 @@ Your testing feedback loop stays short and responsive in GX Cloud. Its visual GU
 
 And you can make those changes with confidence that you won’t disrupt your view of your historical results: **GX Cloud captures every change to an Expectation** within your test result’s historical charts and visualizations, so you can see your Validation Results in context with your evolving understanding of your data. 
 
-<br clear="left" />
-
-## Don't have to take our word for it
+## Don't take our word for it
 
 GX Cloud’s free tier has plenty of power. Give it a try and see for yourself how GX Cloud can help you build a proactive, collaboration-ready data quality framework.
 

--- a/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
+++ b/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
@@ -76,4 +76,6 @@ And you can make those changes with confidence that you won’t disrupt your vie
 
 GX Cloud’s free tier has plenty of power. Give it a try and see for yourself how GX Cloud can help you build a proactive, collaboration-ready data quality framework.
 
+## Next steps
+
 - [Sign up for GX Cloud](https://greatexpectations.io/cloud)


### PR DESCRIPTION
All secondary headings in the _[Why GX Cloud topic](https://docs.greatexpectations.io/docs/cloud/why_gx_cloud)_ are H1. For consistency with existing topics and to meet the requirements specified in our style guides, secondary headings should be H2.  Also, some external links are partially bolded. Links should not be partially bolded. This PR corrects these issues.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated