### PR TITLE
[DOCS] corrects mislabeled element in top navbar

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -122,7 +122,7 @@ module.exports = {
           position: 'right'
         },
         {
-          label: 'GX Core',
+          label: 'GX OSS',
           to: '/docs/oss/',
           position: 'right'
         },


### PR DESCRIPTION
## Description
- Reverts "GX Core" to "GX OSS" in the top nav bar.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated