### PR TITLE
[MAINTENANCE] Move redirect to top and add force flag

### DIFF
--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -1,3 +1,7 @@
+# Old docs (0.16 and below; note that 'legacy' is 0.13 and below)
+https://old.docs.greatexpectations.io/* https://648b46c2ec119e00089c4318--niobium-lead-7998.netlify.app/:splat 200!
+http://old.docs.greatexpectations.io/* http://648b46c2ec119e00089c4318--niobium-lead-7998.netlify.app/:splat 200!
+
 # Redirect from what the browser serves
 
 /v2 https://legacy.docs.greatexpectations.io/en/latest/
@@ -433,7 +437,3 @@ docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure
 /docs/cloud/quickstarts/snowflake_quickstart /docs/cloud/try_gx_cloud
 /docs/cloud/quickstarts/airflow_quickstart /docs/cloud/connect/connect_airflow
 /docs/cloud/quickstarts/python_quickstart /docs/cloud/connect/connect_python
-
-# Old docs (0.16 and below; note that 'legacy' is 0.13 and below)
-https://old.docs.greatexpectations.io/* https://648b46c2ec119e00089c4318--niobium-lead-7998.netlify.app/:splat 200
-http://old.docs.greatexpectations.io/* http://648b46c2ec119e00089c4318--niobium-lead-7998.netlify.app/:splat 200


### PR DESCRIPTION
Not confident in this, but worth a try. See https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
