### PR TITLE
[MAINTENANCE] Check for snippets in docs

### DIFF
--- a/docs/docusaurus/scripts/remark-named-snippets/index.js
+++ b/docs/docusaurus/scripts/remark-named-snippets/index.js
@@ -24,7 +24,7 @@ const constructSnippetMap = require('./snippet')
 
 function getDirs () {
   // Get all directories that should be processed
-  const manualDirs = ['../../great_expectations', '../../tests']
+  const manualDirs = ['../../great_expectations', '../../tests', './docs']
   const versionDirs = glob.sync('versioned_code/*/')
   // remove v0.14.13 from processing since it does not use named snippets
   const index = versionDirs.indexOf('versioned_code/version-0.14.13/')


### PR DESCRIPTION
We need to look in the docs directory for snippets. Maybe we should also add `versioned_docs/`

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
