### PR TITLE
add pydantic model for cloud

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -7,7 +7,6 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     List,
     Mapping,
     Optional,
@@ -87,11 +86,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 # TODO Migrate to BaseSettings and support conffile
 class GxCloudConfigEnvVars(BaseModel):
     GX_CLOUD_BASE_URL: Optional[HttpUrl] = CLOUD_DEFAULT_BASE_URL
     GX_CLOUD_ACCESS_TOKEN: SecretStr
     GX_CLOUD_ORGANIZATION_ID: UUID
+
 
 def _extract_fluent_datasources(config_dict: dict) -> dict:
     """
@@ -243,7 +244,7 @@ class CloudDataContext(SerializableDataContext):
                 cloud_access_token=cloud_access_token,
                 cloud_organization_id=cloud_organization_id,
             )
-        except ValueError as e:
+        except ValueError:
             return False
         return True
 
@@ -334,7 +335,6 @@ class CloudDataContext(SerializableDataContext):
             GXCloudError if a GX Cloud variable is missing
         """
         try:
-
             cloud_config_env_vars = cls._get_cloud_config(
                 cloud_base_url=cloud_base_url,
                 cloud_access_token=cloud_access_token,
@@ -386,7 +386,7 @@ class CloudDataContext(SerializableDataContext):
             conf_file_section="ge_cloud_config",
             conf_file_option="access_token",
         )
-        config_dict ={
+        config_dict = {
             GXCloudEnvironmentVariable.BASE_URL: cloud_base_url,
             GXCloudEnvironmentVariable.ORGANIZATION_ID: cloud_organization_id,
             GXCloudEnvironmentVariable.ACCESS_TOKEN: cloud_access_token,


### PR DESCRIPTION
Add validation on gx cloud vars via pydantic `BaseModel`

Note: using BaseModel instead of BaseSettings bc latter would require matching support of conffiles:

```
def _get_cloud_env_var(
        cls,
        primary_environment_variable: GXCloudEnvironmentVariable,
        deprecated_environment_variable: GXCloudEnvironmentVariable,
        conf_file_section: str,
        conf_file_option: str,
    )
```

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
