### PR TITLE
[DOCS] Update docs versioning readme

### DIFF
--- a/docs/docs_build.py
+++ b/docs/docs_build.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import zipfile
 from contextlib import contextmanager
 from functools import cached_property
-import json
-from .logging import Logger
-import os
-import shutil
-from pathlib import Path
-import re
-from typing import TYPE_CHECKING, Generator, List, Optional, cast
 from io import BytesIO
-import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator, List, Optional, cast
 
-
+from docs.docs_version_bucket_info import S3_URL
+from docs.logging import Logger
 from docs.prepare_prior_versions import prepare_prior_versions
 
 if TYPE_CHECKING:
@@ -83,7 +84,6 @@ class DocsBuilder:
         as the versions.json file, which contains the list of versions that we then download from github.
         """
 
-        S3_URL = "https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions_20230615.zip"
         if os.path.exists("versioned_code"):
             shutil.rmtree("versioned_code")
         os.mkdir("versioned_code")

--- a/docs/docs_version_bucket_info.py
+++ b/docs/docs_version_bucket_info.py
@@ -1,0 +1,12 @@
+# This file is used to store information related to where the oss_docs_versions zip file is stored,
+# which contains the content used to build earlier versions of the docs.
+
+S3_BUCKET = "superconductive-public"
+REGION = "us-east-2"
+FILENAME = "oss_docs_versions_20230615.zip"
+
+S3_URL = f"https://{S3_BUCKET}.s3.{REGION}.amazonaws.com/{FILENAME}"
+
+# Run this file to print the S3_URL
+if __name__ == "__main__":
+    print(S3_URL)

--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -77,19 +77,19 @@ To add a new version, follow these steps:
 (Note: yarn commands should be run from docs/docusaurus/)
 
 1. It may help to start with a fresh virtualenv and clone of gx.
-2. Check out the version from the tag, e.g. `git checkout 0.15.50`
-3. Modify `docs/docusaurus/docusaurus.config.js` and `docs/docusaurus/docs/components/_data.jsx` to the new version (the patch version may be off by 1 e.g. 0.17.22 instead of 0.17.23 since we update this in the release PR which comes after the release tag).
-4. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"` and `pip install pyspark`
-5. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
-6. Build API docs `invoke api-docs` from the repo root.
-7. Run `yarn install` from `docs/docusaurus/`.
-8. Temporarily change onBrokenLinks: 'throw' to onBrokenLinks: 'warn' in `docusaurus.config.js` to allow the build to complete even if there are broken links.
-9. Run `yarn build` from `docs/docusaurus/`.
-10. Create the version e.g. `yarn docusaurus docs:version 0.15.50` from `docs/docusaurus/`.
-11. Pull down the version file (see `docs/build_docs` for the file path, currently https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions.zip)
-12. Unzip and add your newly created versioned docs via the following:
-13. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
-14. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
-15. Add your version number to `versions.json` in the unzipped version file.
-16. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` as `oss_docs_versions.zip` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
-17. Once the docs are built again, this zip file will be used for the prior versions.
+1. Check out the version from the tag, e.g. `git checkout 0.15.50`
+1. Modify `docs/docusaurus/docusaurus.config.js` and `docs/docusaurus/docs/components/_data.jsx` to the new version (the patch version may be off by 1 e.g. 0.17.22 instead of 0.17.23 since we update this in the release PR which comes after the release tag).
+1. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"` and `pip install pyspark`
+1. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
+1. Build API docs `invoke api-docs` from the repo root.
+1. Run `yarn install` from `docs/docusaurus/`.
+1. Temporarily change onBrokenLinks: 'throw' to onBrokenLinks: 'warn' in `docusaurus.config.js` to allow the build to complete even if there are broken links.
+1. Run `yarn build` from `docs/docusaurus/`.
+1. Create the version e.g. `yarn docusaurus docs:version 0.15.50` from `docs/docusaurus/`.
+1. Pull down the version file (see `docs/build_docs` for the file path, currently https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions.zip)
+1. Unzip and add your newly created versioned docs via the following:
+1. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
+1. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
+1. Add your version number to `versions.json` in the unzipped version file.
+1. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` as `oss_docs_versions.zip` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
+1. Once the docs are built again, this zip file will be used for the prior versions.

--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -78,17 +78,18 @@ To add a new version, follow these steps:
 
 1. It may help to start with a fresh virtualenv and clone of gx.
 2. Check out the version from the tag, e.g. `git checkout 0.15.50`
-3. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"` and `pip install pyspark`
-4. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
-5. Build API docs `invoke api-docs` from the repo root.
-6. Run `yarn install` from `docs/docusaurus/`.
-7. Temporarily change onBrokenLinks: 'throw' to onBrokenLinks: 'warn' in `docusaurus.config.js` to allow the build to complete even if there are broken links.
-8. Run `yarn build` from `docs/docusaurus/`.
-9. Create the version e.g. `yarn docusaurus docs:version 0.15.50` from `docs/docusaurus/`.
-10. Pull down the version file (see `docs/build_docs` for the file, currently https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions.zip)
-11. Unzip and add your newly created versioned docs via the following:
-12. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
-13. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
-14. Add your version number to `versions.json` in the unzipped version file.
-15. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
-16. Once the docs are built again, this zip file will be used for the prior versions.
+3. Modify `docs/docusaurus/docusaurus.config.js` and `docs/docusaurus/docs/components/_data.jsx` to the new version (the patch version may be off by 1 e.g. 0.17.22 instead of 0.17.23 since we update this in the release PR which comes after the release tag).
+4. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"` and `pip install pyspark`
+5. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
+6. Build API docs `invoke api-docs` from the repo root.
+7. Run `yarn install` from `docs/docusaurus/`.
+8. Temporarily change onBrokenLinks: 'throw' to onBrokenLinks: 'warn' in `docusaurus.config.js` to allow the build to complete even if there are broken links.
+9. Run `yarn build` from `docs/docusaurus/`.
+10. Create the version e.g. `yarn docusaurus docs:version 0.15.50` from `docs/docusaurus/`.
+11. Pull down the version file (see `docs/build_docs` for the file path, currently https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions.zip)
+12. Unzip and add your newly created versioned docs via the following:
+13. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
+14. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
+15. Add your version number to `versions.json` in the unzipped version file.
+16. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` as `oss_docs_versions.zip` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
+17. Once the docs are built again, this zip file will be used for the prior versions.

--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -83,13 +83,13 @@ To add a new version, follow these steps:
 1. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
 1. Build API docs `invoke api-docs` from the repo root.
 1. Run `yarn install` from `docs/docusaurus/`.
-1. Temporarily change onBrokenLinks: 'throw' to onBrokenLinks: 'warn' in `docusaurus.config.js` to allow the build to complete even if there are broken links.
+1. Temporarily change `onBrokenLinks: 'throw'` to `onBrokenLinks: 'warn'` in `docusaurus.config.js` to allow the build to complete even if there are broken links.
 1. Run `yarn build` from `docs/docusaurus/`.
 1. Create the version e.g. `yarn docusaurus docs:version 0.15.50` from `docs/docusaurus/`.
-1. Pull down the version file (see `docs/build_docs` for the file path, currently https://superconductive-public.s3.us-east-2.amazonaws.com/oss_docs_versions.zip)
+1. Pull down the version file (run `docs/docs_version_bucket_info.py` to generate the url).
 1. Unzip and add your newly created versioned docs via the following:
 1. Copy the version you built in step 4 from inside `versioned_docs` in your repo to the `versioned_docs` from the unzipped version file.
 1. Copy the version you built in step 4 from inside `versioned_sidebars` in your repo to the `versioned_sidebars` from the unzipped version file.
-1. Add your version number to `versions.json` in the unzipped version file.
-1. Zip up `versioned_docs`, `versioned_sidebars` and `versions.json` as `oss_docs_versions.zip` and upload to the s3 bucket (see `docs/build_docs` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
-1. Once the docs are built again, this zip file will be used for the prior versions.
+1. Add your version number to `versions.json` in the unzipped version file (at the top if it is the most recent).
+1. Run `zip oss_docs_versions.zip versioned_docs versioned_sidebars versions.json` to zip up `versioned_docs`, `versioned_sidebars` and `versions.json` as `oss_docs_versions.zip` and upload the zip file to the s3 bucket (see `docs/docs_version_bucket_info.py` for the bucket name). Make sure `versioned_docs`, `versioned_sidebars` and `versions.json` are at the top level of the zip file (not nested in a folder).
+1. Once the docs are built again, this zip file will be used to build the earlier versions.

--- a/docs/docusaurus/README.md
+++ b/docs/docusaurus/README.md
@@ -78,7 +78,7 @@ To add a new version, follow these steps:
 
 1. It may help to start with a fresh virtualenv and clone of gx.
 2. Check out the version from the tag, e.g. `git checkout 0.15.50`
-3. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"`
+3. Make sure dev dependencies are installed `pip install -c constraints-dev.txt -e ".[test]"` and `pip install pyspark`
 4. Install API docs dependencies `pip install -r docs/sphinx_api_docs_source/requirements-dev-api-docs.txt`
 5. Build API docs `invoke api-docs` from the repo root.
 6. Run `yarn install` from `docs/docusaurus/`.


### PR DESCRIPTION
Update versioning readme with changes required after latest build. 

See PR comments for more info on what changed, the diff looks larger than it is because the line numbers changed for most of the lines.



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
