### PR TITLE
[BUGFIX] Should not fail loading utils if an integration is missing a type

### DIFF
--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -113,16 +113,23 @@ logger = logging.getLogger(__name__)
 
 if sqlalchemy.sqlite:
     SQLITE_TYPES = {
-        "VARCHAR": sqlalchemy.sqlite.VARCHAR,
-        "CHAR": sqlalchemy.sqlite.CHAR,
-        "INTEGER": sqlalchemy.sqlite.INTEGER,
-        "SMALLINT": sqlalchemy.sqlite.SMALLINT,
-        "DATETIME": sqlalchemy.sqlite.DATETIME(truncate_microseconds=True),
-        "DATE": sqlalchemy.sqlite.DATE,
-        "FLOAT": sqlalchemy.sqlite.FLOAT,
-        "BOOLEAN": sqlalchemy.sqlite.BOOLEAN,
-        "TIMESTAMP": sqlalchemy.sqlite.TIMESTAMP,
+        sqlite_type: getattr(sqlalchemy.sqlite, sqlite_type, None)
+        for sqlite_type in [
+            "VARCHAR",
+            "CHAR",
+            "INTEGER",
+            "SMALLINT",
+            "DATE",
+            "FLOAT",
+            "BOOLEAN",
+            "TIMESTAMP",
+        ]
     }
+    SQLITE_TYPES.update(
+        {
+            "DATETIME": sqlalchemy.sqlite.DATETIME(truncate_microseconds=True),
+        }
+    )
 else:
     SQLITE_TYPES = {}
 
@@ -142,16 +149,19 @@ try:
     from sqlalchemy.dialects.postgresql import dialect as pgDialect  # noqa: TID251
 
     POSTGRESQL_TYPES = {
-        "TEXT": postgresqltypes.TEXT,
-        "CHAR": postgresqltypes.CHAR,
-        "INTEGER": postgresqltypes.INTEGER,
-        "SMALLINT": postgresqltypes.SMALLINT,
-        "BIGINT": postgresqltypes.BIGINT,
-        "TIMESTAMP": postgresqltypes.TIMESTAMP,
-        "DATE": postgresqltypes.DATE,
-        "DOUBLE_PRECISION": postgresqltypes.DOUBLE_PRECISION,
-        "BOOLEAN": postgresqltypes.BOOLEAN,
-        "NUMERIC": postgresqltypes.NUMERIC,
+        postgresql_type: getattr(postgresqltypes, postgresql_type, None)
+        for postgresql_type in [
+            "TEXT",
+            "CHAR",
+            "INTEGER",
+            "SMALLINT",
+            "BIGINT",
+            "TIMESTAMP",
+            "DATE",
+            "DOUBLE_PRECISION",
+            "BOOLEAN",
+            "NUMERIC",
+        ]
     }
 except (ImportError, KeyError):
     postgresqltypes = None
@@ -164,20 +174,27 @@ try:
     # noinspection PyPep8Naming
     from sqlalchemy.dialects.mysql import dialect as mysqlDialect  # noqa: TID251
 
-    MYSQL_TYPES = {
-        "TEXT": mysqltypes.TEXT,
-        "CHAR": mysqltypes.CHAR,
-        "INTEGER": mysqltypes.INTEGER,
-        "SMALLINT": mysqltypes.SMALLINT,
-        "BIGINT": mysqltypes.BIGINT,
-        "DATETIME": mysqltypes.DATETIME,
-        "TIMESTAMP": mysqltypes.TIMESTAMP,
-        "DATE": mysqltypes.DATE,
-        "FLOAT": mysqltypes.FLOAT,
-        "DOUBLE": mysqltypes.DOUBLE,
-        "BOOLEAN": mysqltypes.BOOLEAN,
-        "TINYINT": mysqltypes.TINYINT,
-    }
+    MYSQL_TYPES = (
+        {
+            mysql_type: getattr(mysqltypes, mysql_type, None)
+            for mysql_type in [
+                "TEXT",
+                "CHAR",
+                "INTEGER",
+                "SMALLINT",
+                "BIGINT",
+                "DATETIME",
+                "TIMESTAMP",
+                "DATE",
+                "FLOAT",
+                "DOUBLE",
+                "BOOLEAN",
+                "TINYINT",
+            ]
+        }
+        if mysqltypes
+        else {}
+    )
 except (ImportError, KeyError):
     mysqltypes = None
     mysqlDialect = None
@@ -198,36 +215,39 @@ try:
 
     # noinspection PyUnresolvedReferences
     MSSQL_TYPES = {
-        "BIGINT": mssqltypes.BIGINT,
-        "BINARY": mssqltypes.BINARY,
-        "BIT": mssqltypes.BIT,
-        "CHAR": mssqltypes.CHAR,
-        "DATE": mssqltypes.DATE,
-        "DATETIME": mssqltypes.DATETIME,
-        "DATETIME2": mssqltypes.DATETIME2,
-        "DATETIMEOFFSET": mssqltypes.DATETIMEOFFSET,
-        "DECIMAL": mssqltypes.DECIMAL,
-        "FLOAT": mssqltypes.FLOAT,
-        "IMAGE": mssqltypes.IMAGE,
-        "INT": mssqltypes.INT,
-        "INTEGER": mssqltypes.INTEGER,
-        "MONEY": mssqltypes.MONEY,
-        "NCHAR": mssqltypes.NCHAR,
-        "NTEXT": mssqltypes.NTEXT,
-        "NUMERIC": mssqltypes.NUMERIC,
-        "NVARCHAR": mssqltypes.NVARCHAR,
-        "REAL": mssqltypes.REAL,
-        "SMALLDATETIME": mssqltypes.SMALLDATETIME,
-        "SMALLINT": mssqltypes.SMALLINT,
-        "SMALLMONEY": mssqltypes.SMALLMONEY,
-        "SQL_VARIANT": mssqltypes.SQL_VARIANT,
-        "TEXT": mssqltypes.TEXT,
-        "TIME": mssqltypes.TIME,
-        "TIMESTAMP": mssqltypes.TIMESTAMP,
-        "TINYINT": mssqltypes.TINYINT,
-        "UNIQUEIDENTIFIER": mssqltypes.UNIQUEIDENTIFIER,
-        "VARBINARY": mssqltypes.VARBINARY,
-        "VARCHAR": mssqltypes.VARCHAR,
+        mssql_type: getattr(mssqltypes, mssql_type, None)
+        for mssql_type in [
+            "BIGINT",
+            "BINARY",
+            "BIT",
+            "CHAR",
+            "DATE",
+            "DATETIME",
+            "DATETIME2",
+            "DATETIMEOFFSET",
+            "DECIMAL",
+            "FLOAT",
+            "IMAGE",
+            "INT",
+            "INTEGER",
+            "MONEY",
+            "NCHAR",
+            "NTEXT",
+            "NUMERIC",
+            "NVARCHAR",
+            "REAL",
+            "SMALLDATETIME",
+            "SMALLINT",
+            "SMALLMONEY",
+            "SQL_VARIANT",
+            "TEXT",
+            "TIME",
+            "TIMESTAMP",
+            "TINYINT",
+            "UNIQUEIDENTIFIER",
+            "VARBINARY",
+            "VARCHAR",
+        ]
     }
 except (ImportError, KeyError):
     mssqltypes = None
@@ -242,37 +262,50 @@ try:
     )
 
     CLICKHOUSE_TYPES = {
-        "INT256": clickhousetypes.Int256,
-        "INT128": clickhousetypes.Int128,
-        "INT64": clickhousetypes.Int64,
-        "INT32": clickhousetypes.Int32,
-        "INT16": clickhousetypes.Int16,
-        "INT8": clickhousetypes.Int8,
-        "UINT256": clickhousetypes.UInt256,
-        "UINT128": clickhousetypes.UInt128,
-        "UINT64": clickhousetypes.UInt64,
-        "UINT32": clickhousetypes.UInt32,
-        "UINT16": clickhousetypes.UInt16,
-        "UINT8": clickhousetypes.UInt8,
-        "DATE": clickhousetypes.Date,
-        "DATETIME": clickhousetypes.DateTime,
-        "DATETIME64": clickhousetypes.DateTime64,
-        "FLOAT64": clickhousetypes.Float64,
-        "FLOAT32": clickhousetypes.Float32,
-        "DECIMAL": clickhousetypes.Decimal,
-        "STRING": clickhousetypes.String,
-        "BOOL": clickhousetypes.Boolean,
-        "BOOLEAN": clickhousetypes.Boolean,
-        "UUID": clickhousetypes.UUID,
-        "FIXEDSTRING": clickhousetypes.String,
-        "ENUM8": clickhousetypes.Enum8,
-        "ENUM16": clickhousetypes.Enum16,
-        "ARRAY": clickhousetypes.Array,
-        "NULLABLE": clickhousetypes.Nullable,
-        "LOWCARDINALITY": clickhousetypes.LowCardinality,
-        "TUPLE": clickhousetypes.Tuple,
-        "MAP": clickhousetypes.Map,
+        clickhouse_type.upper(): getattr(clickhousetypes, clickhouse_type, None)
+        for clickhouse_type in [
+            "Int256",
+            "Int128",
+            "Int64",
+            "Int32",
+            "Int16",
+            "Int8",
+            "UInt256",
+            "UInt128",
+            "UInt64",
+            "UInt32",
+            "UInt16",
+            "UInt8",
+            "Date",
+            "DateTime",
+            "DateTime64",
+            "Float64",
+            "Float32",
+            "Decimal",
+            "String",
+            "UUID",
+            "Enum8",
+            "Enum16",
+            "Array",
+            "Nullable",
+            "LowCardinality",
+            "Tuple",
+            "Map",
+        ]
     }
+    if getattr(clickhousetypes, "String", None):
+        CLICKHOUSE_TYPES.update(
+            {
+                "FIXEDSTRING": clickhousetypes.String,
+            }
+        )
+    if getattr(clickhousetypes, "Boolean", None):
+        CLICKHOUSE_TYPES.update(
+            {
+                "BOOL": clickhousetypes.Boolean,
+                "BOOLEAN": clickhousetypes.Boolean,
+            }
+        )
 except (ImportError, KeyError):
     clickhouse = None
     clickhousetypes = None
@@ -282,22 +315,25 @@ except (ImportError, KeyError):
 
 TRINO_TYPES: Dict[str, Any] = (
     {
-        "BOOLEAN": trino.trinotypes._type_map["boolean"],
-        "TINYINT": trino.trinotypes._type_map["tinyint"],
-        "SMALLINT": trino.trinotypes._type_map["smallint"],
-        "INT": trino.trinotypes._type_map["int"],
-        "INTEGER": trino.trinotypes._type_map["integer"],
-        "BIGINT": trino.trinotypes._type_map["bigint"],
-        "REAL": trino.trinotypes._type_map["real"],
-        "DOUBLE": trino.trinotypes._type_map["double"],
-        "DECIMAL": trino.trinotypes._type_map["decimal"],
-        "VARCHAR": trino.trinotypes._type_map["varchar"],
-        "CHAR": trino.trinotypes._type_map["char"],
-        "VARBINARY": trino.trinotypes._type_map["varbinary"],
-        "JSON": trino.trinotypes._type_map["json"],
-        "DATE": trino.trinotypes._type_map["date"],
-        "TIME": trino.trinotypes._type_map["time"],
-        "TIMESTAMP": trino.trinotypes._type_map["timestamp"],
+        trino_type.upper(): trino.trinotypes._type_map.get(trino_type)
+        for trino_type in [
+            "boolean",
+            "tinyint",
+            "smallint",
+            "int",
+            "integer",
+            "bigint",
+            "real",
+            "double",
+            "decimal",
+            "varchar",
+            "char",
+            "varbinary",
+            "json",
+            "date",
+            "time",
+            "timestamp",
+        ]
     }
     if trino.trinotypes
     else {}
@@ -305,22 +341,25 @@ TRINO_TYPES: Dict[str, Any] = (
 
 REDSHIFT_TYPES: Dict[str, Any] = (
     {
-        "BIGINT": aws.redshiftdialect.BIGINT,
-        "BOOLEAN": aws.redshiftdialect.BOOLEAN,
-        "CHAR": aws.redshiftdialect.CHAR,
-        "DATE": aws.redshiftdialect.DATE,
-        "DECIMAL": aws.redshiftdialect.DECIMAL,
-        "DOUBLE_PRECISION": aws.redshiftdialect.DOUBLE_PRECISION,
-        "FOREIGN_KEY_RE": aws.redshiftdialect.FOREIGN_KEY_RE,
-        "GEOMETRY": aws.redshiftdialect.GEOMETRY,
-        "INTEGER": aws.redshiftdialect.INTEGER,
-        "PRIMARY_KEY_RE": aws.redshiftdialect.PRIMARY_KEY_RE,
-        "REAL": aws.redshiftdialect.REAL,
-        "SMALLINT": aws.redshiftdialect.SMALLINT,
-        "TIMESTAMP": aws.redshiftdialect.TIMESTAMP,
-        "TIMESTAMPTZ": aws.redshiftdialect.TIMESTAMPTZ,
-        "TIMETZ": aws.redshiftdialect.TIMETZ,
-        "VARCHAR": aws.redshiftdialect.VARCHAR,
+        redshift_type: getattr(aws.redshiftdialect, redshift_type, None)
+        for redshift_type in [
+            "BIGINT",
+            "BOOLEAN",
+            "CHAR",
+            "DATE",
+            "DECIMAL",
+            "DOUBLE_PRECISION",
+            "FOREIGN_KEY_RE",
+            "GEOMETRY",
+            "INTEGER",
+            "PRIMARY_KEY_RE",
+            "REAL",
+            "SMALLINT",
+            "TIMESTAMP",
+            "TIMESTAMPTZ",
+            "TIMETZ",
+            "VARCHAR",
+        ]
     }
     if aws.redshiftdialect
     else {}
@@ -339,61 +378,92 @@ if (
     )
 
     SNOWFLAKE_TYPES = {
-        "ARRAY": snowflake.snowflaketypes.ARRAY,
-        "BYTEINT": snowflake.snowflaketypes.BYTEINT,
-        "CHARACTER": snowflake.snowflaketypes.CHARACTER,
-        "DEC": snowflake.snowflaketypes.DEC,
-        "BOOLEAN": snowflake.snowflakedialect.BOOLEAN,
-        "DOUBLE": snowflake.snowflaketypes.DOUBLE,
-        "FIXED": snowflake.snowflaketypes.FIXED,
-        "NUMBER": snowflake.snowflaketypes.NUMBER,
-        "INTEGER": snowflake.snowflakedialect.INTEGER,
-        "OBJECT": snowflake.snowflaketypes.OBJECT,
-        "STRING": snowflake.snowflaketypes.STRING,
-        "TEXT": snowflake.snowflaketypes.TEXT,
-        "TIMESTAMP_LTZ": snowflake.snowflaketypes.TIMESTAMP_LTZ,
-        "TIMESTAMP_NTZ": snowflake.snowflaketypes.TIMESTAMP_NTZ,
-        "TIMESTAMP_TZ": snowflake.snowflaketypes.TIMESTAMP_TZ,
-        "TINYINT": snowflake.snowflaketypes.TINYINT,
-        "VARBINARY": snowflake.snowflaketypes.VARBINARY,
-        "VARIANT": snowflake.snowflaketypes.VARIANT,
+        snowflake_type: getattr(snowflake.snowflaketypes, snowflake_type, None)
+        for snowflake_type in [
+            "ARRAY",
+            "BYTEINT",
+            "CHARACTER",
+            "DEC",
+            "DOUBLE",
+            "FIXED",
+            "NUMBER",
+            "OBJECT",
+            "STRING",
+            "TEXT",
+            "TIMESTAMP_LTZ",
+            "TIMESTAMP_NTZ",
+            "TIMESTAMP_TZ",
+            "TINYINT",
+            "VARBINARY",
+            "VARIANT",
+        ]
     }
+    SNOWFLAKE_TYPES.update(
+        {
+            snowflake_type: getattr(snowflake.snowflakedialect, snowflake_type, None)
+            for snowflake_type in ["INTEGER", "BOOLEAN"]
+        }
+    )
 else:
     SNOWFLAKE_TYPES = {}
 
-ATHENA_TYPES: Dict[str, Any] = (
-    # athenatypes is just `from sqlalchemy import types`
-    # https://github.com/laughingman7743/PyAthena/blob/master/pyathena/sqlalchemy_athena.py#L692
-    #   - the _get_column_type method of AthenaDialect does some mapping via conditional statements
-    # https://github.com/laughingman7743/PyAthena/blob/master/pyathena/sqlalchemy_athena.py#L105
-    #   - The AthenaTypeCompiler has some methods named `visit_<TYPE>`
-    {
-        "BOOLEAN": aws.athenatypes.BOOLEAN,
-        "FLOAT": aws.athenatypes.FLOAT,
-        "DOUBLE": aws.athenatypes.FLOAT,
-        "REAL": aws.athenatypes.FLOAT,
-        "TINYINT": aws.athenatypes.INTEGER,
-        "SMALLINT": aws.athenatypes.INTEGER,
-        "INTEGER": aws.athenatypes.INTEGER,
-        "INT": aws.athenatypes.INTEGER,
-        "BIGINT": aws.athenatypes.BIGINT,
-        "DECIMAL": aws.athenatypes.DECIMAL,
-        "CHAR": aws.athenatypes.CHAR,
-        "VARCHAR": aws.athenatypes.VARCHAR,
-        "STRING": aws.athenatypes.String,
-        "DATE": aws.athenatypes.DATE,
-        "TIMESTAMP": aws.athenatypes.TIMESTAMP,
-        "BINARY": aws.athenatypes.BINARY,
-        "VARBINARY": aws.athenatypes.BINARY,
-        "ARRAY": aws.athenatypes.String,
-        "MAP": aws.athenatypes.String,
-        "STRUCT": aws.athenatypes.String,
-        "ROW": aws.athenatypes.String,
-        "JSON": aws.athenatypes.String,
-    }
-    if aws.pyathena and aws.athenatypes
-    else {}
-)
+if aws.pyathena and aws.athenatypes:
+    ATHENA_TYPES: Dict[str, Any] = (
+        # athenatypes is just `from sqlalchemy import types`
+        # https://github.com/laughingman7743/PyAthena/blob/master/pyathena/sqlalchemy_athena.py#L692
+        #   - the _get_column_type method of AthenaDialect does some mapping via conditional statements
+        # https://github.com/laughingman7743/PyAthena/blob/master/pyathena/sqlalchemy_athena.py#L105
+        #   - The AthenaTypeCompiler has some methods named `visit_<TYPE>`
+        {
+            athena_type: getattr(aws.athenatypes, athena_type, None)
+            for athena_type in [
+                "BOOLEAN",
+                "BIGINT",
+                "DECIMAL",
+                "CHAR",
+                "VARCHAR",
+                "DATE",
+                "TIMESTAMP",
+            ]
+        }
+    )
+    if getattr(aws.athenatypes, "BINARY", None):
+        ATHENA_TYPES.update(
+            {
+                "BINARY": aws.athenatypes.BINARY,
+                "VARBINARY": aws.athenatypes.BINARY,
+            }
+        )
+    if getattr(aws.athenatypes, "INTEGER", None):
+        ATHENA_TYPES.update(
+            {
+                "TINYINT": aws.athenatypes.INTEGER,
+                "SMALLINT": aws.athenatypes.INTEGER,
+                "INTEGER": aws.athenatypes.INTEGER,
+                "INT": aws.athenatypes.INTEGER,
+            }
+        )
+    if getattr(aws.athenatypes, "FLOAT", None):
+        ATHENA_TYPES.update(
+            {
+                "FLOAT": aws.athenatypes.FLOAT,
+                "DOUBLE": aws.athenatypes.FLOAT,
+                "REAL": aws.athenatypes.FLOAT,
+            }
+        )
+    if getattr(aws.athenatypes, "String", None):
+        ATHENA_TYPES.update(
+            {
+                "STRING": aws.athenatypes.String,
+                "ARRAY": aws.athenatypes.String,
+                "MAP": aws.athenatypes.String,
+                "STRUCT": aws.athenatypes.String,
+                "ROW": aws.athenatypes.String,
+                "JSON": aws.athenatypes.String,
+            }
+        )
+else:
+    ATHENA_TYPES = {}
 
 # # Others from great_expectations/dataset/sqlalchemy_dataset.py
 # try:
@@ -1929,9 +1999,11 @@ def generate_expectation_tests(  # noqa: C901, PLR0912, PLR0913, PLR0915
             _debug(f"Getting validators with data: {c}")
 
             tests_suppressed_for_backend = [
-                c in sup or ("sqlalchemy" in sup and c in SQL_DIALECT_NAMES)
-                if sup
-                else False
+                (
+                    c in sup or ("sqlalchemy" in sup and c in SQL_DIALECT_NAMES)
+                    if sup
+                    else False
+                )
                 for sup in suppress_test_fors
             ]
             only_fors_ok = []


### PR DESCRIPTION
This issue occurs when loading types of an integration wherein the lib is installed but might be of a different version.

Example: Readshift Dialect added GEOMETRY in a later version than used. This error was shown:
```
\---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel\_12/2434301553.py in <cell line: 8>()
      6 \_hex\_pks.kernel\_execution.scope\_watcher.mark\_dirty\_scope\_items(args=\_hex\_types.MarkDirtyScopeItemsArgs.from\_dict({\*\*\_hex\_json.loads("{\\"dirty\_scope\_items\\":\[\\"gx\\"\]}")}), app\_session\_token=\_hex\_APP\_SESSION\_TOKEN, python\_kernel\_init\_status=\_hex\_python\_kernel\_init\_status, hex\_timezone=\_hex\_kernel.variable\_or\_none("hex\_timezone", scope\_getter=lambda: globals()), interrupt\_event=locals().get("\_hex\_interrupt\_event"))
      7 
\----> 8 import great\_expectations as gx

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/\_\_init\_\_.py in <module>
     30 #   import great\_expectations as gx
     31 #   from great\_expectations.core import ExpectationSuite, ExpectationConfiguration
\---> 32 register\_core\_expectations()
     33 
     34 # from great\_expectations.expectations.core import \*

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/expectations/registry.py in register\_core\_expectations()
    185     # Implicitly calls MetaExpectation.\_\_new\_\_ as Expectations are loaded from core.\_\_init\_\_.py
    186     # As \_\_new\_\_ calls upon register\_expectation, this import builds our core registry
\--> 187     from great\_expectations.expectations import core  # noqa: F401
    188 
    189     after\_count = len(\_registered\_expectations)

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/expectations/core/\_\_init\_\_.py in <module>
\----> 1 from .expect\_column\_distinct\_values\_to\_be\_in\_set import (
      2     ExpectColumnDistinctValuesToBeInSet,
      3 )
      4 from .expect\_column\_distinct\_values\_to\_contain\_set import (
      5     ExpectColumnDistinctValuesToContainSet,

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/expectations/core/expect\_column\_distinct\_values\_to\_be\_in\_set.py in <module>
     10 from great\_expectations.core.\_docs\_decorators import public\_api
     11 from great\_expectations.execution\_engine import ExecutionEngine
\---> 12 from great\_expectations.expectations.expectation import (
     13     ColumnAggregateExpectation,
     14     InvalidExpectationConfigurationError,

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/expectations/expectation.py in <module>
    124     num\_to\_str,
    125 )
\--> 126 from great\_expectations.self\_check.util import (
    127     evaluate\_json\_test\_v3\_api,
    128     generate\_dataset\_name\_from\_expectation\_name,

\~/.cache/pypoetry/virtualenvs/python-kernel-OtKFaj5M-py3.9/lib/python3.9/site-packages/great\_expectations/self\_check/util.py in <module>
    313         "DOUBLE\_PRECISION": aws.redshiftdialect.DOUBLE\_PRECISION,
    314         "FOREIGN\_KEY\_RE": aws.redshiftdialect.FOREIGN\_KEY\_RE,
\--> 315         "GEOMETRY": aws.redshiftdialect.GEOMETRY,
    316         "INTEGER": aws.redshiftdialect.INTEGER,
    317         "PRIMARY\_KEY\_RE": aws.redshiftdialect.PRIMARY\_KEY\_RE,

AttributeError: module 'sqlalchemy\_redshift.dialect' has no attribute 'GEOMETRY'
```
- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
