### PR TITLE
[MAINTENANCE] move prepare_prior_versions to allow one version at a time

### DIFF
--- a/docs/docs_build.py
+++ b/docs/docs_build.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Generator, List, Optional, cast
 
 from docs.docs_version_bucket_info import S3_URL
 from docs.logging import Logger
-from docs.prepare_prior_versions import prepare_prior_versions
+from docs.prepare_prior_versions import prepare_prior_versions, Version
 
 if TYPE_CHECKING:
     from invoke.context import Context
@@ -54,14 +54,14 @@ class DocsBuilder:
     def _prepare(self) -> None:
         """A whole bunch of common work we need"""
         self.logger.print_header("Preparing to build docs...")
-        self._load_files()
+        versions_loaded = self._load_files()
 
         self.logger.print_header(
             "Updating versioned code and docs via prepare_prior_versions.py..."
         )
         # TODO: none of this messing with current directory stuff
         os.chdir("..")
-        prepare_prior_versions()
+        prepare_prior_versions([Version.from_string(v) for v in versions_loaded])
         os.chdir("docusaurus")
         self.logger.print("Updated versioned code and docs")
 
@@ -77,11 +77,13 @@ class DocsBuilder:
         with zipfile.ZipFile(zip_data, "r") as zip_ref:
             yield zip_ref
 
-    def _load_files(self) -> None:
+    def _load_files(self) -> List[str]:
         """Load oss_docs_versions zip and relevant versions from github.
 
         oss_docs_versions contains the versioned docs to be used later by prepare_prior_versions, as well
         as the versions.json file, which contains the list of versions that we then download from github.
+
+        Returns a list of verions loaded.
         """
 
         if os.path.exists("versioned_code"):
@@ -108,6 +110,7 @@ class DocsBuilder:
                     self._current_directory / f"versioned_code/version-{version}"
                 )
                 shutil.move(str(old_location), str(new_location))
+        return versions
 
     def _invoke_api_docs(self) -> None:
         """Invokes the invoke api-docs command.

--- a/docs/docs_build.py
+++ b/docs/docs_build.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Generator, List, Optional, cast
 
 from docs.docs_version_bucket_info import S3_URL
 from docs.logging import Logger
-from docs.prepare_prior_versions import prepare_prior_versions, Version
 
 if TYPE_CHECKING:
     from invoke.context import Context
@@ -52,6 +51,8 @@ class DocsBuilder:
         self._context.run("yarn start")
 
     def _prepare(self) -> None:
+        from docs.prepare_prior_versions import prepare_prior_versions, Version
+
         """A whole bunch of common work we need"""
         self.logger.print_header("Preparing to build docs...")
         versions_loaded = self._load_files()

--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -483,14 +483,22 @@ def prepare_prior_versions(versions: list[Version]) -> None:
 
 def prepare_prior_version(version: Version) -> None:
     print(f"Starting to process files for version {version}")
-    change_paths_for_docs_file_references(version)
-    prepend_version_info_to_name_for_snippet_by_name_references(version)
+    if version < Version(0, 15):
+        change_paths_for_docs_file_references(version)
+    if version >= Version(0, 15):
+        prepend_version_info_to_name_for_snippet_by_name_references(version)
+
     prepend_version_info_to_name_for_href_absolute_links(version)
     update_tag_references_for_correct_version(version)
     use_relative_path_for_imports(version)
-    prepend_version_info_to_name_for_md_relative_links(version)
+
+    if version >= Version(0, 16):
+        prepend_version_info_to_name_for_md_relative_links(version)
+
     prepend_version_info_for_md_absolute_links(version)
-    prepend_version_info_to_name_for_md_images(version)
+
+    if version >= Version(0, 16):
+        prepend_version_info_to_name_for_md_images(version)
 
 
 @total_ordering

--- a/docs/prepare_prior_versions.py
+++ b/docs/prepare_prior_versions.py
@@ -3,10 +3,14 @@
 There are changes to paths that need to be made to prior versions of docs.
 """
 from __future__ import annotations
+from dataclasses import dataclass
+from functools import total_ordering
 
 import glob
 import pathlib
 import re
+
+from typing_extensions import override
 
 
 def _docs_dir() -> pathlib.Path:
@@ -14,16 +18,30 @@ def _docs_dir() -> pathlib.Path:
     return pathlib.Path().absolute()
 
 
-def change_paths_for_docs_file_references(verbose: bool = False) -> None:
+def _path_to_versioned_docs() -> pathlib.Path:
+    return _docs_dir() / "docusaurus/versioned_docs"
+
+
+def _path_to_versioned_code() -> pathlib.Path:
+    return _docs_dir() / "docusaurus/versioned_code"
+
+
+def version_dir_name(version: Version) -> str:
+    return f"version-{version}"
+
+
+def change_paths_for_docs_file_references(
+    version: Version, verbose: bool = False
+) -> None:
     """Change file= style references to use versioned_docs paths.
 
     This is used in v0.14 docs like v0.14.13 since we moved to using named
     snippets only for v0.15.50 and later.
     """
-    path = _docs_dir() / "docusaurus/versioned_docs/version-0.14.13/"
+    path = _docs_dir() / f"docusaurus/versioned_docs/{version_dir_name(version)}/"
     files = glob.glob(f"{path}/**/*.md", recursive=True)
     pattern = re.compile(r"((.*)(file *= *)((../)*))(.*)")
-    path_to_insert = "versioned_code/version-0.14.13/"
+    path_to_insert = f"versioned_code/version-{version}/"
 
     print(f"Processing {len(files)} files in change_paths_for_docs_file_references...")
     for file_path in files:
@@ -38,71 +56,21 @@ def change_paths_for_docs_file_references(verbose: bool = False) -> None:
     print(f"Processed {len(files)} files in change_paths_for_docs_file_references")
 
 
-def _paths_to_versioned_docs() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_docs"
-    paths = [f for f in data_path.iterdir() if f.is_dir()]
-    return paths
-
-
-def _paths_to_versioned_docs_after_v0_14_13() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_docs"
-    paths = [f for f in data_path.iterdir() if f.is_dir() and "0.14.13" not in str(f)]
-    return paths
-
-
-def _paths_to_versioned_docs_after_v0_15_50() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_docs"
-    paths = [
-        f
-        for f in data_path.iterdir()
-        if f.is_dir() and ("0.14.13" not in str(f) and "0.15.50" not in str(f))
-    ]
-    return paths
-
-
-def _paths_to_versioned_docs_after_v0_16_16() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_docs"
-    paths = [
-        f
-        for f in data_path.iterdir()
-        if f.is_dir()
-        and (
-            "0.14.13" not in str(f)
-            and "0.15.50" not in str(f)
-            and "0.16.16" not in str(f)
-        )
-    ]
-    return paths
-
-
-def _paths_to_versioned_code() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_code"
-    paths = [f for f in data_path.iterdir() if f.is_dir()]
-    return paths
-
-
-def _paths_to_versioned_code_after_v0_14_13() -> list[pathlib.Path]:
-    data_path = _docs_dir() / "docusaurus/versioned_code"
-    paths = [f for f in data_path.iterdir() if f.is_dir() and "0.14.13" not in str(f)]
-    return paths
-
-
 def prepend_version_info_to_name_for_snippet_by_name_references(
+    version: Version,
     verbose: bool = False,
 ) -> None:
     """Prepend version info e.g. name="snippet_name" -> name="version-0.15.50 snippet_name" """
 
+    version_string = version_dir_name(version)
     pattern = re.compile(r"((.*)(name *= *\"))(.*)")
-    paths = (
-        _paths_to_versioned_docs_after_v0_14_13()
-        + _paths_to_versioned_code_after_v0_14_13()
-    )
 
-    print(
-        f"Processing {len(paths)} paths in prepend_version_info_to_name_for_snippet_by_name_references..."
-    )
-    for path in paths:
-        version = path.name
+    print(f"Processing prepend_version_info_to_name_for_snippet_by_name_references...")
+    for path in (
+        _path_to_versioned_docs() / version_string,
+        _path_to_versioned_code() / version_string,
+    ):
+        dir_name = path.name
         files = []
         for extension in (".md", ".mdx", ".py", ".yml", ".yaml"):
             files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
@@ -112,7 +80,7 @@ def prepend_version_info_to_name_for_snippet_by_name_references(
         for file_path in files:
             with open(file_path, "r+") as f:
                 contents = f.read()
-                contents = re.sub(pattern, rf"\1{version} \4", contents)
+                contents = re.sub(pattern, rf"\1{dir_name} \4", contents)
                 f.seek(0)
                 f.truncate()
                 f.write(contents)
@@ -121,29 +89,18 @@ def prepend_version_info_to_name_for_snippet_by_name_references(
         print(
             f"    Processed {len(files)} files for path {path} in prepend_version_info_to_name_for_snippet_by_name_references"
         )
-    print(
-        f"Processed {len(paths)} paths in prepend_version_info_to_name_for_snippet_by_name_references"
-    )
 
 
-def prepend_version_info_to_name_for_href_absolute_links(verbose: bool = False) -> None:
+def prepend_version_info_to_name_for_href_absolute_links(
+    version: Version, verbose: bool = False
+) -> None:
     """Prepend version info to absolute links: /docs/... becomes /docs/{version}/..."""
 
     href_pattern = re.compile(r"(?P<href>href=[\"\']/docs/)(?P<link>\S*[\"\'])")
-    version_from_path_name_pattern = re.compile(
-        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
-    )
-    paths = _paths_to_versioned_docs() + _paths_to_versioned_code()
-
-    print(
-        f"Processing {len(paths)} paths in prepend_version_info_to_name_for_href_absolute_links..."
-    )
-    for path in paths:
-        version = path.name
-        version_only = version_from_path_name_pattern.search(version).group("version")
-        if not version_only:
-            raise ValueError("Path does not contain a version number")
-
+    print(f"Processing prepend_version_info_to_name_for_href_absolute_links...")
+    for path in _path_to_versioned_docs() / version_dir_name(
+        version
+    ), _path_to_versioned_code() / version_dir_name(version):
         files = []
         for extension in (".md", ".mdx"):
             files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
@@ -155,7 +112,7 @@ def prepend_version_info_to_name_for_href_absolute_links(verbose: bool = False) 
                 contents = f.read()
                 # href="/docs/link" -> href="/docs/0.14.13/link"
                 contents = re.sub(
-                    href_pattern, rf"\g<href>{version_only}/\g<link>", contents
+                    href_pattern, rf"\g<href>{version}/\g<link>", contents
                 )
                 f.seek(0)
                 f.truncate()
@@ -165,55 +122,46 @@ def prepend_version_info_to_name_for_href_absolute_links(verbose: bool = False) 
         print(
             f"    Processed {len(files)} files for path {path} in prepend_version_info_to_name_for_href_absolute_links"
         )
-    print(
-        f"Processed {len(paths)} paths in prepend_version_info_to_name_for_href_absolute_links"
-    )
 
 
 def update_tag_references_for_correct_version(
+    version: Version,
     verbose: bool = False,
 ) -> None:
     """Change _tag.mdx to point to appropriate version."""
 
-    version_from_path_name_pattern = re.compile(
-        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
-    )
-    paths = _paths_to_versioned_docs()
+    path = _path_to_versioned_docs() / version_dir_name(version)
 
     method_name_for_logging = "update_tag_references_for_correct_version"
-    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
-    for path in paths:
-        version = path.name
-        version_only = version_from_path_name_pattern.search(version).group("version")
-        if not version_only:
-            raise ValueError("Path does not contain a version number")
-        files = [path / "term_tags/_tag.mdx"]
-        print(
-            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
-        )
-        for file_path in files:
-            with open(file_path, "r+") as f:
-                contents = f.read()
-                # <a href={'/docs/' + data[props.tag].url}>{props.text}</a>
-                # to ->
-                # <a href={'/docs/0.14.13/' + data[props.tag].url}>{props.text}</a>
-                # where 0.14.13 is replaced with the corresponding doc version e.g. 0.14.13, 0.15.50, etc.
-                contents = _update_tag_references_for_correct_version_substitution(
-                    contents, version_only
-                )
-                f.seek(0)
-                f.truncate()
-                f.write(contents)
-            if verbose:
-                print(f"processed {file_path}")
-        print(
-            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
-        )
-    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+    print(f"Processing {method_name_for_logging}...")
+
+    files = [path / "term_tags/_tag.mdx"]
+    print(
+        f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+    )
+    for file_path in files:
+        with open(file_path, "r+") as f:
+            contents = f.read()
+            # <a href={'/docs/' + data[props.tag].url}>{props.text}</a>
+            # to ->
+            # <a href={'/docs/0.14.13/' + data[props.tag].url}>{props.text}</a>
+            # where 0.14.13 is replaced with the corresponding doc version e.g. 0.14.13, 0.15.50, etc.
+            contents = _update_tag_references_for_correct_version_substitution(
+                contents, version
+            )
+            f.seek(0)
+            f.truncate()
+            f.write(contents)
+        if verbose:
+            print(f"processed {file_path}")
+    print(
+        f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+    )
+    print(f"Processed {method_name_for_logging}")
 
 
 def _update_tag_references_for_correct_version_substitution(
-    contents: str, version: str
+    contents: str, version: Version
 ) -> str:
     """Change _tag.mdx to point to appropriate version.
 
@@ -230,6 +178,7 @@ def _update_tag_references_for_correct_version_substitution(
 
 
 def use_relative_path_for_imports(
+    version: Version,
     verbose: bool = False,
 ) -> None:
     """Use relative imports instead of @site
@@ -238,35 +187,33 @@ def use_relative_path_for_imports(
     instead of `import TechnicalTag from '@site/docs/term_tags/_tag.mdx';`
     """
 
-    paths = _paths_to_versioned_docs()
+    path = _path_to_versioned_docs() / version_dir_name(version)
 
     method_name_for_logging = "use_relative_imports_for_tag_references"
-    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
-    for path in paths:
-        files = []
-        for extension in (".md", ".mdx"):
-            files.extend(path.glob(f"**/*{extension}"))
-        print(
-            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
-        )
-        for file_path in files:
-            with open(file_path, "r+") as f:
-                contents = f.read()
-                contents = _use_relative_path_for_imports_substitution(
-                    contents, path, file_path
-                )
-                contents = _use_relative_path_for_imports_substitution_path_starting_with_forwardslash(
-                    contents, path, file_path
-                )
-                f.seek(0)
-                f.truncate()
-                f.write(contents)
-            if verbose:
-                print(f"processed {file_path}")
-        print(
-            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
-        )
-    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+    print(f"Processing {method_name_for_logging}...")
+    files: list[pathlib.Path] = []
+    for extension in (".md", ".mdx"):
+        files.extend(path.glob(f"**/*{extension}"))
+    print(
+        f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+    )
+    for file_path in files:
+        with open(file_path, "r+") as f:
+            contents = f.read()
+            contents = _use_relative_path_for_imports_substitution(
+                contents, path, file_path
+            )
+            contents = _use_relative_path_for_imports_substitution_path_starting_with_forwardslash(
+                contents, path, file_path
+            )
+            f.seek(0)
+            f.truncate()
+            f.write(contents)
+        if verbose:
+            print(f"processed {file_path}")
+    print(
+        f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+    )
 
 
 def _use_relative_path_for_imports_substitution(
@@ -330,6 +277,7 @@ def _use_relative_path_for_imports_substitution_path_starting_with_forwardslash(
 
 
 def prepend_version_info_to_name_for_md_relative_links(
+    version: Version,
     verbose: bool = False,
 ) -> None:
     """Prepend version info to md relative links.
@@ -349,58 +297,50 @@ def prepend_version_info_to_name_for_md_relative_links(
     # Links to ../../../../docs/guides/validation/index.md#actions
     # Should link to: ../../../../docs/0.16.16/guides/validation/index.md#actions
 
-    version_from_path_name_pattern = re.compile(
-        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
-    )
-    paths = _paths_to_versioned_docs_after_v0_15_50()
+    dir_name = version_dir_name(version)
+    path = _path_to_versioned_docs() / dir_name
 
     method_name_for_logging = (
         "prepend_version_info_to_name_for_md_relative_links_to_index_files"
     )
-    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
-    for path in paths:
-        version = path.name
-        version_only = version_from_path_name_pattern.search(version).group("version")
-        if not version_only:
-            raise ValueError("Path does not contain a version number")
+    print(f"Processing {method_name_for_logging}...")
 
-        files = []
-        for extension in (".md", ".mdx"):
-            files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
-        print(
-            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
-        )
-        # NOTE: update files_to_process if there are more files that use relative markdown links.
-        # Alternatively, remove this list if all files should be processed.
-        files_to_process = [
-            "_data_docs_build_and_view.md",
-            "_checkpoint_create_and_run.md",
-        ]
-        files = [file for file in files if file.split("/")[-1] in files_to_process]
-        for file_path in files:
-            with open(file_path, "r+") as f:
-                contents = f.read()
-                contents = (
-                    _prepend_version_info_to_name_for_md_relative_links_to_index_files(
-                        contents=contents, version=version_only
-                    )
+    files = []
+    for extension in (".md", ".mdx"):
+        files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
+    print(
+        f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+    )
+    # NOTE: update files_to_process if there are more files that use relative markdown links.
+    # Alternatively, remove this list if all files should be processed.
+    files_to_process = [
+        "_data_docs_build_and_view.md",
+        "_checkpoint_create_and_run.md",
+    ]
+    files = [file for file in files if file.split("/")[-1] in files_to_process]
+    for file_path in files:
+        with open(file_path, "r+") as f:
+            contents = f.read()
+            contents = (
+                _prepend_version_info_to_name_for_md_relative_links_to_index_files(
+                    contents=contents, version=version
                 )
-                contents = _prepend_version_info_to_name_for_md_relative_links(
-                    contents=contents, version=version_only
-                )
-                f.seek(0)
-                f.truncate()
-                f.write(contents)
-            if verbose:
-                print(f"processed {file_path}")
-        print(
-            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
-        )
-    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+            )
+            contents = _prepend_version_info_to_name_for_md_relative_links(
+                contents=contents, version=version
+            )
+            f.seek(0)
+            f.truncate()
+            f.write(contents)
+        if verbose:
+            print(f"processed {file_path}")
+    print(
+        f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+    )
 
 
 def _prepend_version_info_to_name_for_md_relative_links(
-    contents: str, version: str
+    contents: str, version: Version
 ) -> str:
     """
     Fixes issues like this:
@@ -415,7 +355,9 @@ def _prepend_version_info_to_name_for_md_relative_links(
     return contents
 
 
-def prepend_version_info_to_name_for_md_images(verbose: bool = False) -> None:
+def prepend_version_info_to_name_for_md_images(
+    version: Version, verbose: bool = False
+) -> None:
     """Prepend version info to md relative image links.
 
     Links to ../../../static/img/<FILENAME>
@@ -424,50 +366,41 @@ def prepend_version_info_to_name_for_md_images(verbose: bool = False) -> None:
         verbose: Whether to print verbose output.
     """
 
-    version_from_path_name_pattern = re.compile(
-        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
-    )
-    paths = _paths_to_versioned_docs_after_v0_15_50()
+    path = _path_to_versioned_docs() / version_dir_name(version)
 
     method_name_for_logging = "prepend_version_info_to_name_for_md_images"
-    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
-    for path in paths:
-        version = path.name
-        version_only = version_from_path_name_pattern.search(version).group("version")
-        if not version_only:
-            raise ValueError("Path does not contain a version number")
+    print(f"Processing {method_name_for_logging}...")
 
-        files = []
-        for extension in (".md", ".mdx"):
-            files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
-        print(
-            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
-        )
-        # NOTE: update files_to_process if there are more files that use relative markdown links.
-        # Alternatively, remove this list if all files should be processed.
-        files_to_process = {
-            "manage_validations.md",
-        }
-        files = [file for file in files if file.split("/")[-1] in files_to_process]
-        for file_path in files:
-            with open(file_path, "r+") as f:
-                contents = f.read()
-                contents = _prepend_version_info_to_name_for_md_image(
-                    contents=contents, version=version_only
-                )
-                f.seek(0)
-                f.truncate()
-                f.write(contents)
-            if verbose:
-                print(f"processed {file_path}")
-        print(
-            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
-        )
-    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+    files = []
+    for extension in (".md", ".mdx"):
+        files.extend(glob.glob(f"{path}/**/*{extension}", recursive=True))
+    print(
+        f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+    )
+    # NOTE: update files_to_process if there are more files that use relative markdown links.
+    # Alternatively, remove this list if all files should be processed.
+    files_to_process = {
+        "manage_validations.md",
+    }
+    files = [file for file in files if file.split("/")[-1] in files_to_process]
+    for file_path in files:
+        with open(file_path, "r+") as f:
+            contents = f.read()
+            contents = _prepend_version_info_to_name_for_md_image(
+                contents=contents, version=version
+            )
+            f.seek(0)
+            f.truncate()
+            f.write(contents)
+        if verbose:
+            print(f"processed {file_path}")
+    print(
+        f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+    )
 
 
 def _prepend_version_info_to_name_for_md_relative_links_to_index_files(
-    contents: str, version: str
+    contents: str, version: Version
 ) -> str:
     pattern = re.compile(
         r"(?P<docs>(.*\.\./docs/))(?P<middle>(.*))(?P<index>(index\.md))(?P<rest>(.*))"
@@ -477,7 +410,7 @@ def _prepend_version_info_to_name_for_md_relative_links_to_index_files(
     return contents
 
 
-def _prepend_version_info_to_name_for_md_image(contents: str, version: str) -> str:
+def _prepend_version_info_to_name_for_md_image(contents: str, version: Version) -> str:
     pattern = re.compile(r"\.\./(?P<path>(static/img/.*\.(gif|png)))")
     contents = re.sub(
         pattern,
@@ -489,6 +422,7 @@ def _prepend_version_info_to_name_for_md_image(contents: str, version: str) -> s
 
 
 def prepend_version_info_for_md_absolute_links(
+    version: Version,
     verbose: bool = False,
 ) -> None:
     """Add version info to md absolute links.
@@ -502,46 +436,32 @@ def prepend_version_info_for_md_absolute_links(
         verbose: Whether to print verbose output.
     """
 
-    paths = _paths_to_versioned_docs()
-
-    version_from_path_name_pattern = re.compile(
-        r"(?P<version>\d{1,2}\.\d{1,2}\.\d{1,2})"
-    )
+    path = _path_to_versioned_docs() / version_dir_name(version)
 
     method_name_for_logging = "prepend_version_info_for_md_absolute_links"
-    print(f"Processing {len(paths)} paths in {method_name_for_logging}...")
-    for path in paths:
-        version = path.name
-        version_only: str = version_from_path_name_pattern.search(version).group(
-            "version"
-        )
-        if not version_only:
-            raise ValueError("Path does not contain a version number")
+    print(f"Processing {method_name_for_logging}...")
 
-        files = []
-        for extension in (".md", ".mdx"):
-            files.extend(path.glob(f"**/*{extension}"))
-        print(
-            f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
-        )
-        for file_path in files:
-            with open(file_path, "r+") as f:
-                contents = f.read()
-                contents = _prepend_version_info_for_md_absolute_links(
-                    contents, version_only
-                )
-                f.seek(0)
-                f.truncate()
-                f.write(contents)
-            if verbose:
-                print(f"processed {file_path}")
-        print(
-            f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
-        )
-    print(f"Processed {len(paths)} paths in {method_name_for_logging}")
+    files: list[pathlib.Path] = []
+    for extension in (".md", ".mdx"):
+        files.extend(path.glob(f"**/*{extension}"))
+    print(
+        f"    Processing {len(files)} files for path {path} in {method_name_for_logging}..."
+    )
+    for file_path in files:
+        with open(file_path, "r+") as f:
+            contents = f.read()
+            contents = _prepend_version_info_for_md_absolute_links(contents, version)
+            f.seek(0)
+            f.truncate()
+            f.write(contents)
+        if verbose:
+            print(f"processed {file_path}")
+    print(
+        f"    Processed {len(files)} files for path {path} in {method_name_for_logging}"
+    )
 
 
-def _prepend_version_info_for_md_absolute_links(contents: str, version: str) -> str:
+def _prepend_version_info_for_md_absolute_links(contents: str, version: Version) -> str:
     # The negative lookahead (?!\d{1,2}\.\d{1,2}\.\d{1,2}) ensures that we don't add the version if there
     # already is a version in the link (e.g. when we manually reference earlier versions):
 
@@ -554,18 +474,43 @@ def _prepend_version_info_for_md_absolute_links(contents: str, version: str) -> 
     return contents
 
 
-def prepare_prior_versions() -> None:
+def prepare_prior_versions(versions: list[Version]) -> None:
     print("Starting to process files in prepare_prior_versions.py...")
-    change_paths_for_docs_file_references()
-    prepend_version_info_to_name_for_snippet_by_name_references()
-    prepend_version_info_to_name_for_href_absolute_links()
-    update_tag_references_for_correct_version()
-    use_relative_path_for_imports()
-    prepend_version_info_to_name_for_md_relative_links()
-    prepend_version_info_for_md_absolute_links()
-    prepend_version_info_to_name_for_md_images()
+    for version in versions:
+        prepare_prior_version(version)
     print("Finished processing files in prepare_prior_versions.py")
 
 
-if __name__ == "__main__":
-    prepare_prior_versions()
+def prepare_prior_version(version: Version) -> None:
+    print(f"Starting to process files for version {version}")
+    change_paths_for_docs_file_references(version)
+    prepend_version_info_to_name_for_snippet_by_name_references(version)
+    prepend_version_info_to_name_for_href_absolute_links(version)
+    update_tag_references_for_correct_version(version)
+    use_relative_path_for_imports(version)
+    prepend_version_info_to_name_for_md_relative_links(version)
+    prepend_version_info_for_md_absolute_links(version)
+    prepend_version_info_to_name_for_md_images(version)
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    major: int = 0
+    minor: int = 0
+    patch: int = 0
+
+    def as_tuple(self) -> tuple[int, int, int]:
+        return self.major, self.minor, self.patch
+
+    def __lt__(self, other: Version) -> bool:
+        return self.as_tuple() < other.as_tuple()
+
+    @override
+    def __str__(self) -> str:
+        return ".".join(str(x) for x in self.as_tuple())
+
+    @staticmethod
+    def from_string(string: str) -> Version:
+        major, minor, patch = [int(x) for x in string.split(".")]
+        return Version(major, minor, patch)

--- a/tests/docs/test_prepare_prior_versions.py
+++ b/tests/docs/test_prepare_prior_versions.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 
 from docs.prepare_prior_versions import (
+    Version,
     _prepend_version_info_for_md_absolute_links,
     _prepend_version_info_to_name_for_md_relative_links,
     _prepend_version_info_to_name_for_md_relative_links_to_index_files,
@@ -232,3 +233,31 @@ class TestPrependVersionInfoForMdAbsoluteLinks:
             contents, version
         )
         assert updated_contents == expected_contents
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        (Version(0, 0, 0), Version(0, 0, 1), True),
+        (Version(0, 0, 0), Version(0, 1, 0), True),
+        (Version(1, 0, 0), Version(0, 1, 0), False),
+    ],
+)
+@pytest.mark.unit
+def test_version__lt(a: Version, b: Version, expected: bool):
+    output = a < b
+    assert output == expected
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        (Version(0, 0, 0), Version(0, 0, 0), True),
+        (Version(1, 1, 1), Version(1, 1, 1), True),
+        (Version(0, 1, 1), Version(1, 1, 0), False),
+    ],
+)
+@pytest.mark.unit
+def test_version__eq(a: Version, b: Version, expected: bool):
+    output = a == b
+    assert output == expected


### PR DESCRIPTION
Migrates prepare_prior_versions to allow just building specific versions. This will be used in a new versioning flow (coming in a subsequent PR) It can also be use for backward compatibility in case we need to rebuild v 0.17 or 0.18.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
