### PR TITLE
[MAINTENANCE] allow absolute file links

### DIFF
--- a/docs/checks/docs_link_checker.py
+++ b/docs/checks/docs_link_checker.py
@@ -251,6 +251,7 @@ class LinkChecker:
         - Relative links that begin with either . or .. and have a .md suffix
         - Relative images with an image suffix
         - Docroot links that begin with a character (neither . or /) are relative to the doc root (ex: /docs) and have a .md suffix
+        - Absolute file paths for markdown files
 
         Args:
             match: A positive match of a markdown link (ex: [...](...)) or image

--- a/docs/checks/docs_link_checker.py
+++ b/docs/checks/docs_link_checker.py
@@ -94,6 +94,9 @@ class LinkChecker:
         )
         self._absolute_link_pattern = re.compile(absolute_link_regex)
 
+        absolute_file_regex = rf"(?!(\/{site_prefix}\/))\/\S+\.mdx?(#[^'\"]+)?"
+        self._absolute_file_pattern = re.compile(absolute_file_regex)
+
         # docroot links start without a . or a slash
         docroot_link_regex = r"^(?P<path>\w[\.\w\/-]+\.md)(?:#\S+)?$"
         self._docroot_link_pattern = re.compile(docroot_link_regex)
@@ -284,6 +287,10 @@ class LinkChecker:
                     result = self._check_absolute_link(
                         link, file, match.group("path"), match.group("version")
                     )
+                elif match := self._absolute_file_pattern.match(link):  # type: ignore[assignment]
+                    # This could be more robust like the other checks, but the level of complexity will be high for versioned_docs,
+                    # and we should be able to just set onBrokenMarkdownLinks: 'error'
+                    result = None
                 else:
                     match = self._docroot_link_pattern.match(link)  # type: ignore[assignment]
                     if match:


### PR DESCRIPTION
Allow absolute file links. This is a prereq for https://github.com/great-expectations/great_expectations/pull/9281. I didn't make this as robust as the other checks because I want to work on removing our custom checks in favor of relying on docusurus's build-in checks. If anything, I might want to lint to prevent any links that start with `/docs/`, since they'll break with versioning. But that needs to happen later.

See https://docusaurus.io/docs/markdown-features/links 's info on "absolute file paths"

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
