### PR TITLE
[MAINTENANCE] Use `import great_expectations.expectations as gxe` consistently

### DIFF
--- a/contrib/cli/tests/test_package.py
+++ b/contrib/cli/tests/test_package.py
@@ -10,17 +10,9 @@ from great_expectations_contrib.package import (
     Maturity,
 )
 
+import great_expectations.expectations as gxe
 from great_expectations.core.expectation_diagnostics.expectation_diagnostics import (
     ExpectationDiagnostics,
-)
-from great_expectations.expectations.core.expect_column_min_to_be_between import (
-    ExpectColumnMinToBeBetween,
-)
-from great_expectations.expectations.core.expect_column_most_common_value_to_be_in_set import (
-    ExpectColumnMostCommonValueToBeInSet,
-)
-from great_expectations.expectations.core.expect_column_stdev_to_be_between import (
-    ExpectColumnStdevToBeBetween,
 )
 
 
@@ -33,9 +25,9 @@ def package() -> GreatExpectationsContribPackageManifest:
 @pytest.fixture
 def diagnostics() -> List[ExpectationDiagnostics]:
     expectations = [
-        ExpectColumnMinToBeBetween,
-        ExpectColumnMostCommonValueToBeInSet,
-        ExpectColumnStdevToBeBetween,
+        gxe.ExpectColumnMinToBeBetween,
+        gxe.ExpectColumnMostCommonValueToBeInSet,
+        gxe.ExpectColumnStdevToBeBetween,
     ]
     diagnostics = list(
         map(

--- a/tests/checkpoint/conftest.py
+++ b/tests/checkpoint/conftest.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 import pandas as pd
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import get_context
 from great_expectations.data_context.data_context.file_data_context import (
@@ -12,7 +13,6 @@ from great_expectations.data_context.data_context.file_data_context import (
 )
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.datasource.fluent import BatchRequest as FluentBatchRequest
-from great_expectations.expectations.core import ExpectColumnValuesToBeBetween
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -100,7 +100,7 @@ def titanic_pandas_data_context_stats_enabled_and_expectation_suite_with_one_exp
     context = titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled
     # create expectation suite
     suite = context.add_expectation_suite("my_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="col1",
         min_value=1,
         max_value=2,

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -5,24 +5,13 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.checkpoint.configurator import ActionDetails, ActionDict
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.exceptions import CheckpointError
-from great_expectations.expectations.core.expect_column_pair_values_to_be_equal import (
-    ExpectColumnPairValuesToBeEqual,
-)
-from great_expectations.expectations.core.expect_column_values_to_be_in_set import (
-    ExpectColumnValuesToBeInSet,
-)
-from great_expectations.expectations.core.expect_column_values_to_not_be_in_set import (
-    ExpectColumnValuesToNotBeInSet,
-)
-from great_expectations.expectations.core.expect_multicolumn_sum_to_equal import (
-    ExpectMulticolumnSumToEqual,
-)
 from great_expectations.expectations.expectation import Expectation
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
@@ -145,26 +134,26 @@ def reference_sql_checkpoint_config_for_multi_column_sum_table(
 
 @pytest.fixture()
 def expect_multicolumn_sum_to_equal() -> Expectation:
-    return ExpectMulticolumnSumToEqual(column_list=["a", "b", "c"], sum_total=30)
+    return gxe.ExpectMulticolumnSumToEqual(column_list=["a", "b", "c"], sum_total=30)
 
 
 @pytest.fixture()
 def expect_column_pair_values_to_be_equal() -> Expectation:
-    return ExpectColumnPairValuesToBeEqual(
+    return gxe.ExpectColumnPairValuesToBeEqual(
         column_A="ordered_item", column_B="received_item"
     )
 
 
 @pytest.fixture()
 def expect_column_values_to_be_in_set() -> Expectation:
-    return ExpectColumnValuesToBeInSet(
+    return gxe.ExpectColumnValuesToBeInSet(
         column="animals", value_set=["cat", "fish", "dog"]
     )
 
 
 @pytest.fixture()
 def expect_column_values_to_not_be_in_set() -> Expectation:
-    return ExpectColumnValuesToNotBeInSet(
+    return gxe.ExpectColumnValuesToNotBeInSet(
         column="animals", value_set=["giraffe", "lion", "zebra"]
     )
 

--- a/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
+++ b/tests/checkpoint/test_checkpoint_with_fluent_datasources.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 
 import great_expectations as gx
+import great_expectations.expectations as gxe
 from great_expectations.checkpoint import Checkpoint
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.core import (
@@ -31,9 +32,6 @@ from great_expectations.data_context.types.resource_identifiers import (
 )
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest as FluentBatchRequest,
-)
-from great_expectations.expectations.core.expect_column_values_to_be_between import (
-    ExpectColumnValuesToBeBetween,
 )
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.util import (
@@ -1630,7 +1628,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0,
         max_value=71,
@@ -1707,7 +1705,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0,
         max_value=71,
@@ -1785,7 +1783,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0,
         max_value=71,
@@ -1880,7 +1878,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0,
         max_value=71,
@@ -1958,7 +1956,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     context.add_checkpoint(**checkpoint_config)
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0.0,
         max_value=71.0,
@@ -2035,7 +2033,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     context.add_checkpoint(**checkpoint_config)
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0.0,
         max_value=71.0,
@@ -2128,7 +2126,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0.0,
         max_value=71.0,
@@ -2223,7 +2221,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_correct_validation_resu
     )
 
     suite = context.add_expectation_suite("my_new_expectation_suite")
-    expectation = ExpectColumnValuesToBeBetween(
+    expectation = gxe.ExpectColumnValuesToBeBetween(
         column="Age",
         min_value=0.0,
         max_value=71.0,

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
+import great_expectations.expectations as gxe
 from great_expectations import __version__ as ge_version
 from great_expectations import set_context
 from great_expectations.core.expectation_suite import (
@@ -19,9 +20,6 @@ from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.execution_engine import ExecutionEngine
-from great_expectations.expectations.core import (
-    ExpectColumnValuesToBeInSet,
-)
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -201,8 +199,8 @@ class TestCRUDMethods:
     expectation_suite_name = "test-suite"
 
     @pytest.fixture
-    def expectation(self) -> ExpectColumnValuesToBeInSet:
-        return ExpectColumnValuesToBeInSet(
+    def expectation(self) -> gxe.ExpectColumnValuesToBeInSet:
+        return gxe.ExpectColumnValuesToBeInSet(
             column="a",
             value_set=[1, 2, 3],
             result_format="BASIC",
@@ -476,11 +474,11 @@ class TestCRUDMethods:
         context = empty_data_context
         suite_name = "test-suite"
         expectations = [
-            ExpectColumnValuesToBeInSet(
+            gxe.ExpectColumnValuesToBeInSet(
                 column="a",
                 value_set=[1, 2, 3],
             ),
-            ExpectColumnValuesToBeInSet(
+            gxe.ExpectColumnValuesToBeInSet(
                 column="b",
                 value_set=[4, 5, 6],
             ),
@@ -528,11 +526,11 @@ class TestCRUDMethods:
         column_name = "a"
         updated_column_name = "foo"
         expectations = [
-            ExpectColumnValuesToBeInSet(
+            gxe.ExpectColumnValuesToBeInSet(
                 column=column_name,
                 value_set=[1, 2, 3],
             ),
-            ExpectColumnValuesToBeInSet(
+            gxe.ExpectColumnValuesToBeInSet(
                 column="b",
                 value_set=[4, 5, 6],
             ),

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -5,13 +5,13 @@ from uuid import UUID
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.data_context.store import ExpectationsStore
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     GXCloudIdentifier,
 )
-from great_expectations.expectations.core import ExpectColumnValuesToBeInSet
 from great_expectations.util import gen_directory_tree_str
 from tests import test_utils
 from tests.core.usage_statistics.util import (
@@ -339,7 +339,7 @@ def _test_add_expectation_success(context):
     store = context.expectations_store
     suite_name = "test-suite"
     suite = context.add_expectation_suite(suite_name)
-    expectation = ExpectColumnValuesToBeInSet(
+    expectation = gxe.ExpectColumnValuesToBeInSet(
         column="a",
         value_set=[1, 2, 3],
         result_format="BASIC",
@@ -376,7 +376,7 @@ def _test_add_expectation_disregards_provided_id(context):
     suite_name = "test-suite"
     suite = context.add_expectation_suite(suite_name)
     provided_id = "e86bb8a8-b75f-4efb-a3bb-210b6440661e"
-    expectation = ExpectColumnValuesToBeInSet(
+    expectation = gxe.ExpectColumnValuesToBeInSet(
         id=provided_id,
         column="a",
         value_set=[1, 2, 3],
@@ -410,7 +410,7 @@ def _test_update_expectation_success(context):
     # Arrange
     store = context.expectations_store
     suite_name = "test-suite"
-    expectation = ExpectColumnValuesToBeInSet(
+    expectation = gxe.ExpectColumnValuesToBeInSet(
         column="a",
         value_set=[1, 2, 3],
         result_format="BASIC",
@@ -455,7 +455,7 @@ def test_update_expectation_raises_error_for_missing_expectation_cloud(
 def _test_update_expectation_raises_error_for_missing_expectation(context):
     store = context.expectations_store
     suite_name = "test-suite"
-    expectation = ExpectColumnValuesToBeInSet(
+    expectation = gxe.ExpectColumnValuesToBeInSet(
         id="2b284004-0e0e-455d-a7f4-11e162fd06c9",
         column="a",
         value_set=[1, 2, 3],
@@ -492,7 +492,7 @@ def test_delete_expectation_success_filesystem_backend(empty_data_context):
 def _test_delete_expectation_success(context):
     store = context.expectations_store
     suite_name = "test-suite"
-    expectation = ExpectColumnValuesToBeInSet(
+    expectation = gxe.ExpectColumnValuesToBeInSet(
         column="a",
         value_set=[1, 2, 3],
         result_format="BASIC",
@@ -531,7 +531,7 @@ def _test_delete_expectation_raises_error_for_missing_expectation(context):
     # Arrange
     store = context.expectations_store
     suite_name = "test-suite"
-    existing_expectation = ExpectColumnValuesToBeInSet(
+    existing_expectation = gxe.ExpectColumnValuesToBeInSet(
         column="a",
         value_set=[1, 2, 3],
         result_format="BASIC",
@@ -540,7 +540,7 @@ def _test_delete_expectation_raises_error_for_missing_expectation(context):
         suite_name, expectations=[existing_expectation.configuration]
     )
     # Act
-    nonexistent_expectation = ExpectColumnValuesToBeInSet(
+    nonexistent_expectation = gxe.ExpectColumnValuesToBeInSet(
         # this ID will be different from the ID created by the Suite
         id="1296c5c8-6f7b-4cee-a09c-9037c7e40df7",
         column="a",

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -4,13 +4,13 @@ from unittest import mock
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.data_context import get_context
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
 from great_expectations.exceptions import DataContextError
-from great_expectations.expectations.core import ExpectColumnValuesToNotBeNull
 
 
 @pytest.mark.unit
@@ -436,7 +436,7 @@ def test_view_validation_result_uses_run_name_template_env_var(
 
     # Create Suite
     suite = context.add_expectation_suite("my_suite")
-    suite.add_expectation(ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
+    suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
 
     # Create and run Checkpoint
     checkpoint = context.add_or_update_checkpoint(

--- a/tests/datasource/fluent/test_batch.py
+++ b/tests/datasource/fluent/test_batch.py
@@ -6,13 +6,9 @@ from typing import Tuple
 import pytest
 
 import great_expectations as gx
+import great_expectations.expectations as gxe
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.interfaces import Batch
-
-# TODO: We should namespace the expectations better
-from great_expectations.expectations.core.expect_column_values_to_not_be_null import (
-    ExpectColumnValuesToNotBeNull,
-)
 
 
 @pytest.fixture
@@ -34,7 +30,7 @@ def test_batch_validate_expectation(pandas_setup: Tuple[AbstractDataContext, Bat
     _, batch = pandas_setup
 
     # Make Expectation
-    expectation = ExpectColumnValuesToNotBeNull(
+    expectation = gxe.ExpectColumnValuesToNotBeNull(
         column="vendor_id",
         mostly=0.95,
     )
@@ -53,7 +49,7 @@ def test_batch_validate_expectation_suite(
     # Make Expectation Suite
     suite = context.add_expectation_suite("my_suite")
     suite.add_expectation(
-        ExpectColumnValuesToNotBeNull(
+        gxe.ExpectColumnValuesToNotBeNull(
             column="vendor_id",
             mostly=0.95,
         )
@@ -71,7 +67,7 @@ def test_batch_validate_with_updated_expectation(
     _, batch = pandas_setup
 
     # Make Expectation
-    expectation = ExpectColumnValuesToNotBeNull(
+    expectation = gxe.ExpectColumnValuesToNotBeNull(
         column="vendor_id",
     )
     # Validate
@@ -92,7 +88,7 @@ def test_batch_validate_expectation_suite_with_updated_expectation(
 
     # Make Expectation Suite
     suite = context.add_expectation_suite("my_suite")
-    suite.add_expectation(ExpectColumnValuesToNotBeNull(column="vendor_id"))
+    suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="vendor_id"))
     # Validate
     result = batch.validate(suite)
     # Asserts on result
@@ -101,11 +97,11 @@ def test_batch_validate_expectation_suite_with_updated_expectation(
     assert len(suite.expectations) == 1
 
     expectation = suite.expectations[0]
-    assert isinstance(expectation, ExpectColumnValuesToNotBeNull)
+    assert isinstance(expectation, gxe.ExpectColumnValuesToNotBeNull)
     expectation.mostly = 0.95
 
     expectation.save()
-    assert isinstance(suite.expectations[0], ExpectColumnValuesToNotBeNull)
+    assert isinstance(suite.expectations[0], gxe.ExpectColumnValuesToNotBeNull)
     assert suite.expectations[0].mostly == 0.95
 
     result = batch.validate(suite)
@@ -120,7 +116,7 @@ def test_batch_validate_change_expectation_result_format(
 
     # "SUMMARY"" is the default result format
     assert batch.result_format == "SUMMARY"
-    expectation = ExpectColumnValuesToNotBeNull(column="vendor_id", mostly=0.95)
+    expectation = gxe.ExpectColumnValuesToNotBeNull(column="vendor_id", mostly=0.95)
     summary_result = batch.validate(expectation)
     # Summary result succeeds and .result has non-empty summary
     assert summary_result.success is True
@@ -143,7 +139,7 @@ def test_batch_validate_change_expectation_suite_result_format(
     # Make Expectation Suite
     suite = context.add_expectation_suite("my_suite")
     suite.add_expectation(
-        ExpectColumnValuesToNotBeNull(
+        gxe.ExpectColumnValuesToNotBeNull(
             column="vendor_id",
             mostly=0.95,
         )

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -9,15 +9,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations import get_context
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import CloudDataContext, FileDataContext
 from great_expectations.datasource.fluent.config import GxConfig
 from great_expectations.datasource.fluent.interfaces import Datasource
-from great_expectations.expectations.core import (
-    ExpectColumnValuesToBeBetween,
-    ExpectColumnValuesToNotBeNull,
-)
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -308,9 +305,9 @@ def test_quickstart_workflow(
 
     # Create Expectations
     suite = context.add_expectation_suite("my_suite")
-    suite.add_expectation(ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
+    suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
     suite.add_expectation(
-        ExpectColumnValuesToBeBetween(
+        gxe.ExpectColumnValuesToBeBetween(
             column="passenger_count", min_value=1, max_value=6
         )
     )

--- a/tests/expectations/core/test_expect_column_mean_to_be_positive.py
+++ b/tests/expectations/core/test_expect_column_mean_to_be_positive.py
@@ -4,17 +4,15 @@ from typing import Union
 import pandas as pd
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.core.evaluation_parameters import (
     EvaluationParameterDict,
 )
-from great_expectations.expectations.core.expect_column_mean_to_be_between import (
-    ExpectColumnMeanToBeBetween,
-)
 
 
 # <snippet name="tests/expectations/core/test_expect_column_mean_to_be_positive.py ExpectColumnMeanToBePositive_class_def">
-class ExpectColumnMeanToBePositive(ExpectColumnMeanToBeBetween):
+class ExpectColumnMeanToBePositive(gxe.ExpectColumnMeanToBeBetween):
     """Expect the mean of values in this column to be positive."""
 
     min_value: Union[float, EvaluationParameterDict, datetime, None] = 0

--- a/tests/expectations/core/test_expect_column_values_to_be_in_set.py
+++ b/tests/expectations/core/test_expect_column_values_to_be_in_set.py
@@ -3,16 +3,14 @@ from typing import List
 import pandas as pd
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.compatibility import pydantic
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context import AbstractDataContext
-from great_expectations.expectations.core.expect_column_values_to_be_in_set import (
-    ExpectColumnValuesToBeInSet,
-)
 
 
 # <snippet name="tests/expectations/core/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def">
-class ExpectColumnValuesToBeTwoLetterCountryCode(ExpectColumnValuesToBeInSet):
+class ExpectColumnValuesToBeTwoLetterCountryCode(gxe.ExpectColumnValuesToBeInSet):
     value_set: List[str] = ["FR", "DE", "CH", "ES", "IT", "BE", "NL", "PL"]
 
 

--- a/tests/expectations/core/test_expect_column_values_to_match_regex_parameterized.py
+++ b/tests/expectations/core/test_expect_column_values_to_match_regex_parameterized.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.expectations.core import ExpectColumnValuesToMatchRegex
 
 
-class ExpectColumnValuesAsStringToBePositiveInteger(ExpectColumnValuesToMatchRegex):
+class ExpectColumnValuesAsStringToBePositiveInteger(gxe.ExpectColumnValuesToMatchRegex):
     regex: str = "^\\d+$"
 
 

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.compatibility import sqlalchemy
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
@@ -27,7 +28,6 @@ from great_expectations.execution_engine import (
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
-from great_expectations.expectations.core import ExpectColumnValuesToBeInSet
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -143,7 +143,7 @@ def _expecation_configuration_to_validation_result_pandas(
         expectation_configuration (ExpectationConfiguration): configuration that is being tested
 
     """
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="pandas_datasource",
         data_connector_name="runtime_data_connector",
@@ -179,7 +179,7 @@ def _expecation_configuration_to_validation_result_sql(
         expectation_configuration (ExpectationConfiguration): configuration that is being tested
 
     """
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     sqlite_path = file_relative_path(__file__, "../../test_sets/metrics_test.db")
     connection_string = f"sqlite:///{sqlite_path}"
     engine = SqlAlchemyExecutionEngine(
@@ -775,7 +775,7 @@ def test_include_unexpected_rows_without_explicit_result_format_raises_error():
     )
 
     with pytest.raises(ValidationError):
-        ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+        gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
 
 
 # Spark
@@ -794,7 +794,7 @@ def test_spark_single_column_complete_result_format(
             },
         },
     )
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
@@ -851,7 +851,7 @@ def test_spark_single_column_complete_result_format_with_id_pk(
             },
         },
     )
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
@@ -922,7 +922,7 @@ def test_spark_single_column_summary_result_format(
             },
         },
     )
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
@@ -975,7 +975,7 @@ def test_spark_single_column_basic_result_format(
             },
         },
     )
-    expectation = ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
+    expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
     batch_definition = BatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",

--- a/tests/expectations/test_expectation.py
+++ b/tests/expectations/test_expectation.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, List
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.compatibility import pydantic
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.expectations import expectation
-from great_expectations.expectations.core import ExpectColumnMaxToBeBetween
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -209,7 +209,9 @@ def test_validate_dependencies_against_available_metrics_failure(metrics_dict):
 
 @pytest.mark.unit
 def test_expectation_configuration_property():
-    expectation = ExpectColumnMaxToBeBetween(column="foo", min_value=0, max_value=10)
+    expectation = gxe.ExpectColumnMaxToBeBetween(
+        column="foo", min_value=0, max_value=10
+    )
 
     assert expectation.configuration == ExpectationConfiguration(
         expectation_type="expect_column_max_to_be_between",
@@ -223,7 +225,9 @@ def test_expectation_configuration_property():
 
 @pytest.mark.unit
 def test_expectation_configuration_property_recognizes_state_changes():
-    expectation = ExpectColumnMaxToBeBetween(column="foo", min_value=0, max_value=10)
+    expectation = gxe.ExpectColumnMaxToBeBetween(
+        column="foo", min_value=0, max_value=10
+    )
 
     expectation.column = "bar"
     expectation.min_value = 5
@@ -244,6 +248,6 @@ def test_expectation_configuration_property_recognizes_state_changes():
 @pytest.mark.unit
 def test_unrecognized_expectation_arg_raises_error():
     with pytest.raises(pydantic.ValidationError, match="extra fields not permitted"):
-        ExpectColumnMaxToBeBetween(
+        gxe.ExpectColumnMaxToBeBetween(
             column="foo", min_value=0, max_value=10, mostyl=0.95  # 'mostly' typo
         )

--- a/tests/expectations/test_registry.py
+++ b/tests/expectations/test_registry.py
@@ -1,9 +1,7 @@
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.expectations.core.expect_column_values_to_be_in_set import (
-    ExpectColumnValuesToBeInSet,
-)
+import great_expectations.expectations as gxe
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -15,7 +13,7 @@ pytestmark = pytest.mark.unit
 
 def test_registry_basics():
     expectation = get_expectation_impl("expect_column_values_to_be_in_set")
-    assert expectation == ExpectColumnValuesToBeInSet
+    assert expectation == gxe.ExpectColumnValuesToBeInSet
 
 
 def test_registry_from_configuration():
@@ -23,7 +21,7 @@ def test_registry_from_configuration():
         expectation_type="expect_column_values_to_be_in_set",
         kwargs={"column": "PClass", "value_set": [1, 2, 3]},
     )
-    assert configuration._get_expectation_impl() == ExpectColumnValuesToBeInSet
+    assert configuration._get_expectation_impl() == gxe.ExpectColumnValuesToBeInSet
 
 
 def test_registry_raises_error_when_invalid_expectation_requested():

--- a/tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite.py
+++ b/tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite.py
@@ -10,16 +10,13 @@ from great_expectations.expectations.expectation_configuration import (
 # NOTE: The following code is only for testing and can be ignored by users.
 import sys, io
 
-from great_expectations.expectations.core import (
-    ExpectColumnValuesToNotBeNull,
-    ExpectColumnValuesToBeBetween,
-)
 
 stdout = sys.stdout
 sys.stdout = io.StringIO()
 
 # <snippet name="tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite get_context">
 import great_expectations as gx
+import great_expectations.expectations as gxe
 
 context = gx.get_context()
 # </snippet>
@@ -32,9 +29,11 @@ context.sources.pandas_default.read_csv(
 
 
 my_suite = context.add_expectation_suite("my_suite")
-my_suite.add_expectation(ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
+my_suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
 my_suite.add_expectation(
-    ExpectColumnValuesToBeBetween(column="passenger_count", min_value=1, max_value=6)
+    gxe.ExpectColumnValuesToBeBetween(
+        column="passenger_count", min_value=1, max_value=6
+    )
 )
 
 # <snippet name="tests/integration/docusaurus/expectations/how_to_edit_an_expectation_suite show_suite">
@@ -90,8 +89,8 @@ my_suite.add_expectation_configuration(updated_config)
 # </snippet>
 
 assert len(my_suite.expectations) == 2
-assert isinstance(my_suite.expectations[0], ExpectColumnValuesToNotBeNull)
-assert isinstance(my_suite.expectations[1], ExpectColumnValuesToBeBetween)
+assert isinstance(my_suite.expectations[0], gxe.ExpectColumnValuesToNotBeNull)
+assert isinstance(my_suite.expectations[1], gxe.ExpectColumnValuesToBeBetween)
 assert my_suite.expectations[1] == updated_config.to_domain_obj()
 
 

--- a/tests/integration/docusaurus/tutorials/quickstart/quickstart.py
+++ b/tests/integration/docusaurus/tutorials/quickstart/quickstart.py
@@ -1,9 +1,6 @@
 # <snippet name="tutorials/quickstart/quickstart.py import_gx">
 import great_expectations as gx
-from great_expectations.expectations.core import (
-    ExpectColumnValuesToBeBetween,
-    ExpectColumnValuesToNotBeNull,
-)
+import great_expectations.expectations as gxe
 
 # </snippet>
 
@@ -24,9 +21,11 @@ batch = context.sources.pandas_default.read_csv(
 suite = context.add_expectation_suite("my_suite")
 
 # TODO: update where these expectations are imported
-suite.add_expectation(ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
+suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="pickup_datetime"))
 suite.add_expectation(
-    ExpectColumnValuesToBeBetween(column="passenger_count", min_value=1, max_value=6)
+    gxe.ExpectColumnValuesToBeBetween(
+        column="passenger_count", min_value=1, max_value=6
+    )
 )
 # </snippet>
 

--- a/tests/validator/test_v1_validator.py
+++ b/tests/validator/test_v1_validator.py
@@ -4,25 +4,20 @@ from pprint import pformat as pf
 
 import pytest
 
+import great_expectations.expectations as gxe
 from great_expectations.core.batch_config import BatchConfig
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
 from great_expectations.datasource.fluent.interfaces import DataAsset, Datasource
-from great_expectations.expectations.core.expect_column_values_to_be_between import (
-    ExpectColumnValuesToBeBetween,
-)
-from great_expectations.expectations.core.expect_column_values_to_be_in_set import (
-    ExpectColumnValuesToBeInSet,
-)
 from great_expectations.expectations.expectation import Expectation
 from great_expectations.validator.v1_validator import ResultFormat, Validator
 
 
 @pytest.fixture
 def failing_expectation() -> Expectation:
-    return ExpectColumnValuesToBeInSet(
+    return gxe.ExpectColumnValuesToBeInSet(
         column="event_type",
         value_set=["start", "stop"],
     )
@@ -30,7 +25,7 @@ def failing_expectation() -> Expectation:
 
 @pytest.fixture
 def passing_expectation() -> Expectation:
-    return ExpectColumnValuesToBeBetween(
+    return gxe.ExpectColumnValuesToBeBetween(
         column="id",
         min_value=-1,
         max_value=1000000,
@@ -175,7 +170,7 @@ def test_validate_expectation_with_batch_asset_options(
     )
 
     result = validator.validate_expectation(
-        ExpectColumnValuesToBeInSet(
+        gxe.ExpectColumnValuesToBeInSet(
             column="event_type",
             value_set=[desired_event_type],
         )

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
+import great_expectations.expectations as gxe
 from great_expectations.execution_engine import ExecutionEngine
-from great_expectations.expectations.core import ExpectColumnValueZScoresToBeLessThan
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -107,7 +107,7 @@ def expect_column_value_z_scores_to_be_less_than_expectation_validation_graph():
 
     graph = ValidationGraph(execution_engine=execution_engine)
     validation_dependencies: ValidationDependencies = (
-        ExpectColumnValueZScoresToBeLessThan(
+        gxe.ExpectColumnValueZScoresToBeLessThan(
             **expectation_configuration.kwargs
         ).get_validation_dependencies(execution_engine)
     )

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
+import great_expectations.expectations as gxe
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import (
     BatchDefinition,
@@ -31,7 +32,6 @@ from great_expectations.datasource.data_connector.batch_filter import (
     build_batch_filter,
 )
 from great_expectations.execution_engine import PandasExecutionEngine
-from great_expectations.expectations.core import ExpectColumnValuesToBeInSet
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -1208,7 +1208,7 @@ def test_list_available_expectation_types(
 
 def _context_to_validator_and_expectation_sql(
     context: FileDataContext,
-) -> Tuple[Validator, ExpectColumnValuesToBeInSet]:
+) -> Tuple[Validator, gxe.ExpectColumnValuesToBeInSet]:
     """
     Helper method used by sql tests in this suite. Takes in a Datacontext and returns a tuple of Validator and
     Expectation after building a BatchRequest and creating ExpectationSuite.
@@ -1223,7 +1223,7 @@ def _context_to_validator_and_expectation_sql(
             "value_set": ["cat", "fish", "dog"],
         },
     )
-    expectation: ExpectColumnValuesToBeInSet = ExpectColumnValuesToBeInSet(
+    expectation: gxe.ExpectColumnValuesToBeInSet = gxe.ExpectColumnValuesToBeInSet(
         **expectation_configuration.kwargs
     )
 


### PR DESCRIPTION
Use new canonical import path across tests and internal code

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
