### PR TITLE
[MAINTENANCE] Expectation Gallery only builds from success test cases

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -328,14 +328,17 @@ def get_expectation_instances(expectations_info):
             )
             expectation_tracebacks.write(traceback.format_exc())
         except pydantic.ValidationError:
+            expectation_tracebacks.write(
+                f"Test case for {expectation_name} has invalid input type."
+            )
             expectation_tracebacks.write(traceback.format_exc())
-        except IndexError:
+        except (IndexError, ValueError):
             expectation_tracebacks.write(
                 f"Expectation {expectation_name} has invalid test case."
             )
             expectation_tracebacks.write(traceback.format_exc())
-        except Exception as exc:
-            expectation_tracebacks.write(f"Unexpected error occurred: {exc}")
+        except Exception:  # continue even if this expectation fails catastrophically
+            expectation_tracebacks.write("Unexpected error occurred.")
             expectation_tracebacks.write(traceback.format_exc())
     return expectation_instances
 


### PR DESCRIPTION
Follow up PR to ensure that the ExpectationGallery builds from success test cases, to guard against failure test cases providing invalid input types.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
