### PR TITLE
[MAINTENANCE] Remove Click constraint in 0.18.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 altair>=4.2.1,<5.0.0
-Click>=7.1.2
+Click>=7.1.2 # 8.1.4 shouldn't cause any runtime issues it will die at type checking
 colorama>=0.4.3
 cryptography>=3.2
 Ipython>=7.16.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 altair>=4.2.1,<5.0.0
-Click>=7.1.2,!=8.1.4 # 8.1.4 has a mypy typing bug (https://github.com/pallets/click/issues/2558)
+Click>=7.1.2
 colorama>=0.4.3
 cryptography>=3.2
 Ipython>=7.16.3

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -834,29 +834,3 @@ def test_discard_failing_expectations():
     with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
         sub1.discard_failing_expectations()
     assert sub1.get_expectation_suite().expectations == exp1
-
-
-@pytest.mark.unit
-def test_test_expectation_function():
-    asset = gx.dataset.PandasDataset(
-        {
-            "x": [1, 3, 5, 7, 9],
-            "y": [1, 2, None, 7, 9],
-        }
-    )
-    asset_2 = gx.dataset.PandasDataset(
-        {
-            "x": [1, 3, 5, 6, 9],
-            "y": [1, 2, None, 6, 9],
-        }
-    )
-
-    def expect_dataframe_to_contain_7(self):
-        return {"success": bool((self == 7).sum().sum() > 0)}
-
-    assert asset.test_expectation_function(
-        expect_dataframe_to_contain_7, include_config=False
-    ) == ExpectationValidationResult(success=True)
-    assert asset_2.test_expectation_function(
-        expect_dataframe_to_contain_7, include_config=False
-    ) == ExpectationValidationResult(success=False)


### PR DESCRIPTION
Remove constraint now that we have additional minor versions to grab from Click

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
