### PR TITLE
[MAINTENANCE] Clean docs before build

### DIFF
--- a/docs/build_docs
+++ b/docs/build_docs
@@ -8,4 +8,5 @@ echo "Installing api docs dependencies."
 
 # TODO: change netlify settings so we don't need to do this
 cd ../..
+invoke docs --clean
 invoke docs --build


### PR DESCRIPTION
Our build process currently pulls a bunch of `versioned_*` artifacts from s3. We are in the process of pulling those into version control, but the files may be wrong for a bit while that is a work in process. This is a temporary step to remove potentially wrong files we have under version control to make way for the S3 counterparts.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
