### PR TITLE
[DOCS] Remove References to GX_CLOUD_SNOWFLAKE_PASSWORD

### DIFF
--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -14,9 +14,9 @@ To learn more about Data Assets, see [Data Asset](/docs/reference/learn/terms/da
 
 - You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
 
-- You have [set up GX Cloud](../set_up_gx_cloud.md) including setting the `GX_CLOUD_SNOWFLAKE_PASSWORD` environment variable, and the GX Agent is running. 
+- You have [set up GX Cloud](../set_up_gx_cloud.md) and the GX Agent is running. 
 
-- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password.
+- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password. To improve data security, GX recommends using a Snowflake service account to connect to GX Cloud.
 
 
 ## Create a Data Asset
@@ -37,7 +37,7 @@ Create a Data Asset to define the data you want GX Cloud to access. Currently, t
 
     - **Account identifier**: Enter your Snowflake account or locator information. The locator value must include the geographical region. For example, `us-east-1`. To locate these values see [Account Identifiers](https://docs.snowflake.com/en/user-guide/admin-account-identifier).
 
-    - **Password/environment variable**: Enter `${GX_CLOUD_SNOWFLAKE_PASSWORD}`. If you haven't set this variable, see [Set up GX Cloud](../set_up_gx_cloud.md).
+    - **Password**: Enter your Snowflake password.
 
     - **Database**: Enter the name of the Snowflake database where the data you want to validate is stored. In Snowsight, click **Data** > **Databases**. In the Snowflake Classic Console, click **Databases**.
  
@@ -195,6 +195,30 @@ Currently, you can only edit Snowflake Data Assets.
     - **Data Asset name**: Enter a new name for the Data Asset. If you use the same name for multiple Data Assets, each Data Asset must be associated with a unique Data Source.
 
 3. Click **Save**.
+
+## Secure your GX API Data Source connection strings
+
+When you use the GX API and not GX Cloud to connect to Data Sources, you must obfuscate your sensitive Data Source credentials in your connection string. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
+
+1. Store your credential value as an environment variable by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the command to your `~/.bashrc` or `~/.zshrc` file. For example:
+
+    ```bash title="Terminal input"
+    export GX_CLOUD_SNOWFLAKE_PASSWORD=<password-string>
+    ```
+    Prefix environment variable names with `GX_CLOUD_`.
+
+2. Create a Data Source connection string using the environment variable name instead of the credential value. For example:
+
+    ```python title="Example Data Source connection string"
+    snowflake://<user-name>:${GX_CLOUD_SNOWFLAKE_PASSWORD}@<account-name>/<database-name>/<schema-name>?warehouse=<warehouse-name>&role=<role-name>
+    ```
+    Environment variable names must be enclosed by curly braces and be preceded by a dollar sign. For example: `${GX_CLOUD_SNOWFLAKE_PASSWORD}`. Do not use interpolation to add credential values to connection strings.
+
+3. Use the environment variable to supply the credential value when you run the GX Agent. For example:
+
+    ```bash title="Terminal input"
+    docker run --rm -e GX_CLOUD_SNOWFLAKE_PASSWORD="<snowflake_password>" -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
+    ```
 
 ## Delete a Data Asset
 

--- a/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
+++ b/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
@@ -11,7 +11,7 @@ In this quickstart, you'll learn how to connect GX Cloud to Snowflake Data Asset
 
 - You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
 
-- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password.
+- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password. To improve data security, GX recommends using a Snowflake service account to connect to GX Cloud.
 
 - You have a [Docker instance](https://docs.docker.com/get-docker/).
 
@@ -45,12 +45,12 @@ Environment variables securely store your GX Cloud and Snowflake access credenti
 
 1. Start the Docker Engine.
 
-2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN`, `GX_CLOUD_ORGANIZATION_ID`, and `GX_CLOUD_SNOWFLAKE_PASSWORD` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
+2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
 
     ```bash title="Terminal input"
-    docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" -e GX_CLOUD_SNOWFLAKE_PASSWORD="<snowflake_password>" greatexpectations/agent
+    docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
     ```
-    Replace `user_access_token`, `organization_id`, and `snowflake_password` with your own values. 
+   Replace `user_access_token` and `organization_id` with the values you copied previously. 
 
 3. Optional. If you created a temporary file to record your user access token and Organization ID, delete it.
 
@@ -78,7 +78,7 @@ Create a Data Asset to define the data you want GX Cloud to access within Snowfl
 
     - **Account identifier**: Enter your Snowflake account or locator information. The locator value must include the geographical region. For example, `us-east-1`. To locate these values see [Account Identifiers](https://docs.snowflake.com/en/user-guide/admin-account-identifier).
 
-    - **Password/environment variable**: Enter `${GX_CLOUD_SNOWFLAKE_PASSWORD}`. If you haven't set this variable, see [Set up GX Cloud](../set_up_gx_cloud.md).
+    - **Password**: Enter your Snowflake password.
 
     - **Database**: Enter the name of the Snowflake database where the data you want to validate is stored. In Snowsight, click **Data** > **Databases**. In the Snowflake Classic Console, click **Databases**.
  

--- a/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
+++ b/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
@@ -39,13 +39,13 @@ You'll need your user access token and organization ID to set your environment v
 
     GX recommends deleting the temporary file after you set the environment variables.
 
-## Set the environment variables and start the GX Cloud agent
+## Set the environment variables and start the GX Agent
 
-Environment variables securely store your GX Cloud and Snowflake access credentials. The GX Cloud agent runs open source GX code in GX Cloud, and it allows you to securely access your data without connecting to it or interacting with it directly. 
+Environment variables securely store your GX Cloud and Snowflake access credentials. The GX Agent runs open source GX code in GX Cloud, and it allows you to securely access your data without connecting to it or interacting with it directly. 
 
 1. Start the Docker Engine.
 
-2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
+2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Agent:
 
     ```bash title="Terminal input"
     docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
@@ -56,9 +56,9 @@ Environment variables securely store your GX Cloud and Snowflake access credenti
 
 4. Optional. Run `docker ps` or open Docker Desktop to confirm the agent is running.
 
-    If you stop the GX Cloud agent, close the terminal, and open a new terminal you'll need to set the environment variables again.
+    If you stop the GX Agent, close the terminal, and open a new terminal you'll need to set the environment variables again.
 
-    To edit an environment variable, stop the GX Cloud agent, edit the environment variable, save the change, and then restart the GX Cloud agent.
+    To edit an environment variable, stop the GX Agent, edit the environment variable, save the change, and then restart the GX Agent.
 
 ## Create the Snowflake Data Asset
 

--- a/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
+++ b/docs/docusaurus/docs/cloud/quickstarts/snowflake_quickstart.md
@@ -11,7 +11,7 @@ In this quickstart, you'll learn how to connect GX Cloud to Snowflake Data Asset
 
 - You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
 
-- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password. To improve data security, GX recommends using a Snowflake service account to connect to GX Cloud.
+- You have a [Snowflake account](https://docs.snowflake.com/en/user-guide-admin) with USAGE privileges on the table, database, and schema you are validating, and you know your password. To improve data security, GX recommends using a separate Snowflake user service account to connect to GX Cloud.
 
 - You have a [Docker instance](https://docs.docker.com/get-docker/).
 

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -4,7 +4,7 @@ title: 'Set up GX Cloud'
 description: Set up GX Cloud.
 ---
 
-To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Cloud agent.
+To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Agent.
 
 Currently, the GX Cloud user interface is configured for Snowflake. If you don't have a Snowflake Data Source, you won't be able to connect to Data Assets, create Expectation Suites and Expectations, run Validations, or create Checkpoints. 
 
@@ -55,15 +55,15 @@ You'll need your user access token and organization ID to set your environment v
 
     GX recommends deleting the temporary file after you set the environment variables.
 
-## Set the environment variables and start the GX Cloud agent
+## Set the environment variables and start the GX Agent
 
-Environment variables securely store your GX Cloud access credentials. The GX Cloud agent runs open source GX code in GX Cloud, and it allows you to securely access your data without connecting to it or interacting with it directly. 
+Environment variables securely store your GX Cloud access credentials. The GX Agent runs open source GX code in GX Cloud, and it allows you to securely access your data without connecting to it or interacting with it directly. 
 
 Currently, the GX Cloud user interface is configured for Snowflake and this procedure assumes you have a Snowflake Data Source. If you don't have a Snowflake Data Source, you won't be able to connect to Data Assets, create Expectation Suites and Expectations, run Validations, or create Checkpoints. 
 
 1. Start the Docker Engine.
 
-2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
+2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Agent:
 
     ```bash title="Terminal input"
     docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
@@ -80,9 +80,9 @@ Currently, the GX Cloud user interface is configured for Snowflake and this proc
 
 5. Optional. Run `docker ps` or open Docker Desktop to confirm the agent is running.
 
-    If you stop the GX Cloud agent, close the terminal, and open a new terminal you'll need to set the environment variables again.
+    If you stop the GX Agent, close the terminal, and open a new terminal you'll need to set the environment variables again.
 
-    To edit an environment variable, stop the GX Cloud agent, edit the environment variable, save the change, and then restart the GX Cloud agent.
+    To edit an environment variable, stop the GX Agent, edit the environment variable, save the change, and then restart the GX Agent.
 
 ## Next steps
 

--- a/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/set_up_gx_cloud.md
@@ -4,7 +4,9 @@ title: 'Set up GX Cloud'
 description: Set up GX Cloud.
 ---
 
-To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Cloud agent. 
+To get the most out of GX Cloud, you'll need to request a GX Cloud Beta account, generate and record access tokens, set environment variables, and then install and start the GX Cloud agent.
+
+Currently, the GX Cloud user interface is configured for Snowflake. If you don't have a Snowflake Data Source, you won't be able to connect to Data Assets, create Expectation Suites and Expectations, run Validations, or create Checkpoints. 
 
 If you're using Snowflake and are ready to create Expectations and run Validations, see [Quickstart for GX Cloud and Snowflake](/docs/cloud/quickstarts/snowflake_quickstart).
 
@@ -61,20 +63,19 @@ Currently, the GX Cloud user interface is configured for Snowflake and this proc
 
 1. Start the Docker Engine.
 
-2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN`, `GX_CLOUD_ORGANIZATION_ID`, and `GX_CLOUD_SNOWFLAKE_PASSWORD` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
+2. Run the following code to set the `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` environment variables, install GX Cloud and its dependencies, and start the GX Cloud agent:
 
     ```bash title="Terminal input"
-    docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" -e GX_CLOUD_SNOWFLAKE_PASSWORD="<snowflake_password>" greatexpectations/agent
+    docker run --rm --pull=always -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
     ```      
-    Replace `user_access_token` and `organization_id` with the values you copied previously, and `snowflake_password` with your own value.
+    Replace `user_access_token` and `organization_id` with the values you copied previously.
 
-3. Optional. To use GX Cloud in Python scripts: save your `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` as environment variables outside of the Docker Engine by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the commands to your `~/.bashrc` or `~/.zshrc` file. For example:
+3. Optional. To use GX Cloud in Python scripts, save your `GX_CLOUD_ACCESS_TOKEN` and `GX_CLOUD_ORGANIZATION_ID` as environment variables outside the Docker Engine by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the commands to your `~/.bashrc` or `~/.zshrc` file. For example:
 
     ```bash title="Terminal input"
     export GX_CLOUD_ACCESS_TOKEN=<user_access_token>
     export GX_CLOUD_ORGANIZATION_ID=<organization_id>
     ```
-
 4. Optional. If you created a temporary file to record your user access token and Organization ID, delete it.
 
 5. Optional. Run `docker ps` or open Docker Desktop to confirm the agent is running.
@@ -82,30 +83,6 @@ Currently, the GX Cloud user interface is configured for Snowflake and this proc
     If you stop the GX Cloud agent, close the terminal, and open a new terminal you'll need to set the environment variables again.
 
     To edit an environment variable, stop the GX Cloud agent, edit the environment variable, save the change, and then restart the GX Cloud agent.
-
-## Secure your GX API Data Source connection strings
-
-When you use the GX API and not GX Cloud to connect to Data Sources, you must obfuscate your sensitive Data Source credentials in your connection string. Data Source connection strings are persisted in [GX Cloud backend storage](/docs/cloud/about_gx#gx-cloud-architecture). Connection strings containing plaintext credentials are stored as plaintext.
-
-1. Store your credential value as an environment variable by entering `export ENV_VAR_NAME=env_var_value` in the terminal or adding the command to your `~/.bashrc` or `~/.zshrc` file. For example:
-
-    ```bash title="Terminal input"
-    export GX_CLOUD_SNOWFLAKE_PASSWORD=<password-string>
-    ```
-    Prefix environment variable names with `GX_CLOUD_`.
-
-2. Create a Data Source connection string using the environment variable name instead of the credential value. For example:
-
-    ```python title="Example Data Source connection string"
-    snowflake://<user-name>:${GX_CLOUD_SNOWFLAKE_PASSWORD}@<account-name>/<database-name>/<schema-name>?warehouse=<warehouse-name>&role=<role-name>
-    ```
-    Environment variable names must be enclosed by curly braces and be preceded by a dollar sign. For example: `${GX_CLOUD_SNOWFLAKE_PASSWORD}`. Do not use interpolation to add credential values to connection strings.
-
-3. Use the environment variable to supply the credential value when you run the GX Agent. For example:
-
-    ```bash title="Terminal input"
-    docker run --rm -e GX_CLOUD_SNOWFLAKE_PASSWORD="<snowflake_password>" -e GX_CLOUD_ACCESS_TOKEN="<user_access_token>" -e GX_CLOUD_ORGANIZATION_ID="<organization_id>" greatexpectations/agent
-    ```
 
 ## Next steps
 

--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -43,8 +43,8 @@ module.exports = {
           href: "https://greatexpectations.io/cloud"
         },
         secondary: {
-          label: "Learn about Great Expectations",
-          href: "https://greatexpectations.io/company"
+          label: "Learn why GX Cloud is the leading data quality solution",
+          href: "https://docs.greatexpectations.io/docs/cloud/why_gx_cloud"
         }
       }
     },

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -68,11 +68,6 @@ module.exports = {
               label: 'Set the environment variables and start the GX Cloud agent',
               href: '/docs/cloud/set_up_gx_cloud#set-the-environment-variables-and-start-the-gx-cloud-agent',
             },
-            {
-              type: 'link',
-              label: 'Secure your GX API Data Source connection strings',
-              href: '/docs/cloud/set_up_gx_cloud#secure-your-gx-api-data-source-connection-strings',
-            },
           ]
         },
         {
@@ -119,6 +114,11 @@ module.exports = {
               type: 'link',
               label: 'Edit a Data Asset',
               href: '/docs/cloud/data_assets/manage_data_assets#edit-a-data-asset',
+            },
+            {
+              type: 'link',
+              label: 'Secure your GX API Data Source connection strings',
+              href: '/docs/cloud/data_assets/manage_data_assets#secure-your-gx-api-data-source-connection-strings',
             },
             {
               type: 'link',

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -65,7 +65,7 @@ module.exports = {
             },
             {
               type: 'link',
-              label: 'Set the environment variables and start the GX Cloud agent',
+              label: 'Set the environment variables and start the GX Agent',
               href: '/docs/cloud/set_up_gx_cloud#set-the-environment-variables-and-start-the-gx-cloud-agent',
             },
           ]


### PR DESCRIPTION
[DOC-643](https://greatexpectations.atlassian.net/browse/DOC-643) requests the removal of references to GX_CLOUD_SNOWFLAKE_PASSWORD. This change is required because users are discouraged from creating an environment variable for their Snowflake password in the new org agent workflow. This PR implements this change and minor organizational and text changes. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated

[DOC-643]: https://greatexpectations.atlassian.net/browse/DOC-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ