### PR TITLE
[MAINTENANCE] Use verson safe links

### DIFF
--- a/docs/docusaurus/docs/components/_prerequisites.jsx
+++ b/docs/docusaurus/docs/components/_prerequisites.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import GxData from '/docs/components/_data.jsx'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -56,10 +57,10 @@ export default class Prerequisites extends React.Component {
       returnItems.push(<li>An installation of Python {GxData.min_python} to {GxData.max_python}. To download and install Python, see <a href='https://www.python.org/downloads/'>Python downloads.</a></li>)
     }
     if (this.props.requireInstallation === true) {
-      returnItems.push(<li>A Great Expectations instance. See <a href='/docs/oss/guides/setup/installation/install_gx'>Install Great Expectations with Data Source dependencies</a>.</li>)
+      returnItems.push(<li>A Great Expectations instance. See <VersionedLink to='/oss/guides/setup/installation/install_gx'>Install Great Expectations with Data Source dependencies</VersionedLink>.</li>)
     }
     if (this.props.requireDataContext === true) {
-      returnItems.push(<li><a href='/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/instantiate_data_context'>A Data Context.</a></li>)
+      returnItems.push(<li><VersionedLink to='/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/instantiate_data_context'>A Data Context.</VersionedLink></li>)
     }
     if (this.props.requireSourceData === 'filesystem') {
       returnItems.push(<li>Access to data stored in a filesystem.</li>)
@@ -73,10 +74,10 @@ export default class Prerequisites extends React.Component {
     } else if (this.props.requireDatasource === 'SQL') {
       returnItems.push(<li><a href='/docs/0.15.50/guides/connecting_to_your_data/datasource_configuration/how_to_configure_a_sql_datasource'>A Data Source configured to access your sData Assets.</a></li>)
     } else if (this.props.requireDatasource === true) {
-      returnItems.push(<li><a href='/docs/oss/guides/connecting_to_your_data/connect_to_data_overview'>A Data Source configured to access your Data Assets</a></li>)
+      returnItems.push(<li><VersionedLink to='/oss/guides/connecting_to_your_data/connect_to_data_overview'>A Data Source configured to access your Data Assets</VersionedLink></li>)
     }
     if (this.props.requireExpectationSuite === true) {
-      returnItems.push(<li><a href='/docs/oss/guides/expectations/create_expectations_overview'>A configured and saved Expectation Suite.</a></li>)
+      returnItems.push(<li><VersionedLink to='/oss/guides/expectations/create_expectations_overview'>A configured and saved Expectation Suite.</VersionedLink></li>)
     }
 
     return returnItems

--- a/docs/docusaurus/docs/components/prerequisites/_quickstart_completed.mdx
+++ b/docs/docusaurus/docs/components/prerequisites/_quickstart_completed.mdx
@@ -1,1 +1,3 @@
-<span><a href='/docs/oss/tutorials/quickstart'>Completion of the Quickstart</a></span>
+import VersionedLink from '@site/src/components/VersionedLink'
+
+<span><VersionedLink to='/oss/tutorials/quickstart'>Completion of the Quickstart</VersionedLink></span>

--- a/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import VersionedLink from '@site/src/components/VersionedLink'
+import Link from '@docusaurus/Link';
+import VersionedLink from '@site/src/components/VersionedLink';
 
 /**
  * A flexible Prerequisites admonition block.
@@ -35,7 +36,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
-        <li><VersionedLink to='/oss/contributing/contributing_setup'>Set up your dev environment</VersionedLink></li>
+        <li><Link to='/docs/contributing/contributing_setup'>Set up your dev environment</Link></li>
         <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }

--- a/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -33,9 +34,9 @@ export default class Prerequisites extends React.Component {
   defaultPrerequisiteItems () {
     return [
       <li key={0.1}>
-        <li><a href='/docs/oss/tutorials/quickstart'>Completed the Quickstart guide</a></li>
-        <li><a href='/docs/oss/contributing/contributing_setup'>Set up your dev environment</a></li>
-        <li>Created a <a href='/docs/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</a></li>
+        <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
+        <li><VersionedLink to='/oss/contributing/contributing_setup'>Set up your dev environment</VersionedLink></li>
+        <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }
 

--- a/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/contributing/components/prerequisites.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from '@docusaurus/Link';
 import VersionedLink from '@site/src/components/VersionedLink';
 
 /**
@@ -36,7 +35,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
-        <li><Link to='/docs/contributing/contributing_setup'>Set up your dev environment</Link></li>
+        <li><a href='/docs/contributing/contributing_setup'>Set up your dev environment</a></li>
         <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }

--- a/docs/docusaurus/docs/oss/deployment_patterns/components/deployment_pattern_prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/deployment_patterns/components/deployment_pattern_prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -32,7 +33,7 @@ export default class Prerequisites extends React.Component {
 
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}><a href='/docs/oss/tutorials/quickstart'>Completed the Quickstart guide</a></li>
+      <li key={0.1}><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
     ]
   }
 

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -32,8 +33,8 @@ export default class Prerequisites extends React.Component {
 
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}><a href='/docs/oss/tutorials/quickstart'>Completion of the Quickstart guide.</a></li>,
-      <li key={0.2}><a href='/docs/oss/guides/setup/setup_overview'>A working installation of Great Expectations.</a></li>
+      <li key={0.1}><VersionedLink to='/oss/tutorials/quickstart'>Completion of the Quickstart guide.</VersionedLink></li>,
+      <li key={0.2}><VersionedLink to='/oss/guides/setup/setup_overview'>A working installation of Great Expectations.</VersionedLink></li>
     ]
   }
 

--- a/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from '@docusaurus/Link';
 import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
@@ -36,7 +35,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completion of the Quickstart.</VersionedLink></li>
-        <li><Link to='/docs/contributing/contributing_setup'>A configured and functional development environment.</Link></li>
+        <li><a href='/docs/contributing/contributing_setup'>A configured and functional development environment.</a></li>
       </li>]
   }
 

--- a/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '@docusaurus/Link';
 import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
@@ -35,7 +36,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completion of the Quickstart.</VersionedLink></li>
-        <li><VersionedLink to='/oss/contributing/contributing_setup'>A configured and functional development environment.</VersionedLink></li>
+        <li><Link to='/docs/contributing/contributing_setup'>A configured and functional development environment.</Link></li>
       </li>]
   }
 

--- a/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -33,8 +34,8 @@ export default class Prerequisites extends React.Component {
   defaultPrerequisiteItems () {
     return [
       <li key={0.1}>
-        <li><a href='/docs/oss/tutorials/quickstart'>Completion of the Quickstart.</a></li>
-        <li><a href='/docs/oss/contributing/contributing_setup'>A configured and functional development environment.</a></li>
+        <li><VersionedLink to='/oss/tutorials/quickstart'>Completion of the Quickstart.</VersionedLink></li>
+        <li><VersionedLink to='/oss/contributing/contributing_setup'>A configured and functional development environment.</VersionedLink></li>
       </li>]
   }
 

--- a/docs/docusaurus/docs/oss/guides/setup/components/defaultPrerequisiteItems.jsx
+++ b/docs/docusaurus/docs/oss/guides/setup/components/defaultPrerequisiteItems.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -27,7 +28,7 @@ export default class Prerequisites extends React.Component {
 
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}><a href='/docs/oss/tutorials/quickstart'>Completed the Quickstart guide</a></li>
+      <li key={0.1}><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
     ]
   }
 

--- a/docs/docusaurus/docs/oss/guides/setup/components/install_prereq.jsx
+++ b/docs/docusaurus/docs/oss/guides/setup/components/install_prereq.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
 import Prerequisites from './defaultPrerequisiteItems.jsx'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 export default class InsPrerequisites extends Prerequisites {
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}><a href='/docs/oss/tutorials/quickstart'>Completed the Quickstart guide</a></li>
+      <li key={0.1}><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
     ]
   }
 }

--- a/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '@docusaurus/Link';
 import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
@@ -35,7 +36,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
-        <li><VersionedLink to='/oss/contributing/contributing_setup'>Set up your dev environment</VersionedLink></li>
+        <li><Link to='/docs/contributing/contributing_setup'>Set up your dev environment</Link></li>
         <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }

--- a/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import VersionedLink from '@site/src/components/VersionedLink'
 
 /**
  * A flexible Prerequisites admonition block.
@@ -33,9 +34,9 @@ export default class Prerequisites extends React.Component {
   defaultPrerequisiteItems () {
     return [
       <li key={0.1}>
-        <li><a href='/docs/oss/tutorials/quickstart'>Completed the Quickstart guide</a></li>
-        <li><a href='/docs/oss/contributing/contributing_setup'>Set up your dev environment</a></li>
-        <li>Created a <a href='/docs/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</a></li>
+        <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
+        <li><VersionedLink to='/oss/contributing/contributing_setup'>Set up your dev environment</VersionedLink></li>
+        <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }
 

--- a/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
+++ b/docs/docusaurus/docs/oss/integrations/components/prerequisites.jsx
@@ -36,7 +36,7 @@ export default class Prerequisites extends React.Component {
     return [
       <li key={0.1}>
         <li><VersionedLink to='/oss/tutorials/quickstart'>Completed the Quickstart guide</VersionedLink></li>
-        <li><Link to='/docs/contributing/contributing_setup'>Set up your dev environment</Link></li>
+        <li><a href='/docs/contributing/contributing_setup'>Set up your dev environment</a></li>
         <li>Created a <VersionedLink to='/oss/guides/expectations/custom_expectations_lp'>Custom Expectation</VersionedLink></li>
       </li>]
   }


### PR DESCRIPTION
Uses the component added in https://github.com/great-expectations/great_expectations/pull/9300.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
