### PR TITLE
[BUGFIX] Re-enable GCS Docs Integration test

### DIFF
--- a/ci/checks/check_integration_test_gets_run.py
+++ b/ci/checks/check_integration_test_gets_run.py
@@ -55,7 +55,6 @@ IGNORED_VIOLATIONS = [
     "tests/expectations/core/test_expect_column_mean_to_be_positive.py",
     "tests/integration/docusaurus/expectations/examples/column_aggregate_expectation_template.py",
     "tests/integration/docusaurus/expectations/examples/multicolumn_map_expectation_template.py",
-    "tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py",
 ]
 
 

--- a/great_expectations/checkpoint/types/checkpoint_result.py
+++ b/great_expectations/checkpoint/types/checkpoint_result.py
@@ -201,14 +201,14 @@ class CheckpointResult(SerializableDictDot):
 
         Args:
             group_by: Specify how the ExpectationValidationResults should be grouped.
-                Valid options are "validation_result_identifier", "expectation_suite_name",
-                "data_asset_name", or the default None. Providing an invalid group_by
-                value will cause this method to silently fail, and return None.
+            Valid options are "validation_result_identifier", "expectation_suite_name",
+            "data_asset_name", or the default None. Providing an invalid group_by
+            value will cause this method to silently fail, and return None.
 
         Returns:
             A list of ExpectationSuiteValidationResult, when group_by=None
-            A dict of ValidationResultIdentifier keys and ExpectationValidationResults
-                values, when group_by="validation_result_identifier"
+            A dict of ValidationResultIdentifier keys and ExpectationValidationResults values,
+                when group_by="validation_result_identifier"
             A dict of str keys and ExpectationValidationResults values, when
                 group_by="expectation_suite_name" or group_by="data_asset_name"
             None, when group_by is something other than the options described above

--- a/tests/integration/test_definitions/gcs/integration_tests.py
+++ b/tests/integration/test_definitions/gcs/integration_tests.py
@@ -54,13 +54,13 @@ how_to_configure_metadata_store = [
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
         backend_dependencies=[BackendDependencies.GCS],
     ),
-    # IntegrationTestFixture(
-    #     name="how_to_host_and_share_data_docs_on_gcs",
-    #     user_flow_script="tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py",
-    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-    #     backend_dependencies=[BackendDependencies.GCS],
-    # ),
+    IntegrationTestFixture(
+        name="how_to_host_and_share_data_docs_on_gcs",
+        user_flow_script="tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+        backend_dependencies=[BackendDependencies.GCS],
+    ),
     IntegrationTestFixture(
         name="how_to_configure_a_validation_result_store_in_gcs",
         user_flow_script="tests/integration/docusaurus/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py",


### PR DESCRIPTION
- Re-enable test from #9226 



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
