### PR TITLE
[BUGFIX] Remove unneeded and problematic git wrangling in docs build

### DIFF
--- a/docs/docs_build.py
+++ b/docs/docs_build.py
@@ -182,21 +182,9 @@ class DocsBuilder:
         """Invokes the invoke api-docs command.
         If this is a non-PR running on netlify, we use the latest tag. Otherwise, we use the current branch.
         """
-        if self._is_pull_request or self._is_local:
-            self.logger.print_header(
-                "Building locally or from within a pull request, using the latest commit to build API docs so changes can be viewed in the Netlify deploy preview."
-            )
-        else:
-            self._run(f"git checkout {self._latest_tag}")
-            self._run("git pull")
-            self.logger.print_header(
-                f"Not in a pull request. Using latest released version {self._latest_tag} at {self._current_commit} to build API docs."
-            )
-        self.logger.print(
-            "Building API docs for current version. Please ignore sphinx docstring errors in red/pink, for example: ERROR: Unexpected indentation."
-        )
+        self.logger.print("Invoking api-docs...")
 
-        # TODO: not this
+        # TODO: not this: we should do this all in python
         self._run("(cd ../../; invoke api-docs)")
 
     def _checkout_correct_branch(self) -> None:
@@ -221,7 +209,7 @@ class DocsBuilder:
             file.write(content)
 
     def _run(self, command: str) -> Optional[str]:
-        result = self._context.run(command)
+        result = self._context.run(command, echo=True)
         if not result:
             return None
         elif not result.ok:


### PR DESCRIPTION
These git calls were erroring out during the production docs build. Looks like they were a bad migration from the original bash scripts. Either way, we don't know why we'd need to do any git wrangling at this point, so we're deleting it.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
