### PR TITLE
[MAINTENANCE] Stop using relative path to docs from 0.17 docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.17.23/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create_and_run.md
+++ b/docs/docusaurus/versioned_docs/version-0.17.23/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create_and_run.md
@@ -6,6 +6,6 @@ Checkpoints can be preconfigured with a Batch Request and Expectation Suite, or 
 
 :::tip 
 
-To preconfigure a Checkpoint with a Batch Request and Expectation Suite, see [Manage Checkpoints](../../../../docs/guides/validation/checkpoints/checkpoint_lp.md)
+To preconfigure a Checkpoint with a Batch Request and Expectation Suite, see [Manage Checkpoints](/guides/validation/checkpoints/checkpoint_lp.md)
 
 :::

--- a/docs/docusaurus/versioned_docs/version-0.17.23/deployment_patterns/how_to_use_gx_with_aws/components/_data_docs_build_and_view.md
+++ b/docs/docusaurus/versioned_docs/version-0.17.23/deployment_patterns/how_to_use_gx_with_aws/components/_data_docs_build_and_view.md
@@ -4,7 +4,7 @@ The Checkpoint contains `UpdateDataDocsAction` which renders the <TechnicalTag t
 
 :::tip 
 
-For more information on Actions that Checkpoints can perform and how to add them, see [Configure Actions](../../../../docs/guides/validation/validation_actions/actions_lp.md).
+For more information on Actions that Checkpoints can perform and how to add them, see [Configure Actions](/guides/validation/validation_actions/actions_lp.md).
 
 :::
 


### PR DESCRIPTION
Fixed to valid file format. Previously a script was used that replaced the `/docs/` with `/versioned_docs/0.17.x/`, we shouldn't be doing that.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
