### PR TITLE
[MAINTENANCE] Log all duplicate snippets at the same time

### DIFF
--- a/docs/docusaurus/scripts/remark-named-snippets/snippet.js
+++ b/docs/docusaurus/scripts/remark-named-snippets/snippet.js
@@ -10,17 +10,23 @@ const htmlparser2 = require('htmlparser2')
  */
 function constructSnippetMap(dirs) {
   const snippets = parseSourceDirectories(dirs)
+  const duplicateNames = []
 
   const snippetMap = {}
   for (const snippet of snippets) {
     const name = snippet.name
     if (name in snippetMap) {
-      throw new Error(
-        `A snippet named ${name} has already been defined elsewhere`
-      )
+      duplicateNames.push(name)
     }
     delete snippet.name // Remove duplicate filename to clean up stdout
     snippetMap[name] = snippet
+  }
+  if (duplicateNames.length > 0) {
+    console.error("Duplicate snippet names found:")
+    console.error(duplicateNames.map((name) => `  ${name}`).join('\n'))
+    throw new Error(
+      `${duplicateNames.length} duplicate snippet names found`
+    )
   }
 
   return snippetMap


### PR DESCRIPTION
When tracking these down, it's nice to see the whole list all at once, rather than getting the slow drip of one error per run of `yarn build`

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
