### PR TITLE
[MAINTENANCE] Add upper bound for numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ jsonschema>=2.5.1
 makefun>=1.7.0,<2
 marshmallow>=3.7.1,<4.0.0
 mistune>=0.8.4
-numpy>=1.20.3; python_version == "3.8"
-numpy>=1.21.6; python_version == "3.9"
-numpy>=1.22.4; python_version >= "3.10"
+numpy>=1.20.3,<2.0.0; python_version == "3.8"
+numpy>=1.21.6,<2.0.0; python_version == "3.9"
+numpy>=1.22.4,<2.0.0; python_version >= "3.10"
 packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -184,9 +184,13 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
     )
 
     # Polish and ratchet this number down as low as possible
-    assert len(sorted_packages_with_pins_or_upper_bounds) == 73
+    assert len(sorted_packages_with_pins_or_upper_bounds) == 76
     assert sorted_packages_with_pins_or_upper_bounds == [
-        ("requirements-dev-api-docs-test.txt", "docstring-parser", (("==", "0.15"),)),
+        (
+            "requirements-dev-api-docs-test.txt",
+            "docstring-parser",
+            (("==", "0.15"),),
+        ),
         ("requirements-dev-athena.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
         ("requirements-dev-contrib.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-contrib.txt", "black", (("==", "23.10.1"),)),
@@ -205,18 +209,34 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
             (("<", "0.10"), (">=", "0.9.3")),
         ),
         ("requirements-dev-sqlalchemy.txt", "ipykernel", (("<=", "6.17.1"),)),
-        ("requirements-dev-sqlalchemy.txt", "moto", (("<", "3.0.0"), (">=", "2.0.0"))),
-        ("requirements-dev-sqlalchemy.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
+        (
+            "requirements-dev-sqlalchemy.txt",
+            "moto",
+            (("<", "3.0.0"), (">=", "2.0.0")),
+        ),
+        (
+            "requirements-dev-sqlalchemy.txt",
+            "pyathena",
+            (("<", "3"), (">=", "2.0.0")),
+        ),
         ("requirements-dev-sqlalchemy.txt", "snapshottest", (("==", "0.6.0"),)),
         ("requirements-dev-sqlalchemy.txt", "sqlalchemy", (("<", "2.0.0"),)),
-        ("requirements-dev-sqlalchemy.txt", "sqlalchemy-dremio", (("==", "1.2.1"),)),
+        (
+            "requirements-dev-sqlalchemy.txt",
+            "sqlalchemy-dremio",
+            (("==", "1.2.1"),),
+        ),
         (
             "requirements-dev-sqlalchemy.txt",
             "teradatasqlalchemy",
             (("==", "17.0.0.5"),),
         ),
         ("requirements-dev-sqlalchemy1.txt", "sqlalchemy", (("<", "2.0.0"),)),
-        ("requirements-dev-teradata.txt", "teradatasqlalchemy", (("==", "17.0.0.5"),)),
+        (
+            "requirements-dev-teradata.txt",
+            "teradatasqlalchemy",
+            (("==", "17.0.0.5"),),
+        ),
         ("requirements-dev-test.txt", "adr-tools-python", (("==", "1.0.3"),)),
         ("requirements-dev-test.txt", "black", (("==", "23.10.1"),)),
         ("requirements-dev-test.txt", "docstring-parser", (("==", "0.15"),)),
@@ -235,6 +255,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-dev.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
         ("requirements-dev.txt", "moto", (("<", "3.0.0"), (">=", "2.0.0"))),
         ("requirements-dev.txt", "mypy", (("==", "1.7.1"),)),
+        ("requirements-dev.txt", "numpy", (("<", "2.0.0"), (">=", "1.22.4"))),
         ("requirements-dev.txt", "posthog", (("<", "3"), (">=", "2.1.0"))),
         ("requirements-dev.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
         ("requirements-dev.txt", "pypd", (("==", "1.1.0"),)),
@@ -251,12 +272,21 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements-types.txt", "black", (("==", "23.10.1"),)),
         ("requirements-types.txt", "ipykernel", (("<=", "6.17.1"),)),
         ("requirements-types.txt", "makefun", (("<", "2"), (">=", "1.7.0"))),
-        ("requirements-types.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
+        (
+            "requirements-types.txt",
+            "marshmallow",
+            (("<", "4.0.0"), (">=", "3.7.1")),
+        ),
         ("requirements-types.txt", "moto", (("<", "3.0.0"), (">=", "2.0.0"))),
         ("requirements-types.txt", "mypy", (("==", "1.7.1"),)),
+        ("requirements-types.txt", "numpy", (("<", "2.0.0"), (">=", "1.22.4"))),
         ("requirements-types.txt", "posthog", (("<", "3"), (">=", "2.1.0"))),
         ("requirements-types.txt", "pyathena", (("<", "3"), (">=", "2.0.0"))),
-        ("requirements-types.txt", "ruamel.yaml", (("<", "0.17.18"), (">=", "0.16"))),
+        (
+            "requirements-types.txt",
+            "ruamel.yaml",
+            (("<", "0.17.18"), (">=", "0.16")),
+        ),
         ("requirements-types.txt", "ruff", (("==", "0.1.11"),)),
         ("requirements-types.txt", "snapshottest", (("==", "0.6.0"),)),
         ("requirements-types.txt", "sqlalchemy", (("<", "2.0.0"),)),
@@ -265,6 +295,7 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements.txt", "altair", (("<", "5.0.0"), (">=", "4.2.1"))),
         ("requirements.txt", "makefun", (("<", "2"), (">=", "1.7.0"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
+        ("requirements.txt", "numpy", (("<", "2.0.0"), (">=", "1.22.4"))),
         ("requirements.txt", "posthog", (("<", "3"), (">=", "2.1.0"))),
         ("requirements.txt", "ruamel.yaml", (("<", "0.17.18"), (">=", "0.16"))),
     ]


### PR DESCRIPTION
Add upper bound for numpy until we are able to be compatible with v2.0.0.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
