### PR TITLE
[FEATURE] Add Partitioner field to BatchConfig

### DIFF
--- a/great_expectations/core/batch_config.py
+++ b/great_expectations/core/batch_config.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
         BatchRequestOptions,
     )
     from great_expectations.datasource.fluent.interfaces import DataAsset
+    from great_expectations.datasource.fluent.partitioners import Partitioner
 
 
 class BatchConfig(pydantic.BaseModel):
@@ -20,6 +21,7 @@ class BatchConfig(pydantic.BaseModel):
 
     id: Optional[str] = None
     name: str
+    partitioner: Optional[Partitioner] = None
 
     # private attributes that must be set immediately after instantiation
     _data_asset: DataAsset = pydantic.PrivateAttr()

--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -10,6 +10,10 @@ from great_expectations.datasource.fluent.interfaces import (
     GxDatasourceWarning,
     TestConnectionError,
 )
+from great_expectations.datasource.fluent.partitioners import Partitioner
+from great_expectations.core.batch_config import BatchConfig
+
+BatchConfig.update_forward_refs(Partitioner=Partitioner, DataAsset=DataAsset)
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,

--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -11,9 +11,14 @@ from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError,
 )
 from great_expectations.datasource.fluent.partitioners import Partitioner
+
+# Now that DataAsset and Partitioner have both been defined, we need to
+# provide them to the BatchConfig pydantic model.
 from great_expectations.core.batch_config import BatchConfig
 
 BatchConfig.update_forward_refs(Partitioner=Partitioner, DataAsset=DataAsset)
+
+
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -425,10 +425,6 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
                 ) from e
 
 
-# Now that BatchAsset is defined, we need to update BatchConfig
-BatchConfig.update_forward_refs(DataAsset=DataAsset)
-
-
 def _sort_batches_with_none_metadata_values(
     key: str,
 ) -> Callable[[Batch, Batch], int]:

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from great_expectations.datasource.fluent import (
         BatchRequest,
         BatchRequestOptions,
+        Partitioner,
     )
     from great_expectations.datasource.fluent.data_asset.data_connector import (
         DataConnector,
@@ -266,7 +267,9 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
     # End Abstract Methods
 
     @public_api
-    def add_batch_config(self, name: str) -> BatchConfig:
+    def add_batch_config(
+        self, name: str, partitioner: Optional[Partitioner] = None
+    ) -> BatchConfig:
         """Add a BatchConfig to this DataAsset.
         BatchConfig names must be unique within a DataAsset.
 
@@ -274,6 +277,7 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
 
         Args:
             name (str): Name of the new batch config.
+            partitioner: Optional Partitioner to partition this BatchConfig
 
         Returns:
             BatchConfig: The new batch config.
@@ -287,7 +291,7 @@ class DataAsset(FluentBaseModel, Generic[_DatasourceT]):
         # Let mypy know that self.datasource is a Datasource (it is currently bound to MetaDatasource)
         assert isinstance(self.datasource, Datasource)
 
-        batch_config = BatchConfig(name=name)
+        batch_config = BatchConfig(name=name, partitioner=partitioner)
         batch_config.set_data_asset(self)
         self.batch_configs.append(batch_config)
         if self.datasource.data_context:

--- a/great_expectations/datasource/fluent/partitioners.py
+++ b/great_expectations/datasource/fluent/partitioners.py
@@ -1,0 +1,69 @@
+from typing import Union
+
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerColumnValue as SparkPartitionerColumnValue,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerDatetimePart as SparkPartitionerDatetimePart,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerDividedInteger as SparkPartitionerDividedInteger,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerModInteger as SparkPartitionerModInteger,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerMultiColumnValue as SparkPartitionerMultiColumnValue,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerYear as SparkPartitionerYear,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerYearAndMonth as SparkPartitionerYearAndMonth,
+)
+from great_expectations.datasource.fluent.spark_generic_partitioners import (
+    PartitionerYearAndMonthAndDay as SparkPartitionerYearAndMonthAndDay,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerColumnValue as SqlPartitionerColumnValue,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerDatetimePart as SqlPartitionerDatetimePart,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerDividedInteger as SqlPartitionerDividedInteger,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerModInteger as SqlPartitionerModInteger,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerMultiColumnValue as SqlPartitionerMultiColumnValue,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerYear as SqlPartitionerYear,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerYearAndMonth as SqlPartitionerYearAndMonth,
+)
+from great_expectations.datasource.fluent.sql_datasource import (
+    PartitionerYearAndMonthAndDay as SqlPartitionerYearAndMonthAndDay,
+)
+
+Partitioner = Union[
+    SqlPartitionerYear,
+    SqlPartitionerYearAndMonth,
+    SqlPartitionerYearAndMonthAndDay,
+    SqlPartitionerDatetimePart,
+    SqlPartitionerDividedInteger,
+    SqlPartitionerModInteger,
+    SqlPartitionerColumnValue,
+    SqlPartitionerMultiColumnValue,
+    SparkPartitionerYear,
+    SparkPartitionerYearAndMonth,
+    SparkPartitionerYearAndMonthAndDay,
+    SparkPartitionerDatetimePart,
+    SparkPartitionerDividedInteger,
+    SparkPartitionerModInteger,
+    SparkPartitionerColumnValue,
+    SparkPartitionerMultiColumnValue,
+]

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
@@ -105,130 +105,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -251,7 +128,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,6 +204,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -373,28 +631,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -459,28 +717,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -102,130 +102,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -248,7 +125,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -324,6 +201,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -97,130 +97,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -243,7 +120,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -266,7 +143,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -289,7 +166,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,6 +196,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/Datasource.json
@@ -50,6 +50,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -62,6 +472,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
@@ -96,6 +96,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -108,6 +518,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
@@ -68,6 +68,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -80,6 +490,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
@@ -108,6 +108,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -120,6 +530,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
@@ -92,6 +92,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -104,6 +514,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
@@ -68,130 +68,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -214,7 +91,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -237,7 +114,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -260,7 +137,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -290,6 +167,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "_FilePathDataAsset": {
             "title": "_FilePathDataAsset",
@@ -343,28 +601,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -405,130 +405,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,7 +428,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,7 +451,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -597,7 +474,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -627,6 +504,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -94,10 +94,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -296,130 +296,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -442,7 +319,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -465,7 +342,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -488,7 +365,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -518,6 +395,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -119,130 +119,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -288,7 +165,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -341,6 +218,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -157,130 +157,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -326,7 +203,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -349,7 +226,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -379,6 +256,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -217,130 +217,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -363,7 +240,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -386,7 +263,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -409,7 +286,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -439,6 +316,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -204,130 +204,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -396,7 +273,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -426,6 +303,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -115,130 +115,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -261,7 +138,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -284,7 +161,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -307,7 +184,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,6 +214,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -129,130 +129,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -275,7 +152,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -298,7 +175,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -321,7 +198,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,6 +228,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -128,130 +128,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -320,7 +197,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,6 +227,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -125,130 +125,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -317,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -347,6 +224,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -173,130 +173,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,7 +196,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -342,7 +219,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -365,7 +242,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -395,6 +272,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -181,130 +181,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -403,6 +280,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
@@ -64,130 +64,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -210,7 +87,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -233,7 +110,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -256,7 +133,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,6 +163,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "_FilePathDataAsset": {
             "title": "_FilePathDataAsset",
@@ -339,28 +597,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -405,130 +405,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,7 +428,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,7 +451,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -597,7 +474,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -627,6 +504,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -94,10 +94,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -296,130 +296,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -442,7 +319,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -465,7 +342,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -488,7 +365,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -518,6 +395,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -119,130 +119,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -288,7 +165,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -341,6 +218,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -157,130 +157,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -326,7 +203,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -349,7 +226,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -379,6 +256,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -217,130 +217,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -363,7 +240,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -386,7 +263,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -409,7 +286,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -439,6 +316,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -204,130 +204,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -396,7 +273,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -426,6 +303,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -115,130 +115,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -261,7 +138,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -284,7 +161,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -307,7 +184,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,6 +214,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -129,130 +129,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -275,7 +152,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -298,7 +175,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -321,7 +198,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,6 +228,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -128,130 +128,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -320,7 +197,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,6 +227,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -125,130 +125,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -317,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -347,6 +224,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -173,130 +173,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,7 +196,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -342,7 +219,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -365,7 +242,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -395,6 +272,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -181,130 +181,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -403,6 +280,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource.json
@@ -53,6 +53,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -65,6 +475,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
@@ -382,6 +382,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -394,6 +804,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
@@ -73,6 +73,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -85,6 +495,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
@@ -66,6 +66,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -78,6 +488,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
@@ -70,10 +70,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -273,6 +273,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -285,6 +695,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
@@ -122,6 +122,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -134,6 +544,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
@@ -96,6 +96,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -108,6 +518,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
@@ -120,6 +120,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -132,6 +542,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
@@ -134,6 +134,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -146,6 +556,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
@@ -194,6 +194,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -206,6 +616,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
@@ -181,6 +181,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -193,6 +603,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
@@ -92,6 +92,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -104,6 +514,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
@@ -106,6 +106,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -118,6 +528,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
@@ -105,6 +105,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -117,6 +527,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
@@ -122,6 +122,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -134,6 +544,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
@@ -102,6 +102,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -114,6 +524,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
@@ -143,6 +143,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -155,6 +565,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
@@ -135,6 +135,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -147,6 +557,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
@@ -118,6 +118,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -130,6 +540,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
@@ -150,6 +150,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -162,6 +572,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
@@ -378,6 +378,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -390,6 +800,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
@@ -158,6 +158,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -170,6 +580,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -64,130 +64,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -210,7 +87,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -233,7 +110,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -256,7 +133,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,6 +163,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "_FilePathDataAsset": {
             "title": "_FilePathDataAsset",
@@ -339,28 +597,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -405,130 +405,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,7 +428,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,7 +451,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -597,7 +474,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -627,6 +504,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -94,10 +94,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -296,130 +296,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -442,7 +319,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -465,7 +342,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -488,7 +365,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -518,6 +395,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -119,130 +119,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -288,7 +165,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -341,6 +218,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -157,130 +157,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -326,7 +203,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -349,7 +226,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -379,6 +256,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -217,130 +217,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -363,7 +240,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -386,7 +263,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -409,7 +286,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -439,6 +316,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -204,130 +204,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -396,7 +273,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -426,6 +303,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -115,130 +115,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -261,7 +138,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -284,7 +161,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -307,7 +184,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,6 +214,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -129,130 +129,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -275,7 +152,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -298,7 +175,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -321,7 +198,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,6 +228,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -128,130 +128,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -320,7 +197,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,6 +227,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -125,130 +125,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -317,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -347,6 +224,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -173,130 +173,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,7 +196,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -342,7 +219,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -365,7 +242,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -395,6 +272,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -181,130 +181,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -403,6 +280,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
@@ -73,130 +73,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -219,7 +96,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -242,7 +119,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -295,6 +172,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "_FilePathDataAsset": {
             "title": "_FilePathDataAsset",
@@ -348,28 +606,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -405,130 +405,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,7 +428,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,7 +451,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -597,7 +474,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -627,6 +504,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -94,10 +94,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -296,130 +296,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -442,7 +319,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -465,7 +342,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -488,7 +365,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -518,6 +395,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -119,130 +119,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -288,7 +165,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -341,6 +218,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -157,130 +157,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -326,7 +203,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -349,7 +226,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -379,6 +256,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -217,130 +217,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -363,7 +240,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -386,7 +263,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -409,7 +286,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -439,6 +316,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -204,130 +204,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -396,7 +273,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -426,6 +303,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -115,130 +115,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -261,7 +138,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -284,7 +161,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -307,7 +184,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,6 +214,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -129,130 +129,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -275,7 +152,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -298,7 +175,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -321,7 +198,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,6 +228,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -128,130 +128,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -320,7 +197,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,6 +227,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -125,130 +125,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -317,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -347,6 +224,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -173,130 +173,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,7 +196,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -342,7 +219,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -365,7 +242,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -395,6 +272,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -181,130 +181,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -403,6 +280,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
@@ -73,130 +73,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -219,7 +96,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -242,7 +119,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -295,6 +172,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "_FilePathDataAsset": {
             "title": "_FilePathDataAsset",
@@ -348,28 +606,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -405,130 +405,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,7 +428,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,7 +451,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -597,7 +474,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -627,6 +504,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -94,10 +94,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
-                                "type": "integer"
+                                "type": "string"
                             }
                         ]
                     }
@@ -296,130 +296,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -442,7 +319,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -465,7 +342,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -488,7 +365,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -518,6 +395,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -119,130 +119,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -265,7 +142,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -288,7 +165,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -341,6 +218,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -157,130 +157,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -326,7 +203,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -349,7 +226,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -379,6 +256,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -217,130 +217,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -363,7 +240,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -386,7 +263,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -409,7 +286,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -439,6 +316,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -204,130 +204,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -396,7 +273,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -426,6 +303,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -115,130 +115,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -261,7 +138,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -284,7 +161,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -307,7 +184,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,6 +214,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -129,130 +129,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -275,7 +152,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -298,7 +175,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -321,7 +198,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,6 +228,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -128,130 +128,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -320,7 +197,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,6 +227,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -145,130 +145,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -291,7 +168,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -314,7 +191,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -337,7 +214,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -367,6 +244,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -125,130 +125,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -317,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -347,6 +224,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -173,130 +173,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,7 +196,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -342,7 +219,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -365,7 +242,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -395,6 +272,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -181,130 +181,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -350,7 +227,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -373,7 +250,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -403,6 +280,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -105,130 +105,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -251,7 +128,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,6 +204,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -373,28 +631,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -459,28 +717,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -97,130 +97,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -243,7 +120,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -266,7 +143,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -289,7 +166,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,6 +196,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -102,130 +102,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -248,7 +125,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -324,6 +201,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -102,130 +102,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -248,7 +125,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -324,6 +201,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -370,28 +628,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -456,28 +714,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -97,130 +97,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -243,7 +120,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -266,7 +143,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -289,7 +166,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,6 +196,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -102,130 +102,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -248,7 +125,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -324,6 +201,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -108,130 +108,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -254,7 +131,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -277,7 +154,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -300,7 +177,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -330,6 +207,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -376,28 +634,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -462,28 +720,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -97,130 +97,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -243,7 +120,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -266,7 +143,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -289,7 +166,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -319,6 +196,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 }
             ]
         },
@@ -102,130 +102,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -248,7 +125,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -271,7 +148,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -294,7 +171,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -324,6 +201,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -135,130 +135,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -281,7 +158,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -304,7 +181,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,7 +204,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,6 +234,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "CSVAsset": {
             "title": "CSVAsset",
@@ -414,28 +672,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -750,28 +1008,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1092,28 +1350,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1252,28 +1510,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1418,28 +1676,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1561,28 +1819,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1710,28 +1968,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2017,28 +2275,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2330,28 +2588,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2470,28 +2728,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2616,28 +2874,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2711,28 +2969,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -352,130 +352,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -544,7 +421,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,6 +451,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -111,130 +111,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -257,7 +134,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -280,7 +157,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -333,6 +210,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -358,130 +358,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -504,7 +381,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -527,7 +404,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -550,7 +427,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -580,6 +457,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -117,130 +117,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -263,7 +140,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -339,6 +216,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -329,130 +329,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -475,7 +352,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,6 +428,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -165,130 +165,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -334,7 +211,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,7 +234,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -387,6 +264,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -182,130 +182,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -374,7 +251,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -404,6 +281,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -162,130 +162,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -308,7 +185,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -331,7 +208,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -354,7 +231,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -384,6 +261,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -323,130 +323,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -469,7 +346,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -492,7 +369,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -515,7 +392,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -545,6 +422,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -159,130 +159,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -305,7 +182,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -381,6 +258,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -176,130 +176,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -322,7 +199,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -345,7 +222,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -368,7 +245,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -398,6 +275,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -156,130 +156,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -302,7 +179,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,7 +202,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -348,7 +225,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -378,6 +255,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -131,130 +131,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -277,7 +154,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -300,7 +177,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -323,7 +200,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -353,6 +230,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "CSVAsset": {
             "title": "CSVAsset",
@@ -410,28 +668,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -746,28 +1004,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1088,28 +1346,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1248,28 +1506,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1414,28 +1672,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1557,28 +1815,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1706,28 +1964,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2013,28 +2271,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2326,28 +2584,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2466,28 +2724,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2612,28 +2870,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2707,28 +2965,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -352,130 +352,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -544,7 +421,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,6 +451,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -111,130 +111,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -257,7 +134,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -280,7 +157,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -333,6 +210,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -358,130 +358,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -504,7 +381,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -527,7 +404,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -550,7 +427,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -580,6 +457,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -117,130 +117,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -263,7 +140,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -339,6 +216,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -329,130 +329,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -475,7 +352,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,6 +428,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -165,130 +165,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -334,7 +211,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,7 +234,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -387,6 +264,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -182,130 +182,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -374,7 +251,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -404,6 +281,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -162,130 +162,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -308,7 +185,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -331,7 +208,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -354,7 +231,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -384,6 +261,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -323,130 +323,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -469,7 +346,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -492,7 +369,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -515,7 +392,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -545,6 +422,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -159,130 +159,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -305,7 +182,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -381,6 +258,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -176,130 +176,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -322,7 +199,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -345,7 +222,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -368,7 +245,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -398,6 +275,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -156,130 +156,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -302,7 +179,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,7 +202,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -348,7 +225,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -378,6 +255,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource.json
@@ -83,6 +83,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -95,6 +505,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
@@ -66,6 +66,416 @@
                 "key"
             ]
         },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "BatchConfig": {
             "title": "BatchConfig",
             "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
@@ -78,6 +488,59 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -131,130 +131,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -277,7 +154,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -300,7 +177,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -323,7 +200,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -353,6 +230,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "CSVAsset": {
             "title": "CSVAsset",
@@ -410,28 +668,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -746,28 +1004,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1088,28 +1346,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1248,28 +1506,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1414,28 +1672,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1557,28 +1815,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1706,28 +1964,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2013,28 +2271,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2326,28 +2584,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2466,28 +2724,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2612,28 +2870,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2707,28 +2965,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -352,130 +352,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -544,7 +421,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,6 +451,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -111,130 +111,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -257,7 +134,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -280,7 +157,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -333,6 +210,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -358,130 +358,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -504,7 +381,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -527,7 +404,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -550,7 +427,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -580,6 +457,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -117,130 +117,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -263,7 +140,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -339,6 +216,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -329,130 +329,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -475,7 +352,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,6 +428,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -165,130 +165,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -334,7 +211,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,7 +234,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -387,6 +264,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -182,130 +182,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -374,7 +251,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -404,6 +281,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -162,130 +162,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -308,7 +185,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -331,7 +208,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -354,7 +231,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -384,6 +261,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -323,130 +323,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -469,7 +346,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -492,7 +369,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -515,7 +392,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -545,6 +422,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -159,130 +159,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -305,7 +182,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -381,6 +258,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -176,130 +176,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -322,7 +199,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -345,7 +222,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -368,7 +245,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -398,6 +275,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -156,130 +156,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -302,7 +179,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,7 +202,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -348,7 +225,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -378,6 +255,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -140,130 +140,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -332,7 +209,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -362,6 +239,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "CSVAsset": {
             "title": "CSVAsset",
@@ -419,28 +677,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -755,28 +1013,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1097,28 +1355,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1257,28 +1515,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1423,28 +1681,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1566,28 +1824,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1715,28 +1973,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2022,28 +2280,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2335,28 +2593,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2475,28 +2733,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2621,28 +2879,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2716,28 +2974,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -352,130 +352,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -544,7 +421,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,6 +451,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -111,130 +111,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -257,7 +134,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -280,7 +157,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -333,6 +210,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -358,130 +358,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -504,7 +381,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -527,7 +404,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -550,7 +427,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -580,6 +457,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -117,130 +117,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -263,7 +140,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -339,6 +216,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -329,130 +329,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -475,7 +352,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,6 +428,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -165,130 +165,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -334,7 +211,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,7 +234,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -387,6 +264,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -182,130 +182,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -374,7 +251,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -404,6 +281,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -162,130 +162,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -308,7 +185,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -331,7 +208,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -354,7 +231,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -384,6 +261,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -323,130 +323,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -469,7 +346,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -492,7 +369,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -515,7 +392,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -545,6 +422,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -159,130 +159,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -305,7 +182,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -381,6 +258,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -176,130 +176,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -322,7 +199,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -345,7 +222,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -368,7 +245,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -398,6 +275,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -156,130 +156,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -302,7 +179,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,7 +202,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -348,7 +225,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -378,6 +255,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -140,130 +140,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -332,7 +209,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -362,6 +239,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "CSVAsset": {
             "title": "CSVAsset",
@@ -419,28 +677,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -755,28 +1013,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1097,28 +1355,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1257,28 +1515,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1423,28 +1681,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1566,28 +1824,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -1715,28 +1973,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2022,28 +2280,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2335,28 +2593,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2475,28 +2733,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2621,28 +2879,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -2716,28 +2974,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -352,130 +352,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -544,7 +421,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -574,6 +451,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -111,130 +111,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -257,7 +134,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -280,7 +157,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -303,7 +180,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -333,6 +210,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -358,130 +358,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -504,7 +381,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -527,7 +404,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -550,7 +427,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -580,6 +457,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -117,130 +117,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -263,7 +140,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -286,7 +163,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -309,7 +186,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -339,6 +216,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -329,130 +329,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -475,7 +352,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -498,7 +375,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -521,7 +398,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -551,6 +428,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -165,130 +165,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -311,7 +188,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -334,7 +211,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -357,7 +234,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -387,6 +264,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -182,130 +182,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -374,7 +251,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -404,6 +281,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -162,130 +162,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -308,7 +185,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -331,7 +208,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -354,7 +231,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -384,6 +261,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -323,130 +323,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -469,7 +346,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -492,7 +369,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -515,7 +392,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -545,6 +422,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -159,130 +159,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -305,7 +182,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -328,7 +205,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -351,7 +228,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -381,6 +258,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -176,130 +176,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -322,7 +199,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -345,7 +222,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -368,7 +245,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -398,6 +275,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
@@ -54,28 +54,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
                 }
             ]
         },
@@ -156,130 +156,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -302,7 +179,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,7 +202,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -348,7 +225,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -378,6 +255,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         }
     }
 }

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -105,130 +105,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -251,7 +128,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -274,7 +151,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -297,7 +174,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -327,6 +204,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -373,28 +631,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },
@@ -459,28 +717,28 @@
                     "title": "Partitioner",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/PartitionerColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerMultiColumnValue"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDividedInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerModInteger"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYear"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonth"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                         },
                         {
-                            "$ref": "#/definitions/PartitionerDatetimePart"
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                         }
                     ]
                 },

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 },
                 {
                     "$ref": "#/definitions/PartitionerHashedColumn"
@@ -103,130 +103,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -249,7 +126,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -272,7 +149,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -295,7 +172,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -325,6 +202,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "PartitionerHashedColumn": {
             "title": "PartitionerHashedColumn",

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -43,28 +43,28 @@
             "title": "Partitioner",
             "anyOf": [
                 {
-                    "$ref": "#/definitions/PartitionerColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerMultiColumnValue"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDividedInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerModInteger"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYear"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonth"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerYearAndMonthAndDay"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerDatetimePart"
+                    "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
                 },
                 {
                     "$ref": "#/definitions/PartitionerHashedColumn"
@@ -108,130 +108,7 @@
                 "key"
             ]
         },
-        "BatchConfig": {
-            "title": "BatchConfig",
-            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "title": "Id",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "PartitionerColumnValue": {
-            "title": "PartitionerColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_column_value",
-                    "enum": [
-                        "partition_on_column_value"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_name"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerMultiColumnValue": {
-            "title": "PartitionerMultiColumnValue",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_names": {
-                    "title": "Column Names",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_multi_column_values",
-                    "enum": [
-                        "partition_on_multi_column_values"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "column_names"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerDividedInteger": {
-            "title": "PartitionerDividedInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_divided_integer",
-                    "enum": [
-                        "partition_on_divided_integer"
-                    ],
-                    "type": "string"
-                },
-                "divisor": {
-                    "title": "Divisor",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "divisor"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerModInteger": {
-            "title": "PartitionerModInteger",
-            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_mod_integer",
-                    "enum": [
-                        "partition_on_mod_integer"
-                    ],
-                    "type": "string"
-                },
-                "mod": {
-                    "title": "Mod",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "mod"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerYear": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYear": {
             "title": "PartitionerYear",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -254,7 +131,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonth": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth": {
             "title": "PartitionerYearAndMonth",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -277,7 +154,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerYearAndMonthAndDay": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay": {
             "title": "PartitionerYearAndMonthAndDay",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -300,7 +177,7 @@
             ],
             "additionalProperties": false
         },
-        "PartitionerDatetimePart": {
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart": {
             "title": "PartitionerDatetimePart",
             "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
@@ -330,6 +207,387 @@
                 "datetime_parts"
             ],
             "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear": {
+            "title": "PartitionerYear",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year",
+                    "enum": [
+                        "partition_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth": {
+            "title": "PartitionerYearAndMonth",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month",
+                    "enum": [
+                        "partition_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay": {
+            "title": "PartitionerYearAndMonthAndDay",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_year_and_month_and_day",
+                    "enum": [
+                        "partition_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart": {
+            "title": "PartitionerDatetimePart",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_date_parts",
+                    "enum": [
+                        "partition_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger": {
+            "title": "PartitionerDividedInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_divided_integer",
+                    "enum": [
+                        "partition_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger": {
+            "title": "PartitionerModInteger",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_mod_integer",
+                    "enum": [
+                        "partition_on_mod_integer"
+                    ],
+                    "type": "string"
+                },
+                "mod": {
+                    "title": "Mod",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "column_name",
+                "mod"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue": {
+            "title": "PartitionerColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_column_value",
+                    "enum": [
+                        "partition_on_column_value"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue": {
+            "title": "PartitionerMultiColumnValue",
+            "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "partition_on_multi_column_values",
+                    "enum": [
+                        "partition_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
+        "BatchConfig": {
+            "title": "BatchConfig",
+            "description": "Configuration for a batch of data.\n\nReferences the DataAsset to be used, and any additional parameters needed to fetch the data.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "partitioner": {
+                    "title": "Partitioner",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__sql_datasource__PartitionerMultiColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYear"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerModInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/great_expectations__datasource__fluent__spark_generic_partitioners__PartitionerMultiColumnValue"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ]
         },
         "PartitionerHashedColumn": {
             "title": "PartitionerHashedColumn",

--- a/tests/datasource/fluent/data_asset/test_data_asset.py
+++ b/tests/datasource/fluent/data_asset/test_data_asset.py
@@ -11,6 +11,7 @@ from great_expectations.data_context.data_context.cloud_data_context import (
 )
 from great_expectations.datasource.fluent.interfaces import DataAsset, Datasource
 from great_expectations.datasource.fluent.pandas_datasource import PandasDatasource
+from great_expectations.datasource.fluent.sql_datasource import PartitionerYear
 
 DATASOURCE_NAME = "my datasource for batch configs"
 EMPTY_DATA_ASSET_NAME = "my data asset for batch configs"
@@ -89,17 +90,43 @@ def test_add_batch_config__success(empty_data_asset: DataAsset):
 
 
 @pytest.mark.unit
+def test_add_batch_config_with_partitioner__success(empty_data_asset: DataAsset):
+    name = "my batch config"
+    partitioner = PartitionerYear(column_name="test-column")
+    batch_config = empty_data_asset.add_batch_config(name, partitioner=partitioner)
+
+    assert batch_config.partitioner == partitioner
+
+
+@pytest.mark.unit
 def test_add_batch_config__persists(
     file_context: AbstractDataContext, empty_data_asset: DataAsset
 ):
     name = "my batch config"
-    batch_config = empty_data_asset.add_batch_config(name)
+    partitioner = PartitionerYear(column_name="test-column")
+    batch_config = empty_data_asset.add_batch_config(name, partitioner=partitioner)
 
     loaded_datasource = file_context.get_datasource(DATASOURCE_NAME)
     assert isinstance(loaded_datasource, Datasource)
     loaded_asset = loaded_datasource.get_asset(EMPTY_DATA_ASSET_NAME)
 
     assert loaded_asset.batch_configs == [batch_config]
+
+
+@pytest.mark.unit
+def test_add_batch_config_with_partitioner__persists(
+    file_context: AbstractDataContext, empty_data_asset: DataAsset
+):
+    name = "my batch config"
+    partitioner = PartitionerYear(column_name="test-column")
+    empty_data_asset.add_batch_config(name, partitioner=partitioner)
+
+    loaded_datasource = file_context.get_datasource(DATASOURCE_NAME)
+    assert isinstance(loaded_datasource, Datasource)
+    loaded_asset = loaded_datasource.get_asset(EMPTY_DATA_ASSET_NAME)
+
+    loaded_batch_config = loaded_asset.batch_configs[0]
+    assert loaded_batch_config.partitioner == partitioner
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This PR adds a Partitioner field to the `BatchConfig` domain object, which will replace `DataAsset.partitioner`.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
