### PR TITLE
[FEATURE] Open DataDocs demo

### DIFF
--- a/tests/integration/docusaurus/tutorials/quickstart/v1_pandas_quickstart.py
+++ b/tests/integration/docusaurus/tutorials/quickstart/v1_pandas_quickstart.py
@@ -54,5 +54,4 @@ assert result.expectation_config.kwargs["mostly"] == 0.95
 suite_result = batch.validate(suite)
 assert suite_result.success
 
-# TODO: Need to implement this
-# validation_result.open_docs()
+suite_result.open_docs()


### PR DESCRIPTION
A very hacky example implementation for opening data docs directly from a SuiteValidationResult. Take the example for a spin at `tests/integration/docusaurus/tutorials/quickstart/v1_pandas_quickstart.py`.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
