### PR TITLE
[MAINTENANCE] Add typevar around add_expectation

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -16,6 +16,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -56,6 +57,8 @@ if TYPE_CHECKING:
     from great_expectations.expectations.expectation_configuration import (
         ExpectationConfiguration,
     )
+
+    _TExpectation = TypeVar("_TExpectation", bound=Expectation)
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +148,7 @@ class ExpectationSuite(SerializableDictDot):
         return self.expectation_suite_name
 
     @public_api
-    def add_expectation(self, expectation: Expectation) -> Expectation:
+    def add_expectation(self, expectation: _TExpectation) -> _TExpectation:
         """Add an Expectation to the collection."""
         if expectation.id:
             raise RuntimeError(
@@ -562,7 +565,8 @@ class ExpectationSuite(SerializableDictDot):
                     match_indexes.append(idx)
             else:  # noqa: PLR5501
                 if expectation.configuration.isEquivalentTo(
-                    other=expectation_configuration, match_type=match_type  # type: ignore[arg-type]
+                    other=expectation_configuration,
+                    match_type=match_type,  # type: ignore[arg-type]
                 ):
                     match_indexes.append(idx)
 

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -565,8 +565,8 @@ class ExpectationSuite(SerializableDictDot):
                     match_indexes.append(idx)
             else:  # noqa: PLR5501
                 if expectation.configuration.isEquivalentTo(
-                    other=expectation_configuration,
-                    match_type=match_type,  # type: ignore[arg-type]
+                    other=expectation_configuration,  # type: ignore[arg-type]
+                    match_type=match_type,
                 ):
                     match_indexes.append(idx)
 

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import uuid
-from typing import TYPE_CHECKING, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Dict, Optional, TypeVar, Union, cast
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
@@ -27,6 +27,8 @@ from great_expectations.util import (
 
 if TYPE_CHECKING:
     from great_expectations.expectations.expectation import Expectation
+
+    _TExpectation = TypeVar("_TExpectation", bound=Expectation)
 
 
 class ExpectationsStore(Store):
@@ -115,8 +117,8 @@ class ExpectationsStore(Store):
         return suite_dict
 
     def add_expectation(
-        self, suite: ExpectationSuite, expectation: Expectation
-    ) -> Expectation:
+        self, suite: ExpectationSuite, expectation: _TExpectation
+    ) -> _TExpectation:
         suite_identifier, fetched_suite = self._refresh_suite(suite)
 
         # we need to find which ID has been added by the backend


### PR DESCRIPTION
Adds TypeVar so that the type checker knows we return the same subclass of Expectation that we pass in to add_expectation.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
