### PR TITLE
[MAINTENANCE] Move Markdown logic from `meta["notes"]` to top-level Expectation notes

### DIFF
--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -297,7 +297,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
         return result
 
     @classmethod
-    def _render_expectation_meta_notes(cls, expectation):  # noqa: PLR0912
+    def _render_expectation_meta_notes(cls, expectation):
         if not expectation.meta.get("notes"):
             return None
         else:
@@ -318,59 +318,16 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     },
                 }
             )
-            notes = expectation.meta["notes"]
-            note_content = None
-
-            if isinstance(notes, str):
-                note_content = [notes]
-
-            elif isinstance(notes, list):
-                note_content = notes
-
-            elif isinstance(notes, dict):
-                if "format" in notes:
-                    if notes["format"] == "string":
-                        if isinstance(notes["content"], str):
-                            note_content = [notes["content"]]
-                        elif isinstance(notes["content"], list):
-                            note_content = notes["content"]
-                        else:
-                            logger.warning(
-                                "Unrecognized Expectation suite notes format. Skipping rendering."
-                            )
-
-                    elif notes["format"] == "markdown":
-                        if isinstance(notes["content"], str):
-                            note_content = [
-                                RenderedMarkdownContent(
-                                    **{
-                                        "content_block_type": "markdown",
-                                        "markdown": notes["content"],
-                                        "styling": {
-                                            "parent": {"styles": {"color": "red"}}
-                                        },
-                                    }
-                                )
-                            ]
-                        elif isinstance(notes["content"], list):
-                            note_content = [
-                                RenderedMarkdownContent(
-                                    **{
-                                        "content_block_type": "markdown",
-                                        "markdown": note,
-                                        "styling": {"parent": {}},
-                                    }
-                                )
-                                for note in notes["content"]
-                            ]
-                        else:
-                            logger.warning(
-                                "Unrecognized Expectation suite notes format. Skipping rendering."
-                            )
-                else:
-                    logger.warning(
-                        "Unrecognized Expectation suite notes format. Skipping rendering."
-                    )
+            notes = expectation.notes
+            note_content = [
+                RenderedMarkdownContent(
+                    **{
+                        "content_block_type": "markdown",
+                        "markdown": notes,
+                        "styling": {"parent": {"styles": {"color": "red"}}},
+                    }
+                )
+            ]
 
             notes_block = TextContent(
                 **{

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -802,7 +802,7 @@ class ExpectationSuitePageRenderer(Renderer):
 
     # TODO: Update tests
     @classmethod
-    def _render_expectation_suite_notes(cls, expectations):  # noqa: PLR0912
+    def _render_expectation_suite_notes(cls, expectations):
         content = []
 
         total_expectations = len(expectations.expectations)
@@ -819,61 +819,17 @@ class ExpectationSuitePageRenderer(Renderer):
             f"This Expectation suite currently contains {total_expectations} total Expectations across {total_columns} columns.",
         ]
 
-        if "notes" in expectations.meta:
-            notes = expectations.meta["notes"]
-            note_content = None
-
-            if isinstance(notes, str):
-                note_content = [notes]
-
-            elif isinstance(notes, list):
-                note_content = notes
-
-            elif isinstance(notes, dict):
-                if "format" in notes:
-                    if notes["format"] == "string":
-                        if isinstance(notes["content"], str):
-                            note_content = [notes["content"]]
-                        elif isinstance(notes["content"], list):
-                            note_content = notes["content"]
-                        else:
-                            logger.warning(
-                                "Unrecognized Expectation suite notes format. Skipping rendering."
-                            )
-
-                    elif notes["format"] == "markdown":
-                        if isinstance(notes["content"], str):
-                            note_content = [
-                                RenderedMarkdownContent(
-                                    **{
-                                        "content_block_type": "markdown",
-                                        "markdown": notes["content"],
-                                        "styling": {"parent": {}},
-                                    }
-                                )
-                            ]
-                        elif isinstance(notes["content"], list):
-                            note_content = [
-                                RenderedMarkdownContent(
-                                    **{
-                                        "content_block_type": "markdown",
-                                        "markdown": note,
-                                        "styling": {"parent": {}},
-                                    }
-                                )
-                                for note in notes["content"]
-                            ]
-                        else:
-                            logger.warning(
-                                "Unrecognized Expectation suite notes format. Skipping rendering."
-                            )
-                else:
-                    logger.warning(
-                        "Unrecognized Expectation suite notes format. Skipping rendering."
-                    )
-
-            if note_content is not None:
-                content += note_content
+        notes = expectations.notes
+        note_content = [
+            RenderedMarkdownContent(
+                **{
+                    "content_block_type": "markdown",
+                    "markdown": notes,
+                    "styling": {"parent": {}},
+                }
+            )
+        ]
+        content += note_content
 
         return TextContent(
             **{


### PR DESCRIPTION



- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
