### PR TITLE
[DOCS] Update styles for left navigation

### DIFF
--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -27,6 +27,7 @@
     --ifm-color-primary-light: #fd749b;
     --ifm-color-primary-lighter: #fe85a7;
     --ifm-color-primary-lightest: #feb7cb;
+    --color-primary-10: rgba(255, 99, 16, .1);
     --ifm-code-font-size: 95%;
 
     /* make pagination look like the nice buttons */

--- a/docs/docusaurus/src/css/left_navigation.scss
+++ b/docs/docusaurus/src/css/left_navigation.scss
@@ -19,6 +19,10 @@
   font-weight: bold;
 }
 
+.menu__list-item {
+  border-left: 4px solid transparent;
+}
+
 .menu__list-item-collapsible--active,
 .menu__list-item-collapsible--active:hover,
 .menu__link--active:not(.menu__link--sublist) {
@@ -48,8 +52,8 @@ nav.menu {
 }
 
 .menu__caret {
-  padding-left: 9px;
-  padding-right: 9px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .menu__caret:before {

--- a/docs/docusaurus/src/css/left_navigation.scss
+++ b/docs/docusaurus/src/css/left_navigation.scss
@@ -18,3 +18,42 @@
   color: var(--ifm-menu-color);
   font-weight: bold;
 }
+
+.menu__list-item-collapsible--active,
+.menu__list-item-collapsible--active:hover,
+.menu__link--active:not(.menu__link--sublist) {
+  background-color: var(--color-primary-10);
+  border-left: 4px solid var(--ifm-color-primary);
+  border-radius: unset;
+}
+
+nav.menu {
+  background-color: var(--gray-100);
+  border-right: 1px solid var(--gray-200);
+  padding-left: 0;
+  scrollbar-gutter: unset;
+}
+
+.menu__list-item-collapsible {
+  flex-direction: row-reverse;
+
+  a {
+    padding-left: 0;
+  }
+}
+
+.menu__link:hover,
+.menu__list-item-collapsible:hover {
+  border-radius: 0;
+}
+
+.menu__caret {
+  padding-left: 9px;
+  padding-right: 9px;
+}
+
+.menu__caret:before {
+  background: var(--ifm-menu-link-sublist-icon) 50% / 1rem 1rem;
+  height: 0.75rem;
+  width: 0.75rem;
+}


### PR DESCRIPTION
## Description
- Changes background color of left navigation bar
- Changes color to highlight current section

## Screenshots
![Captura desde 2024-01-24 13-03-01](https://github.com/great-expectations/great_expectations/assets/7197057/84686da2-fa72-4672-8fd3-4d8fe87113b3)

![Captura desde 2024-01-24 13-03-07](https://github.com/great-expectations/great_expectations/assets/7197057/ede5d670-e590-48c8-86b8-943f945d4286)

[Grabación de pantalla desde 24-01-24 13:01:38.webm](https://github.com/great-expectations/great_expectations/assets/7197057/121a4e44-aa54-44a3-bf77-a9614b6346c4)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
