### PR TITLE
[MAINTENANCE] Tests which consider ExpectationsStore optional (do not merge)

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -335,6 +335,10 @@ class AbstractDataContext(ConfigPeer, ABC):
         )
         submit_event(event=DataContextInitializedEvent())
 
+        # demonstrate which tests use a context without ExpectationsStore
+        if not self.stores.get(self.expectations_store_name):
+            raise RuntimeError("ExpectationsStore is required.")
+
     def _init_config_provider(self) -> _ConfigurationProvider:
         config_provider = _ConfigurationProvider()
         self._register_providers(config_provider)


### PR DESCRIPTION
Example PR to demonstrate which tests use a DataContext without an ExpectationsStore.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
