### PR TITLE
[DOCS] Reduce Button Text

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -51,7 +51,7 @@ module.exports = {
           href: "https://greatexpectations.io/cloud"
         },
         secondary: {
-          label: "Learn why GX Cloud is the leading data quality solution",
+          label: "Why GX Cloud?",
           href: "https://docs.greatexpectations.io/docs/cloud/why_gx_cloud"
         }
       }


### PR DESCRIPTION
In [this Slack conversation](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1706557563130719), @joshzzheng requested the reduction of the text that appears in the second button on the [Great Expectations documentation landing page](https://docs.greatexpectations.io/docs/home/). This PR implements the change.