### PR TITLE
[CONTRIB] Referential Integrity - Make building of `unexpected_value` table non-case sensitive

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -308,6 +308,8 @@ class ExpectColumnValuesToBePresentInOtherTable(QueryExpectation):
 
         unexpected_list: List[Any] = []
         for values in unexpected_values:
+            # we don't use `foreign_key_column_name` but do an explicit listing of values() here because
+            # the returned unexpected_values are not always case-sensitive.
             value = list(values.values())[0]
             unexpected_list.append(value)
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -308,7 +308,8 @@ class ExpectColumnValuesToBePresentInOtherTable(QueryExpectation):
 
         unexpected_list: List[Any] = []
         for values in unexpected_values:
-            unexpected_list.append(values[foreign_key_column_name])
+            value = list(values.values())[0]
+            unexpected_list.append(value)
 
         partial_unexpected_counts = self._generate_partial_unexpected_counts(
             unexpected_list=unexpected_list,


### PR DESCRIPTION
- Make the adding of `unexpected_values` not case-sensitive
- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated