### PR TITLE
BUGFIX Add template_dict to domain_keys: fixes #8998

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
@@ -32,7 +32,13 @@ class ExpectQueriedCustomQueryToReturnNumRows(QueryExpectation):
         "query",
     )
 
-    domain_keys = ("template_dict", "user_query", "batch_id", "row_condition", "condition_parser")
+    domain_keys = (
+        "template_dict",
+        "user_query",
+        "batch_id",
+        "row_condition",
+        "condition_parser",
+    )
 
     default_kwarg_values = {
         "result_format": "BASIC",

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_custom_query_to_return_num_rows.py
@@ -32,7 +32,7 @@ class ExpectQueriedCustomQueryToReturnNumRows(QueryExpectation):
         "query",
     )
 
-    domain_keys = ("user_query", "batch_id", "row_condition", "condition_parser")
+    domain_keys = ("template_dict", "user_query", "batch_id", "row_condition", "condition_parser")
 
     default_kwarg_values = {
         "result_format": "BASIC",


### PR DESCRIPTION
Fixes [Can't use expect_queried_custom_query_to_return_num_rows more than once per validator](https://github.com/great-expectations/great_expectations/issues/8998)

Added `template_dict` to `domain_keys` because otherwise you can only ever use this expectation once per asset. Now, you can use it multiple times with different custom queries.