### PR TITLE
[MAINTENANCE] Rename expectation to match 0.18.x version

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py
@@ -24,7 +24,7 @@ from great_expectations.compatibility.pydantic import (
 )
 
 
-class ExpectColumnValuesToBePresentInAnotherTable(QueryExpectation):
+class ExpectColumnValuesToBePresentInOtherTable(QueryExpectation):
     """Expect the values in a column to be present in another table.
 
     This is an Expectation that allows for the validation of referential integrity, that a foreign key exists in

--- a/tests/expectations/core/test_expect_column_values_to_be_present_in_other_table.py
+++ b/tests/expectations/core/test_expect_column_values_to_be_present_in_other_table.py
@@ -3,7 +3,7 @@ from typing import Final
 import pandas as pd
 import pytest
 from contrib.experimental.great_expectations_experimental.expectations.expect_column_values_to_be_present_in_other_table import (
-    ExpectColumnValuesToBePresentInAnotherTable,  # needed for expectation registration
+    ExpectColumnValuesToBePresentInOtherTable,  # needed for expectation registration
 )
 
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
@@ -80,7 +80,7 @@ def test_successful_expectation_run(sqlite_datasource):
     asset = datasource.add_table_asset(name=asset_name, table_name="order_table_1")
     batch = asset.get_batch_list_from_batch_request(asset.build_batch_request())[0]
     res = batch.validate(
-        ExpectColumnValuesToBePresentInAnotherTable(
+        ExpectColumnValuesToBePresentInOtherTable(
             foreign_key_column="CUSTOMER_ID",
             foreign_table="customer_table",
             foreign_table_key_column="CUSTOMER_ID",
@@ -96,7 +96,7 @@ def test_failed_expectation_run(sqlite_datasource):
     asset = datasource.add_table_asset(name=asset_name, table_name="order_table_2")
     batch = asset.get_batch_list_from_batch_request(asset.build_batch_request())[0]
     res = batch.validate(
-        ExpectColumnValuesToBePresentInAnotherTable(
+        ExpectColumnValuesToBePresentInOtherTable(
             foreign_key_column="CUSTOMER_ID",
             foreign_table="customer_table",
             foreign_table_key_column="CUSTOMER_ID",
@@ -122,7 +122,7 @@ def test_configuration_invalid_column_name(sqlite_datasource):
     asset = datasource.add_table_asset(name=asset_name, table_name="order_table_2")
     batch = asset.get_batch_list_from_batch_request(asset.build_batch_request())[0]
     res = batch.validate(
-        ExpectColumnValuesToBePresentInAnotherTable(
+        ExpectColumnValuesToBePresentInOtherTable(
             foreign_key_column="I_DONT_EXIST",
             foreign_table="customer_table",
             foreign_table_key_column="CUSTOMER_ID",
@@ -138,7 +138,7 @@ def test_configuration_invalid_column_name(sqlite_datasource):
 
 @pytest.mark.unit
 def test_template_dict_creation():
-    expectation = ExpectColumnValuesToBePresentInAnotherTable(
+    expectation = ExpectColumnValuesToBePresentInOtherTable(
         foreign_key_column="CUSTOMER_ID",
         foreign_table="customer_table",
         foreign_table_key_column="CUSTOMER_ID",


### PR DESCRIPTION
Rename to match 0.18.x branch: https://github.com/great-expectations/great_expectations/blob/0.18.x/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_present_in_other_table.py#L28

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
