### PR TITLE
[MAINTENANCE] Switch over docs build flow and update readme

### DIFF
--- a/docs/docs_build.py
+++ b/docs/docs_build.py
@@ -30,20 +30,18 @@ class DocsBuilder:
         current_directory: Path,
         is_pull_request: bool,
         is_local: bool,
-        s3_url: str = S3_URL,
     ) -> None:
         self._context = context
         self._current_directory = current_directory
         self._is_pull_request = is_pull_request
         self._is_local = is_local
-        self._s3_url = s3_url
 
         self._current_commit = self._run_and_get_output("git rev-parse HEAD")
         self._current_branch = self._run_and_get_output(
             "git rev-parse --abbrev-ref HEAD"
         )
 
-    def build_docs_2(self) -> None:
+    def build_docs(self) -> None:
         """Build API docs + docusaurus docs.
 
         NOTE: This will replace `build_docs` very shortly!
@@ -53,14 +51,6 @@ class DocsBuilder:
 
         self._invoke_api_docs()
 
-        self.logger.print_header("Building docusaurus docs...")
-        self._context.run("yarn build")
-
-    def build_docs(self) -> None:
-        """Build API docs + docusaurus docs.
-        Currently used in our netlify pipeline.
-        """
-        self._prepare()
         self.logger.print_header("Building docusaurus docs...")
         self._context.run("yarn build")
 
@@ -165,11 +155,11 @@ class DocsBuilder:
         return versions
 
     def _load_all_versioned_docs(self) -> List[Version]:
-        self.logger.print(f"Copying previous versioned docs from {self._s3_url}")
+        self.logger.print(f"Copying previous versioned docs from {S3_URL}")
         if os.path.exists("versioned_code"):
             shutil.rmtree("versioned_code")
         os.mkdir("versioned_code")
-        with self._load_zip(self._s3_url) as zip_ref:
+        with self._load_zip(S3_URL) as zip_ref:
             zip_ref.extractall(self._current_directory)
             versions_json = zip_ref.read("versions.json")
             return [Version.from_string(x) for x in json.loads(versions_json)]

--- a/docs/docs_version_bucket_info.py
+++ b/docs/docs_version_bucket_info.py
@@ -3,13 +3,10 @@
 
 S3_BUCKET = "superconductive-public"
 REGION = "us-east-2"
-FILENAME = "oss_docs_versions_20230615.zip"
-UPDATED_FILENAME = "oss_docs_versions_20240118.zip"
+FILENAME = "oss_docs_versions_20240118.zip"
 
 S3_URL = f"https://{S3_BUCKET}.s3.{REGION}.amazonaws.com/{FILENAME}"
-UPDATED_S3_URL = f"https://{S3_BUCKET}.s3.{REGION}.amazonaws.com/{UPDATED_FILENAME}"
 
 # Run this file to print the S3_URL
 if __name__ == "__main__":
     print(S3_URL)
-    print(UPDATED_S3_URL)

--- a/tasks.py
+++ b/tasks.py
@@ -660,7 +660,6 @@ def docs(  # noqa: PLR0913
 ):
     """Build documentation site, including api documentation and earlier doc versions. Note: Internet access required to download earlier versions."""
     from docs.docs_build import DocsBuilder, Version
-    from docs.docs_version_bucket_info import UPDATED_S3_URL
 
     repo_root = pathlib.Path(__file__).parent
 
@@ -698,7 +697,6 @@ def docs(  # noqa: PLR0913
             docusaurus_dir,
             is_pull_request=is_pull_request,
             is_local=is_local,
-            s3_url=UPDATED_S3_URL,
         )
         docs_builder.create_version(version=Version.from_string(version))
     else:  # noqa: PLR5501


### PR DESCRIPTION
Removes old build process in favor of the new one. Some key things:
* Updates the zip file to load from s3 (this includes processed files including `versioned_code/`)
* The readme now shows the new flow
* Removed some now dead code

**Steps to test**
* Do what netlify would do: `invoke docs --build`
* `cd docs/docusaurus && yarn docusaurus serve`
* Poke around to make sure I didn't miss anything!

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
