### PR TITLE
[DOCS]  Add Redirect for GX Cloud Documentation 

### DIFF
--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -436,4 +436,4 @@ docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure
 /docs/cloud/quickstarts/snowflake_quickstart /docs/cloud/try_gx_cloud
 /docs/cloud/quickstarts/airflow_quickstart /docs/cloud/connect/connect_airflow
 /docs/cloud/quickstarts/python_quickstart /docs/cloud/connect/connect_python
-/docs/cloud/set_up_gx_cloud /docs/cloud/try_gx_cloud
+/docs/cloud/set_up_gx_cloud#* /docs/cloud/try_gx_cloud#:splat

--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -436,3 +436,4 @@ docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure
 /docs/cloud/quickstarts/snowflake_quickstart /docs/cloud/try_gx_cloud
 /docs/cloud/quickstarts/airflow_quickstart /docs/cloud/connect/connect_airflow
 /docs/cloud/quickstarts/python_quickstart /docs/cloud/connect/connect_python
+/docs/cloud/set_up_gx_cloud /docs/cloud/try_gx_cloud


### PR DESCRIPTION
When a user who bookmarked a GX Cloud topic that was removed, a 404 error was returned. This PR addresses this issue. 