### PR TITLE
[DOCS] Highlight section docs in sidebar

### DIFF
--- a/docs/docusaurus/___test___/docSidebarWrapper.test.js
+++ b/docs/docusaurus/___test___/docSidebarWrapper.test.js
@@ -11,7 +11,7 @@ jest.mock('@theme-original/DocSidebar', () => {
 })
 
 describe("doc sidebar", () => {
-    test("should retrieve url with hash if it exists", async () => {
+    test("should retrieve url with hash if it exists", () => {
         render(
             <DocSidebarWrapper/>
         );

--- a/docs/docusaurus/___test___/docSidebarWrapper.test.js
+++ b/docs/docusaurus/___test___/docSidebarWrapper.test.js
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { jest, test } from "@jest/globals";
+
+import { render, screen } from "@testing-library/react";
+import DocSidebarWrapper from "../src/theme/DocSidebar/index";
+
+jest.mock('@theme-original/DocSidebar', () => {
+    return (props) => {
+        return props.path
+    }
+})
+
+describe("doc sidebar", () => {
+    test("should retrieve url with hash if it exists", async () => {
+        render(
+            <DocSidebarWrapper/>
+        );
+        screen.getByText("www.example.com/section#some-subsection");
+    });
+});

--- a/docs/docusaurus/__mocks__/@docusaurus/router.js
+++ b/docs/docusaurus/__mocks__/@docusaurus/router.js
@@ -1,0 +1,3 @@
+export const useLocation = () => {
+    return { pathname: "www.example.com/section", hash: "#some-subsection" }
+}

--- a/docs/docusaurus/jest.config.js
+++ b/docs/docusaurus/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     "@docusaurus/(BrowserOnly|ComponentCreator|constants|ExecutionEnvironment|Head|Interpolate|isInternalUrl|Link|Noop|renderRoutes|router|Translate|use.*)":
       "identity-obj-proxy",
     "@theme/(.*)": "@docusaurus/theme-classic/src/theme/$1",
+    "@theme-original/(.*)": "identity-obj-proxy",
     "@site/(.*)": "website/$1",
   },
   transform: {

--- a/docs/docusaurus/src/theme/DocSidebar/index.js
+++ b/docs/docusaurus/src/theme/DocSidebar/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import DocSidebar from '@theme-original/DocSidebar';
+import {useLocation} from '@docusaurus/router';
+
+export default function DocSidebarWrapper(props) {
+  const {pathname, hash} = useLocation();
+
+  let path = pathname;
+  if (hash) {
+      path = path + hash;
+  }
+
+  return (
+    <DocSidebar {...props} path={path}/>
+  );
+}

--- a/docs/docusaurus/src/theme/DocSidebar/index.js
+++ b/docs/docusaurus/src/theme/DocSidebar/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import DocSidebar from '@theme-original/DocSidebar';
-import {useLocation} from '@docusaurus/router';
+import { useLocation } from '@docusaurus/router';
 
 export default function DocSidebarWrapper(props) {
-  const {pathname, hash} = useLocation();
+  const { pathname, hash} = useLocation();
 
   let path = pathname;
   if (hash) {


### PR DESCRIPTION
# Description
Links in the sidebar that correspond to links inside a document (contain `#` in a URL) were not being highlighted in the left sidebar due to not being recognised as matching with the active path, as this only included the pathname of the URLs and not the hashes.
Internally, this router is using [react router](https://reactrouter.com/en/main/hooks/use-location#locationpathname), the original invocation can be seen by ejecting the component of the sidebar in the layout.

# Video
[Grabación de pantalla desde 09-02-24 01:03:18.webm](https://github.com/great-expectations/great_expectations/assets/7197057/7cd9bd74-cb52-4fb6-ac42-67683896c276)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
