### PR TITLE
[MAINTENANCE] Move snippets to snippet directory

### DIFF
--- a/docs/docusaurus/docs/snippets/actions.py
+++ b/docs/docusaurus/docs/snippets/actions.py
@@ -1,0 +1,62 @@
+from typing import TYPE_CHECKING, List, Union
+from great_expectations.checkpoint.actions import ValidationAction
+from great_expectations.core.expectation_validation_result import (
+    ExpectationSuiteValidationResult,
+)
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.data_context.types.resource_identifiers import (
+    GXCloudIdentifier,
+    ValidationResultIdentifier,
+)
+
+if TYPE_CHECKING:
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationSuiteValidationResult,
+    )
+    from great_expectations.data_context import AbstractDataContext
+
+
+class DocsAction(ValidationAction):
+    def __init__(
+        self,
+        data_context: AbstractDataContext,
+        site_names: Union[List[str], str, None] = None,
+    ) -> None:
+        """
+        :param data_context: Data Context
+        :param site_names: *optional* List of site names for building data docs
+        """
+        super().__init__(data_context)
+        self._site_names = site_names
+
+    @override
+    def _run(  # type: ignore[override] # signature does not match parent  # noqa: PLR0913
+        self,
+        validation_result_suite: ExpectationSuiteValidationResult,
+        validation_result_suite_identifier: Union[
+            ValidationResultIdentifier, GXCloudIdentifier
+        ],
+        data_asset,
+        payload=None,
+        expectation_suite_identifier=None,
+        checkpoint_identifier=None,
+    ):
+        # <snippet name="great_expectations/checkpoint/actions.py empty dict">
+        data_docs_validation_results: dict = {}
+        # </snippet>
+        if self._using_cloud_context:
+            return data_docs_validation_results
+
+        # get the URL for the validation result
+        # <snippet name="great_expectations/checkpoint/actions.py get_docs_sites_urls">
+        docs_site_urls_list = self.data_context.get_docs_sites_urls(
+            resource_identifier=validation_result_suite_identifier,
+            site_names=self._site_names,  # type: ignore[arg-type] # could be a `str`
+        )
+        # </snippet>
+        # process payload
+        # <snippet name="great_expectations/checkpoint/actions.py iterate">
+        for sites in docs_site_urls_list:
+            data_docs_validation_results[sites["site_name"]] = sites["site_url"]
+        # </snippet>
+        return data_docs_validation_results

--- a/docs/sphinx_api_docs_source/public_api_missing_threshold.py
+++ b/docs/sphinx_api_docs_source/public_api_missing_threshold.py
@@ -7,6 +7,7 @@ adding an exclude directive to docs/sphinx_api_docs_source/public_api_excludes.p
 ITEMS_IGNORED_FROM_PUBLIC_API = [
     "File: great_expectations/checkpoint/actions.py Name: _run",
     "File: great_expectations/compatibility/not_imported.py Name: is_version_greater_or_equal",
+    "File: great_expectations/compatibility/typing_extensions.py Name: override",
     "File: great_expectations/core/batch.py Name: head",
     "File: great_expectations/core/batch_spec.py Name: to_json_dict",
     "File: great_expectations/core/expectation_diagnostics/expectation_doctor.py Name: print_diagnostic_checklist",
@@ -19,6 +20,7 @@ ITEMS_IGNORED_FROM_PUBLIC_API = [
     "File: great_expectations/data_context/data_context/abstract_data_context.py Name: add_expectation_suite",
     "File: great_expectations/data_context/data_context/abstract_data_context.py Name: add_or_update_checkpoint",
     "File: great_expectations/data_context/data_context/abstract_data_context.py Name: add_or_update_expectation_suite",
+    "File: great_expectations/data_context/data_context/abstract_data_context.py Name: get_docs_sites_urls",
     "File: great_expectations/data_context/data_context/abstract_data_context.py Name: open_data_docs",
     "File: great_expectations/data_context/data_context/context_factory.py Name: get_context",
     "File: great_expectations/data_context/store/_store_backend.py Name: add",
@@ -36,6 +38,7 @@ ITEMS_IGNORED_FROM_PUBLIC_API = [
     "File: great_expectations/data_context/store/tuple_store_backend.py Name: TupleS3StoreBackend",
     "File: great_expectations/data_context/store/validations_store.py Name: ValidationsStore",
     "File: great_expectations/data_context/types/base.py Name: update",
+    "File: great_expectations/data_context/types/resource_identifiers.py Name: GXCloudIdentifier",
     "File: great_expectations/datasource/datasource_dict.py Name: add_dataframe_asset",
     "File: great_expectations/datasource/fluent/config.py Name: get_datasource",
     "File: great_expectations/datasource/fluent/config.py Name: pop",

--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -1207,24 +1207,18 @@ class UpdateDataDocsAction(ValidationAction):
                 expectation_suite_identifier,
             ],
         )
-        # <snippet name="great_expectations/checkpoint/actions.py empty dict">
         data_docs_validation_results: dict = {}
-        # </snippet>
         if self._using_cloud_context:
             return data_docs_validation_results
 
         # get the URL for the validation result
-        # <snippet name="great_expectations/checkpoint/actions.py get_docs_sites_urls">
         docs_site_urls_list = self.data_context.get_docs_sites_urls(
             resource_identifier=validation_result_suite_identifier,
             site_names=self._site_names,  # type: ignore[arg-type] # could be a `str`
         )
-        # </snippet>
         # process payload
-        # <snippet name="great_expectations/checkpoint/actions.py iterate">
         for sites in docs_site_urls_list:
             data_docs_validation_results[sites["site_name"]] = sites["site_url"]
-        # </snippet>
         return data_docs_validation_results
 
 


### PR DESCRIPTION
This looks like the only named snippet we still had outside the docs directory. Did a best effort to get it moved over. If this looks good, then I'll follow up this PR by adding versioned ones ver version 0.17 and 0.18.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
