### PR TITLE
[FEATURE] `TableAsset.test_connection()` should fail if table is not queryable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ wheels/
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Unit test / coverage reports / profiling data
 htmlcov/
 .tox/
 .coverage
@@ -64,6 +64,7 @@ coverage.xml
 .hypothesis/
 src/dgtest/
 type_cov/
+.profiles/
 
 # Translations
 *.mo

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -913,6 +913,7 @@ class TableAsset(_SQLAsset):
         """
         datasource: SQLDatasource = self.datasource
         engine: sqlalchemy.Engine = datasource.get_engine()
+        # TODO: replace this with a select query
         inspector: sqlalchemy.Inspector = sa.inspect(engine)
 
         if self.schema_name and self.schema_name not in inspector.get_schema_names():

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -923,11 +923,9 @@ class TableAsset(_SQLAsset):
 
         try:
             with engine.connect() as connection:
-                connection.execute(
-                    sa.select([sa.text("test_connection")])
-                    .select_from(self.as_selectable())
-                    .limit(1)
-                )
+                table = sa.table(self.qualified_name)
+                # don't need to fetch any data, just want to make sure the table is accessible
+                connection.execute(sa.select(1, table).limit(1))
         except Exception as query_error:
             LOGGER.info(
                 f"{self.name} `.test_connection()` query failed: {query_error!r}"

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -923,7 +923,9 @@ class TableAsset(_SQLAsset):
 
         try:
             with engine.connect() as connection:
-                connection.execute(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
+                connection.execute(
+                    sa.text(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
+                )
         except Exception as query_error:
             LOGGER.info(
                 f"{self.name} `.test_connection()` query failed: {query_error!r}"

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -922,7 +922,8 @@ class TableAsset(_SQLAsset):
             )
 
         try:
-            engine.execute(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
+            with engine.connect() as connection:
+                connection.execute(f"SELECT 1 FROM {self.qualified_name} LIMIT 1;")
         except Exception as query_error:
             LOGGER.debug(
                 f"{self.name} `.test_connection()` query failed: {query_error!r}"

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -923,7 +923,7 @@ class TableAsset(_SQLAsset):
 
         try:
             engine.execute(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
-        except sa.exc.ProgrammingError as query_error:
+        except Exception as query_error:
             LOGGER.debug(
                 f"{self.name} `.test_connection()` query failed: {query_error!r}"
             )
@@ -931,15 +931,6 @@ class TableAsset(_SQLAsset):
                 f"Attempt to connect to table: {self.qualified_name} failed because the test query "
                 f"failed. Ensure the table exists and the user has access: {query_error}"
             ) from query_error
-        # TODO: remove this inspector check
-        if not inspector.has_table(
-            table_name=self.table_name,
-            schema=self.schema_name,
-        ):
-            raise TestConnectionError(
-                f"Attempt to connect to table: {self.qualified_name} failed because the table"
-                f" {self.table_name} does not exist or the user does not have access to it."
-            )
 
     @override
     def test_splitter_connection(self) -> None:

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -932,7 +932,7 @@ class TableAsset(_SQLAsset):
             )
             raise TestConnectionError(
                 f"Attempt to connect to table: {self.qualified_name} failed because the test query "
-                f"failed. Ensure the table exists and the user has access: {query_error}"
+                f"failed. Ensure the table exists and the user has access to select data from the table: {query_error}"
             ) from query_error
 
     @override

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -923,7 +923,7 @@ class TableAsset(_SQLAsset):
 
         try:
             with engine.connect() as connection:
-                table = sa.table(self.qualified_name)
+                table = sa.table(self.table_name, schema=self.schema_name)
                 # don't need to fetch any data, just want to make sure the table is accessible
                 connection.execute(sa.select(1, table).limit(1))
         except Exception as query_error:

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -924,7 +924,9 @@ class TableAsset(_SQLAsset):
         try:
             with engine.connect() as connection:
                 connection.execute(
-                    sa.text(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
+                    sa.select([sa.text("test_connection")])
+                    .select_from(self.as_selectable())
+                    .limit(1)
                 )
         except Exception as query_error:
             LOGGER.info(

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -923,9 +923,9 @@ class TableAsset(_SQLAsset):
 
         try:
             with engine.connect() as connection:
-                connection.execute(f"SELECT 1 FROM {self.qualified_name} LIMIT 1;")
+                connection.execute(f"SELECT * FROM {self.qualified_name} LIMIT 1;")
         except Exception as query_error:
-            LOGGER.debug(
+            LOGGER.info(
                 f"{self.name} `.test_connection()` query failed: {query_error!r}"
             )
             raise TestConnectionError(

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -291,6 +291,6 @@ def filesystem_datasource(test_backends, empty_data_context, request) -> Datasou
 @pytest.fixture
 def context() -> EphemeralDataContext:
     """Return an ephemeral data context for testing."""
-    ctx = get_context(cloud_mode=False)
+    ctx = get_context(mode="ephemeral")
     assert isinstance(ctx, EphemeralDataContext)
     return ctx

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 import pathlib
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from great_expectations import get_context
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
@@ -25,6 +27,9 @@ from great_expectations.datasource.fluent.interfaces import (
 from great_expectations.datasource.fluent.sources import (
     DEFAULT_PANDAS_DATA_ASSET_NAME,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.data_context import EphemeralDataContext
 
 logger = logging.getLogger(__name__)
 
@@ -285,3 +290,11 @@ def multibatch_datasource_test_data(
 @pytest.fixture(params=[pandas_filesystem_datasource, spark_filesystem_datasource])
 def filesystem_datasource(test_backends, empty_data_context, request) -> Datasource:
     return request.param(test_backends=test_backends, context=empty_data_context)
+
+
+@pytest.fixture
+def context() -> EphemeralDataContext:
+    """Return an ephemeral data context for testing."""
+    ctx = get_context(cloud_mode=False)
+    assert isinstance(ctx, EphemeralDataContext)
+    return ctx

--- a/tests/datasource/fluent/integration/conftest.py
+++ b/tests/datasource/fluent/integration/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -13,7 +12,7 @@ from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
-from great_expectations.data_context import AbstractDataContext
+from great_expectations.data_context import AbstractDataContext, EphemeralDataContext
 from great_expectations.datasource.fluent import (
     BatchRequest,
     PandasFilesystemDatasource,
@@ -27,9 +26,6 @@ from great_expectations.datasource.fluent.interfaces import (
 from great_expectations.datasource.fluent.sources import (
     DEFAULT_PANDAS_DATA_ASSET_NAME,
 )
-
-if TYPE_CHECKING:
-    from great_expectations.data_context import EphemeralDataContext
 
 logger = logging.getLogger(__name__)
 

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -76,7 +76,6 @@ class TestSnowflake:
         assert unqueryable_table, "no unqueryable tables found, cannot run test"
 
         with pytest.raises(TestConnectionError) as exc_info:
-            # TODO: check specific error message
             asset = snowflake_ds.add_table_asset(
                 name="un-reachable asset", table_name=unqueryable_table
             )

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -50,13 +50,9 @@ class TestSnowflake:
             "my_ds", connection_string=connection_string
         )
 
-        inspector_schemas = sa.inspection.inspect(
-            snowflake_ds.get_engine()
-        ).get_schema_names()
         inspector_tables = sa.inspection.inspect(
             snowflake_ds.get_engine()
         ).get_table_names()
-        print(f"schemas: {len(inspector_schemas)}")
         print(f"tables: {len(inspector_tables)}")
 
         table_name = random.choice(inspector_tables)
@@ -96,13 +92,9 @@ class TestSnowflake:
             "my_ds", connection_string=connection_string
         )
 
-        inspector_schemas = sa.inspection.inspect(
-            snowflake_ds.get_engine()
-        ).get_schema_names()
         inspector_tables = sa.inspection.inspect(
             snowflake_ds.get_engine()
         ).get_table_names()
-        print(f"schemas: {len(inspector_schemas)}")
         print(f"tables: {len(inspector_tables)}")
 
         table_name = random.choice(inspector_tables)

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -26,12 +26,10 @@ class TestSnowflake:
             param(
                 "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci",
                 id="missing role",
-                # marks=pytest.mark.skip,
             ),
             param(
                 "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}?warehouse=ci&role=ci",
                 id="missing database + schema",
-                # marks=pytest.mark.skip(reason="taking too long"),
             ),
             param(
                 "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci?warehouse=ci&role=ci",

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+import pytest
+import sqlalchemy as sa
+from pytest import param
+
+from great_expectations.datasource.fluent import (
+    SnowflakeDatasource,
+    TestConnectionError,
+)
+
+if TYPE_CHECKING:
+    from great_expectations.data_context import AbstractDataContext as DataContext
+
+
+@pytest.mark.snowflake
+class TestSnowflake:
+    @pytest.mark.parametrize(
+        "connection_string",
+        [
+            param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci",
+                id="missing role",
+                # marks=pytest.mark.skip,
+            ),
+            param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?role=ci",
+                id="missing warehouse",
+                # marks=pytest.mark.skip(reason="taking too long"),
+            ),
+            param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}?warehouse=ci&role=ci",
+                id="missing database + schema",
+                # marks=pytest.mark.skip(reason="taking too long"),
+            ),
+            param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci?warehouse=ci&role=ci",
+                id="missing schema",
+            ),
+        ],
+    )
+    def test_un_queryable_asset_should_raise_error(
+        self, context: DataContext, connection_string: str
+    ):
+        """
+        A SnowflakeDatasource can successfully connect even if things like database, schema, warehouse, and role are omitted.
+        However, if we try to add an asset that is not queryable with the current datasource connection details,
+        then we should expect a TestConnectionError.
+        https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#connection-parameters
+        """
+        snowflake_ds: SnowflakeDatasource = context.sources.add_snowflake(
+            "my_ds", connection_string=connection_string
+        )
+
+        inspector_schemas = sa.inspection.inspect(
+            snowflake_ds.get_engine()
+        ).get_schema_names()
+        inspector_tables = sa.inspection.inspect(
+            snowflake_ds.get_engine()
+        ).get_table_names()
+        print(f"schemas: {len(inspector_schemas)}")
+        print(f"tables: {len(inspector_tables)}")
+
+        table_name = random.choice(inspector_tables)
+
+        # query the asset, if it fails then we should expect a TestConnectionError
+        # expect the sql ProgrammingError to be raised
+        # we are only testing the failure case here
+        try:
+            snowflake_ds.get_engine().execute(f"SELECT * FROM {table_name} LIMIT 1;")
+        except sa.exc.ProgrammingError as sql_err:
+            print(f"\n  {table_name} is not queryable ->\n{sql_err!r}")
+
+        with pytest.raises(TestConnectionError) as exc_info:
+            # TODO: check specific error message
+            asset = snowflake_ds.add_table_asset(
+                name="un-reachable asset", table_name=table_name
+            )
+            print(f"\n  Uh oh, asset should not have been created...\n{asset!r}")
+        print(f"\n  TestConnectionError was raised as expected.\n{exc_info.exconly()}")
+
+    @pytest.mark.parametrize(
+        "connection_string",
+        [
+            param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci",
+                id="full connection string",
+            ),
+        ],
+    )
+    def test_queryable_asset_should_pass_test_connection(
+        self, context: DataContext, connection_string: str
+    ):
+        snowflake_ds: SnowflakeDatasource = context.sources.add_snowflake(
+            "my_ds", connection_string=connection_string
+        )
+
+        inspector_schemas = sa.inspection.inspect(
+            snowflake_ds.get_engine()
+        ).get_schema_names()
+        inspector_tables = sa.inspection.inspect(
+            snowflake_ds.get_engine()
+        ).get_table_names()
+        print(f"schemas: {len(inspector_schemas)}")
+        print(f"tables: {len(inspector_tables)}")
+
+        table_name = random.choice(inspector_tables)
+
+        # query the asset, if it fails then we should expect a TestConnectionError
+        try:
+            snowflake_ds.get_engine().execute(f"SELECT * FROM {table_name} LIMIT 1;")
+        except sa.exc.ProgrammingError:
+            print(f"\n  {table_name} is not queryable")
+            raise
+
+        asset = snowflake_ds.add_table_asset(
+            name="reachable asset", table_name=table_name
+        )
+        print(f"\n  Yay, asset was created!\n{asset!r}")
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -28,6 +28,10 @@ class TestSnowflake:
                 id="missing role",
             ),
             param(
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=no_select",
+                id="role wo select",
+            ),
+            param(
                 "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}?warehouse=ci&role=ci",
                 id="missing database + schema",
             ),

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -28,7 +28,7 @@ class TestSnowflake:
                 id="missing role",
             ),
             param(
-                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=no_select",
+                "snowflake://ci:${SNOWFLAKE_CI_USER_PASSWORD}@${SNOWFLAKE_CI_ACCOUNT}/ci/public?warehouse=ci&role=ci_no_select",
                 id="role wo select",
             ),
             param(

--- a/tests/datasource/fluent/integration/test_connections.py
+++ b/tests/datasource/fluent/integration/test_connections.py
@@ -119,4 +119,4 @@ class TestSnowflake:
 
 
 if __name__ == "__main__":
-    pytest.main()
+    pytest.main([__file__, "-vv"])

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -21,7 +21,6 @@ import pytest
 from packaging.version import Version
 from pytest import param
 
-from great_expectations import get_context
 from great_expectations.compatibility.sqlalchemy import (
     ProgrammingError as SqlAlchemyProgrammingError,
 )
@@ -140,13 +139,6 @@ UNQUOTED_UPPER_COL: Final[Literal["UNQUOTED_UPPER_COL"]] = "UNQUOTED_UPPER_COL"
 UNQUOTED_LOWER_COL: Final[Literal["unquoted_lower_col"]] = "unquoted_lower_col"
 QUOTED_UPPER_COL: Final[Literal["QUOTED_UPPER_COL"]] = "QUOTED_UPPER_COL"
 QUOTED_LOWER_COL: Final[Literal["quoted_lower_col"]] = "quoted_lower_col"
-
-
-@pytest.fixture
-def context() -> EphemeralDataContext:
-    ctx = get_context(cloud_mode=False)
-    assert isinstance(ctx, EphemeralDataContext)
-    return ctx
 
 
 def get_random_identifier_name() -> str:

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -1080,7 +1080,7 @@ def mock_connection_execute_failure(mocker: MockFixture) -> Mock:
     """
     Engine execute should raise an exception when called.
     """
-    execute = mocker.patch("tests.sqlalchemy_test_doubles._MockConnection")
+    execute = mocker.patch("tests.sqlalchemy_test_doubles._MockConnection.execute")
 
     def execute_side_effect(*args, **kwargs):
         LOGGER.info("MockSaEngine.execute() called")

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -14,11 +14,13 @@ from typing import (
     Dict,
     Generator,
     List,
+    Literal,
     Optional,
     Tuple,
 )
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.compatibility.pydantic import ValidationError
@@ -48,6 +50,9 @@ from tests.datasource.fluent.conftest import sqlachemy_execution_engine_mock_cls
 from tests.sqlalchemy_test_doubles import Dialect, MockSaEngine, MockSaInspector
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from pytest_mock import MockFixture
     from typing_extensions import TypeAlias
 
     from great_expectations.data_context import AbstractDataContext
@@ -1026,26 +1031,74 @@ def bad_configuration_datasource(
     )
 
 
-@pytest.mark.postgresql
-def test_test_connection_failures(
-    mocker,
-    bad_configuration_datasource: PostgresDatasource,
-):
+@pytest.fixture
+def mock_create_engine(mocker: MockFixture) -> Mock:
     create_engine = mocker.patch("sqlalchemy.create_engine")
     create_engine.return_value = MockSaEngine(dialect=Dialect("postgresql"))
-    mocker.patch("tests.datasource.fluent.conftest.MockSaEngine.connect")
+    return create_engine
+
+
+@pytest.fixture
+def mock_inspector(
+    mocker: MockFixture,
+) -> Generator[dict[Literal["schema_names", "table_names"], list[str]], None, None]:
+    """
+    Mock the inspector to return the schema and table names we want.
+    Append the desired schema and table names (in tests) to the mock_inspector_returns dict.
+    """
+    mock_inspector_returns: dict[Literal["schema_names", "table_names"], list[str]] = {
+        "schema_names": [],
+        "table_names": [],
+    }
+    mock_inspector = MockSaInspector()
+
+    def get_table_names(schema: str | None = None) -> list[str]:
+        LOGGER.info("MockSaInspector.get_table_names() called")
+        return mock_inspector_returns["table_names"]
+
+    def get_schema_names() -> list[str]:
+        LOGGER.info("MockSaInspector.get_schema_names() called")
+        return mock_inspector_returns["schema_names"]
+
+    def has_table(table_name: str, schema: str | None = None) -> bool:
+        LOGGER.info("MockSaInspector.has_table() called")
+        return table_name in mock_inspector_returns["table_names"]
+
+    # directly patching the instance rather then using mocker.patch
+    mock_inspector.get_schema_names = get_schema_names  # type: ignore[method-assign]
+    mock_inspector.get_table_names = get_table_names  # type: ignore[method-assign]
+    mock_inspector.has_table = has_table  # type: ignore[method-assign]
+
     inspect = mocker.patch("sqlalchemy.inspect")
-    inspect.return_value = MockSaInspector()
-    get_schema_names = mocker.patch(
-        "tests.sqlalchemy_test_doubles.MockSaInspector.get_schema_names"
-    )
-    get_schema_names.return_value = ["good_schema"]
-    has_table = mocker.patch("tests.sqlalchemy_test_doubles.MockSaInspector.has_table")
-    has_table.return_value = False
-    get_table_names = mocker.patch(
-        "tests.sqlalchemy_test_doubles.MockSaInspector.get_table_names"
-    )
-    get_table_names.return_value = ["good_table", "bad_table"]
+    inspect.return_value = mock_inspector
+
+    yield mock_inspector_returns
+
+
+@pytest.fixture
+def mock_connection_execute_failure(mocker: MockFixture) -> Mock:
+    """
+    Engine execute should raise an exception when called.
+    """
+    execute = mocker.patch("tests.sqlalchemy_test_doubles._MockConnection")
+
+    def execute_side_effect(*args, **kwargs):
+        LOGGER.info("MockSaEngine.execute() called")
+        raise SQLAlchemyError("Mocked exception")
+
+    execute.side_effect = execute_side_effect
+    return execute
+
+
+@pytest.mark.postgresql
+def test_test_connection_failures(
+    mock_create_engine: Mock,
+    mock_connection_execute_failure: Mock,
+    mock_inspector: dict[Literal["schema_names", "table_names"], list[str]],
+    bad_configuration_datasource: PostgresDatasource,
+):
+    mock_inspector["schema_names"].extend(["good_schema"])
+    mock_inspector["table_names"].extend(["good_table", "bad_table"])
 
     with pytest.raises(TestConnectionError):
         bad_configuration_datasource.test_connection()


### PR DESCRIPTION
This PR changes `TableAsset.test_connection()` to attempt to query the `table_name` in question rather than using the `sqlalchemy` `Inspector`. 
Without this, a user could successfully add a `TableAsset` whose table exists and passes the `.test_connection()` check, but it isn't actually usable because the user/datasource config cannot query the table.


## TODO

- [x] Add tests to ensure unquerable assets raise `TestConnectionError` when adding a `TableAsset` to a `SnowflakeDatasource`
- [x] Create and add snowflake CI role for additional testing 