### PR TITLE
[DOCS] Remove Missingness Assistant Content from GX Cloud Documentation

### DIFF
--- a/docs/docusaurus/docs/cloud/expectation_suites/manage_expectation_suites.md
+++ b/docs/docusaurus/docs/cloud/expectation_suites/manage_expectation_suites.md
@@ -14,27 +14,7 @@ To learn more about Expectation Suites, see [Expectation Suites](/reference/lear
 
 - You have a [Data Asset](/cloud/data_assets/manage_data_assets.md#create-a-data-asset).
 
-## Automatically create an Expectation Suite that tests for missing data
-
-Automatically create an Expectation Suite that you can use to determine if your Data Asset contains missing data (null values). Creating Expectation Suites automatically saves you writing and then running the same code for each column in your Data Asset.
-
-1. In GX Cloud, click **Data Assets** and select a Data Asset in the **Data Assets** list.
-
-2. Click the **Expectations** tab.
-
-3. Click **Create New Suite** in the **Expectation Suites** pane.
-
-4. Click **Automatic (Experimental)**.
-
-5. Click **Missingness** and then enter a name for the Expectation Suite in the **Suite name** field.
-
-6. Click **Generate Expectations**. 
-
-    It might take several minutes to create the Expectation Suite. When the process is complete, a new Expectation Suite appears in the **Expectation Suites** pane.
-
-7. Optional. Run a Validation on the Expectation Suite. See [Run a Validation](/cloud/validations/manage_validations.md#run-a-validation).
-
-## Create an empty Expectation Suite
+## Create an Expectation Suite
 
 If you have specific business requirements, or you want to examine specific data, you can create an empty Expectation Suite and then add Expectations individually.
 
@@ -42,13 +22,11 @@ If you have specific business requirements, or you want to examine specific data
 
 2. Click the **Expectations** tab.
 
-3. Click **Create New Suite** in the **Expectation Suites** pane.
+3. Click **New Suite** in the **Expectation Suites** pane.
 
-4. Click **Manual**.
+4. Enter a name for the Expectation Suite in the **Expectation Suite name** field.
 
-5. Enter a name for the Expectation Suite in the **Suite name** field.
-
-6. Click **Generate Expectations**. 
+5. Click **Create Suite**. 
 
 7. Add Expectations to the Expectation Suite. See [Create an Expectation](/cloud/expectations/manage_expectations.md#create-an-expectation).
 

--- a/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
+++ b/docs/docusaurus/docs/cloud/why_gx_cloud.mdx
@@ -12,8 +12,6 @@ If you’ve made it this far, you know that you need a data quality framework—
 
 Proactive data quality lets you catch issues before they can become problems downstream. And with GX Cloud, you can have your first proactive data quality tests in place today.
 
-GX Cloud makes it easy to [set up your first data quality checks automatically](/cloud/expectation_suites/manage_expectation_suites.md#automatically-create-an-expectation-suite-that-tests-for-missing-data). Even a dataset you’ve never seen before can be brought under test in minutes.
-
 ## Expect great things
 
 An Expectation is a simple, verifiable assertion about the way your data should be. 

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -140,13 +140,8 @@ module.exports = {
           items: [
             {
               type: 'link',
-              label: 'Automatically create an Expectation Suite that tests for missing data',
-              href: '/docs/cloud/expectation_suites/manage_expectation_suites#automatically-create-an-expectation-suite-that-tests-for-missing-data',
-            },
-            {
-              type: 'link',
-              label: 'Create an empty Expectation Suite ',
-              href: '/docs/cloud/expectation_suites/manage_expectation_suites#create-an-empty-expectation-suite',
+              label: 'Create an Expectation Suite ',
+              href: '/docs/cloud/expectation_suites/manage_expectation_suites#create-an-expectation-suite',
             },
             {
               type: 'link',


### PR DESCRIPTION
[DOC-650](https://greatexpectations.atlassian.net/browse/DOC-650) requests the removal of Missingness Assistant content from the existing GX Cloud documentation. This PR implements this change. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated



[DOC-650]: https://greatexpectations.atlassian.net/browse/DOC-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ