### PR TITLE
[DOCS] adds additional bulk redirects for `learn` pages

### DIFF
--- a/docs/docusaurus/static/_redirects
+++ b/docs/docusaurus/static/_redirects
@@ -441,3 +441,5 @@ docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure
 # Broken link redirect
 
 /docs/reference/expectations/standard_arguments/* /docs/reference/learn/expectations/standard_arguments/:splat
+/docs/reference/expectations/* /docs/reference/learn/expectations/:splat
+/docs/reference/terms/* /docs/reference/learn/terms/:splat


### PR DESCRIPTION
## Description
- adds additional bulk redirects for expectation `learn` pages
- adds additional bulk redirect for /docs/reference/terms/ pages

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
