### PR TITLE
[DOCS] Add Directive Text to Snowflake Quickstart Tiles

### DIFF
--- a/docs/docusaurus/docs/cloud/gx_cloud_lp.md
+++ b/docs/docusaurus/docs/cloud/gx_cloud_lp.md
@@ -23,7 +23,7 @@ If you're ready to get started and using Snowflake to store your data, try the <
 <LinkCardGrid>
   <LinkCard topIcon label="About GX Cloud" description="Learn more about GX Cloud features and functionality and why it's the best choice for data validation." href="/docs/cloud/about_gx" icon="/img/small_gx_logo.png" />
   <LinkCard topIcon label="Set up GX Cloud" description="To get the most from GX Cloud, configure your environment first." href="/docs/cloud/set_up_gx_cloud" icon="/img/small_gx_logo.png" />
-  <LinkCard topIcon label="Quickstarts" description="Quickly start using GX Cloud with data platforms and orchestration tools." href="/docs/cloud/quickstarts/quickstart_lp" icon="/img/small_gx_logo.png" />
+  <LinkCard topIcon label="Quickstarts" description="Quickly start using GX Cloud with data platforms and orchestration tools.<br/>Start with the Quickstart for GX Cloud and Snowflake if you're new to GX Cloud, using Snowflake, and want to test features and functionality." href="/docs/cloud/quickstarts/quickstart_lp" icon="/img/small_gx_logo.png" />
 </LinkCardGrid>
 
 ### Manage

--- a/docs/docusaurus/docs/cloud/gx_cloud_lp.md
+++ b/docs/docusaurus/docs/cloud/gx_cloud_lp.md
@@ -15,7 +15,7 @@ import LinkCard from '/docs/components/LinkCard';
 <br /> 
 To learn how its fast setup, collaboration-forward approach, and accessibility to technical and nontechnical stakeholders could be the perfect solution for your organization, see <a href='/docs/cloud/why_gx_cloud'>Why GX Cloud</a>.
 <br />
-If you're ready to get started and using Snowflake to store your data, try the <a href='/docs/cloud/quickstarts/snowflake_quickstart'>Quickstart for GX Cloud and Snowflake</a>.
+Start with the <a href='/docs/cloud/quickstarts/snowflake_quickstart'>Quickstart for GX Cloud and Snowflake</a> if you're new to GX Cloud, using Snowflake, and want to test features and functionality.
 </p>
 
 ### Get started
@@ -23,7 +23,7 @@ If you're ready to get started and using Snowflake to store your data, try the <
 <LinkCardGrid>
   <LinkCard topIcon label="About GX Cloud" description="Learn more about GX Cloud features and functionality and why it's the best choice for data validation." href="/docs/cloud/about_gx" icon="/img/small_gx_logo.png" />
   <LinkCard topIcon label="Set up GX Cloud" description="To get the most from GX Cloud, configure your environment first." href="/docs/cloud/set_up_gx_cloud" icon="/img/small_gx_logo.png" />
-  <LinkCard topIcon label="Quickstarts" description="Quickly start using GX Cloud with data platforms and orchestration tools.<br/>Start with the Quickstart for GX Cloud and Snowflake if you're new to GX Cloud, using Snowflake, and want to test features and functionality." href="/docs/cloud/quickstarts/quickstart_lp" icon="/img/small_gx_logo.png" />
+  <LinkCard topIcon label="Quickstarts" description="Quickly start using GX Cloud with data platforms and orchestration tools." href="/docs/cloud/quickstarts/quickstart_lp" icon="/img/small_gx_logo.png" />
 </LinkCardGrid>
 
 ### Manage

--- a/docs/docusaurus/docs/cloud/quickstarts/quickstart_lp.md
+++ b/docs/docusaurus/docs/cloud/quickstarts/quickstart_lp.md
@@ -11,7 +11,7 @@ import LinkCard from '/docs/components/LinkCard';
 
 
 <LinkCardGrid>
-  <LinkCard topIcon label="Quickstart for GX Cloud and Snowflake" description="Quickly start using GX Cloud with Snowflake." href="/docs/cloud/quickstarts/snowflake_quickstart" icon="/img/snowflake_icon.png" />
+  <LinkCard topIcon label="Quickstart for GX Cloud and Snowflake" description="An ideal starting point if you’re new to GX Cloud, using Snowflake, and want to test features and functionality." icon="/img/snowflake_icon.png" />
   <LinkCard topIcon label="Quickstart for GX Cloud and Airflow" description="Quickly start using GX Cloud with Airflow." href="/docs/cloud/quickstarts/airflow_quickstart" icon="/img/airflow_icon.png" />
     <LinkCard topIcon label="Quickstart for GX Cloud and Python" description="Quickly start using GX Cloud with Python." href="/docs/cloud/quickstarts/python_quickstart" icon="/img/python_icon.svg" />
 </LinkCardGrid>


### PR DESCRIPTION
In this [Slack conversation](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1704404122726689), @joshzzheng requested the addition of descriptive text to the existing tiles for the Snowflake quickstart. This descriptive text intends to identify the quickstart as the preferred path for getting started with GX Cloud. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated