### PR TITLE
[DOCS] Remove version prefix from 0.18 docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/checkpoints/manage_checkpoints.md
@@ -102,7 +102,7 @@ To learn more about Checkpoints, see [Checkpoint](/reference/learn/terms/checkpo
 2. Run the following Python code to retrieve the Checkpoint:
 
     ```python title="Jupyter Notebook"
-    retrieved_checkpoint = context.get_checkpoint(name="version-0.18 <checkpoint_name>") 
+    retrieved_checkpoint = context.get_checkpoint(name="<checkpoint_name>") 
     ```
 3. Edit the Checkpoint configuration. 
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_python.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_python.md
@@ -74,7 +74,7 @@ Environment variables securely store your GX Cloud access credentials.
 
 - Run the following Python code to create a Data Context object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py get_context"
+    ```python name="tutorials/quickstart/quickstart.py get_context"
     ```
   
     The Data Context will detect the previously set environment variables and connect to your GX Cloud account.
@@ -83,7 +83,7 @@ Environment variables securely store your GX Cloud access credentials.
 
 - Run the following Python code to connect to existing `.csv` data stored in the `great_expectations` GitHub repository and create a Validator object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py connect_to_data"
+    ```python name="tutorials/quickstart/quickstart.py connect_to_data"
     ```
 
     The code example uses the default Data Source for Pandas to access the `.csv` data from the file at the specified URL path.
@@ -92,7 +92,7 @@ Environment variables securely store your GX Cloud access credentials.
 
 - Run the following Python code to create two Expectations and save them to the Expectation Suite:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_expectation"
+    ```python name="tutorials/quickstart/quickstart.py create_expectation"
     ```
 
   The first Expectation uses domain knowledge (the `pickup_datetime` shouldn't be null).
@@ -103,17 +103,17 @@ Environment variables securely store your GX Cloud access credentials.
 
 1. Run the following Python code to define a Checkpoint and examine the data to determine if it matches the defined Expectations:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py create_checkpoint"
     ```
 
 2. Use the following command to return the Validation Results:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py run_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py run_checkpoint"
     ```
 
 3. Run the following Python code to view an HTML representation of the Validation Results in the generated Data Docs:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py view_results"
+    ```python name="tutorials/quickstart/quickstart.py view_results"
     ```
 
 ## Related documentation

--- a/docs/docusaurus/versioned_docs/version-0.18/components/connect_to_data/cloud/_abs_fluent_data_asset_config_keys.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/components/connect_to_data/cloud/_abs_fluent_data_asset_config_keys.mdx
@@ -10,7 +10,7 @@ To specify data to connect to you can specify the following elements:
 1. Run the following Python code to define the connection values:
 
     ```python title="Python code"
-    asset_name = "version-0.18 my_taxi_data_asset"
+    asset_name = "my_taxi_data_asset"
     batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
     abs_container = "my_container"
     abs_name_starts_with = "data/taxi_yellow_tripdata_samples/"

--- a/docs/docusaurus/versioned_docs/version-0.18/components/setup/data_context/_admonition_convert_to_file_context.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/components/setup/data_context/_admonition_convert_to_file_context.md
@@ -1,6 +1,6 @@
 An Ephemeral Data Context is an in-memory Data Context that is not intended to persist beyond the current Python session.  However, if you decide that you would like to save its contents for future use you can do so by converting it to a Filesystem Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context"
+```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context"
 ```
 
 This method will initialize a Filesystem Data Context in the current working directory of the Python process that contains the Ephemeral Data Context.  For more detailed explanation of this method, please see our guide on [how to convert an ephemeral data context to a filesystem data context](/oss/guides/setup/configuring_data_contexts/how_to_convert_an_ephemeral_data_context_to_a_filesystem_data_context.md)

--- a/docs/docusaurus/versioned_docs/version-0.18/components/setup/datasource/data_asset/_get_existing_data_asset_from_existing_datasource.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/components/setup/datasource/data_asset/_get_existing_data_asset_from_existing_datasource.md
@@ -3,6 +3,6 @@ If you already have an instance of your Data Asset stored in a Python variable, 
 
 In this example we will use a previously defined Data Source named `my_datasource` and a previously defined Data Asset named `my_asset`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_asset"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_asset"
 ```
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_add_csv_asset_to_pandas_s3_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_add_csv_asset_to_pandas_s3_datasource.mdx
@@ -1,6 +1,6 @@
 Add a CSV `Asset` into your `Data Source` by using the `add_csv_asset` function.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_pandas_s3_asset"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_pandas_s3_asset"
 ```
 
 Here we have added a `Asset` named `csv_taxi_s3_asset` using the `add_csv_asset` function. The `batching_regex` is a regular expression that 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_add_table_and_query_assets.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_add_table_and_query_assets.mdx
@@ -10,10 +10,10 @@ Although there is no set maximum number of Data Assets you can define for a Data
 
 We will indicate a table to connect to with a Table Data Asset.  This is done by providing the `add_table_asset(...)` method a `name` by which we will reference the Data Asset in the future and a `table_name` to specify the table we wish the Data Asset to connect to.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py table_asset"
+```python name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py table_asset"
 ```
 
 To indicate the query that provides data to connect to we will define a Query Data Asset.  This done by providing the `add_query_asset(...)` method a `name` by which we will reference the Data Asset in the future and a `query` which will provide the data we wish the Data Asset to connect to.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py query_asset"
+```python name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py query_asset"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create.md
@@ -1,6 +1,6 @@
 Run the following code to create the Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py create_checkpoint"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py create_checkpoint"
 ```
 
 The Checkpoint you created is named `my_checkpoint`. It includes a Validation using the `BatchRequest` you created earlier, and an `ExpectationSuite` containing two Expectations, `test_suite`.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create_tab_python.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_create_tab_python.md
@@ -1,4 +1,4 @@
 Run the following code to create the Checkpoint configuration:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Add Checkpoint"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py Add Checkpoint"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_run.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_run.md
@@ -1,4 +1,4 @@
 Run the following code to run the Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Run Checkpoint"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py Run Checkpoint"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_save_tab_python.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_save_tab_python.md
@@ -1,2 +1,2 @@
-```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add checkpoint config"
+```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add checkpoint config"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_save_tab_yaml.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_save_tab_yaml.md
@@ -1,2 +1,2 @@
-```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add checkpoint config"
+```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add checkpoint config"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_test_tab_yaml.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_checkpoint_test_tab_yaml.md
@@ -1,2 +1,2 @@
-```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test checkpoint config"
+```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test checkpoint config"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_configure_your_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_configure_your_datasource.mdx
@@ -3,7 +3,7 @@ import Tabs from '@theme/Tabs';
 
 Using this example configuration, add in your S3 bucket and path to a directory that contains some of your data:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_s3_datasource"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_s3_datasource"
 ```
 
 In the example, we have added a Data Source that connects to data in S3 using a Pandas dataframe. The name of

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_configure_your_redshift_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_configure_your_redshift_datasource.mdx
@@ -1,9 +1,9 @@
 Creating a Redshift Data Source is as simple as providing the `add_or_update_sql(...)` method a `name` by which to reference it in the future and the `connection_string` with which to access it.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py vars"
+```python name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py vars"
 ```
 
 With these two values, we can create our Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py datasource"
+```python name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py datasource"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_datasource_sql_runtime_configuration.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_datasource_sql_runtime_configuration.md
@@ -1,4 +1,4 @@
 Using the following example, add in the `CONNECTION_STRING` for your database and create a batch request:
 
-```python name="version-0.18 tests/integration/docusaurus/connecting_to_your_data/database/athena_python_example.py Datasource dict config"
+```python name="tests/integration/docusaurus/connecting_to_your_data/database/athena_python_example.py Datasource dict config"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_expectation_suite_add_expectations_with_validator.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_expectation_suite_add_expectations_with_validator.md
@@ -2,7 +2,7 @@ import TechnicalTag from '../../../../reference/learn/term_tags/_tag.mdx';
 
 There are many Expectations available for you to use.  To demonstrate the creation of an Expectation through the use of the Validator you defined earlier, here are examples of the process for two of them:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_expectations"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_expectations"
 ```
 
 Each time you evaluate an Expectation with `validator.expect_*`, the Expectation is immediately Validated against your provided Batch of data. This instant feedback helps you identify unexpected data quickly. The Expectation configuration is stored in the Expectation Suite you provided when the Validator was initialized.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_expectation_suite_save.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_expectation_suite_save.md
@@ -1,4 +1,4 @@
 When you have run all of the Expectations you want for this dataset, you can call `validator.save_expectation_suite()` to save the Expectation Suite (all of the unique Expectation Configurations from each run of `validator.expect_*`)for later use in a Checkpoint.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py save_expectations"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py save_expectations"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_initialize_data_context_with_create.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_initialize_data_context_with_create.mdx
@@ -4,5 +4,5 @@ The simplest way to create a new <TechnicalTag relative="../../../" tag="data_co
 
 From a Notebook or script where you want to deploy Great Expectations run the following command. Here the `full_path_to_project_directory` can be an empty directory where you intend to build your Great Expectations configuration.:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py imports"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py imports"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_test_your_new_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_test_your_new_datasource.mdx
@@ -6,5 +6,5 @@ Verify your new <TechnicalTag tag="datasource" text="Data Source" /> by loading 
 
 We will use the `BatchRequest` configured in the previous step.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_validator"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_validator"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_test_your_new_redshift_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/deployment_patterns/how_to_use_gx_with_aws/components/_test_your_new_redshift_datasource.mdx
@@ -2,5 +2,5 @@ import TechnicalTag from '../../../../reference/learn/term_tags/_tag.mdx';
 
 Verify your new <TechnicalTag tag="datasource" text="Data Source" /> by loading data from it into a <TechnicalTag tag="validator" text="Validator" /> using a <TechnicalTag tag="batch_request" text="Batch Request" />.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_suite_and_get_validator"
+```python name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_suite_and_get_validator"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/get_started/get_started_with_gx_and_databricks.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/get_started/get_started_with_gx_and_databricks.md
@@ -48,7 +48,7 @@ The complete code used in the following examples is available on GitHub:
 
 2. Run the following command to import the Python configurations you'll use in the following steps:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
   ```
 
 ## Set up GX
@@ -59,11 +59,11 @@ DBFS is a distributed file system mounted in a Databricks workspace and availabl
 
 1. Run the following code to set up a <TechnicalTag tag="data_context" text="Data Context"/> with the default settings:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
   ```
 2. Run the following code to instantiate your Data Context:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
   ```
 
 ## Prepare your data
@@ -117,27 +117,27 @@ df = spark.read.format("csv")\
 
 1. Run the following command to set the base directory that contains the data:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory"
   ```
 
 2. Run the following command to create our <TechnicalTag tag="datasource" text="Data Source" />:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource"
   ```
 
 3. Run the following command to set the [batching regex](https://docs.greatexpectations.io/docs/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset/#create-a-batching_regex):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex"
   ```
 
 4. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> with the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset"
   ```
 
 5. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> with the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured earlier:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request"
   ```
 
 </TabItem>
@@ -145,17 +145,17 @@ df = spark.read.format("csv")\
 
 1. Run the following command to create the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource"
   ```
 
 2. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> with the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset"
   ```
 
 3. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> with the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured earlier:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request"
   ```
 
 </TabItem>
@@ -169,17 +169,17 @@ Every time you evaluate an Expectation with `validator.expect_*`, it is immediat
 
 1. Run the following command to create the suite and get a `Validator`:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator"
   ```
 
 2. Run the following command to use the `Validator` to add a few Expectations:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations"
   ```
 
 3. Run the following command to save your Expectation Suite (all the unique Expectation Configurations from each run of `validator.expect_*`) to your Expectation Store:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite"
   ```
 
 ## Validate your data
@@ -188,17 +188,17 @@ You'll create and store a <TechnicalTag tag="checkpoint" text="Checkpoint"/> for
 
 1. Run the following command to create the Checkpoint configuration that uses your Data Context, passes in your Batch Request (your data) and your Expectation Suite (your tests):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config"
   ```
 
 2. Run the following command to save the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config"
   ```
 
 3. Run the following command to run the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint"
   ```
 
   Your Checkpoint configuration includes the `store_validation_result` and `update_data_docs` actions. The `store_validation_result` action saves your validation results from the Checkpoint run and allows the results to be persisted for future use. The  `update_data_docs` action builds Data Docs files for the validations run in the Checkpoint.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/get_started/get_started_with_gx_and_sql.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/get_started/get_started_with_gx_and_sql.md
@@ -41,7 +41,7 @@ The full code used in the following examples is available on GitHub:
 
 2. Run the following command to import configuration information that you'll use in the following steps:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports"
   ```
 
 ## Set up GX
@@ -50,7 +50,7 @@ To avoid configuring external resources, you'll use your local filesystem for yo
 
 Run the following code to create a <TechnicalTag tag="data_context" text="Data Context"/> with the default settings:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context"
+```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context"
 ```
 
 ## Connect to your data
@@ -65,19 +65,19 @@ Run the following code to create a <TechnicalTag tag="data_context" text="Data C
 
 2. Run the following command to create a <TechnicalTag tag='datasource' text='Data Source' /> to represent the data available in your PostgreSQL database:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource"
   ```
 
 3. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> to represent a discrete set of data: 
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset"
   ```
 
   In this example, the name of a specific table within your database is used.
 
 4. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> using the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured previously:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request"
   ```
 
 ## Create Expectations
@@ -88,17 +88,17 @@ Every time you evaluate an Expectation with `validator.expect_*`, it is immediat
 
 1. Run the following command to create the suite and get a `Validator`:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator"
   ```
 
 2. Run the following command to use the `Validator` to add a few Expectations:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations"
   ```
 
 3. Run the following command to save your Expectation Suite (all the unique Expectation Configurations from each run of `validator.expect_*`) to your Expectation Store:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite"
   ```
 ## Validate your data
 
@@ -106,17 +106,17 @@ You'll create and store a <TechnicalTag tag="checkpoint" text="Checkpoint"/> for
 
 1. Run the following command to create the Checkpoint configuration that uses your Data Context:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config"
   ```
 
 2. Run the following command to save the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config"
   ```
 
 3. Run the following command to run the Checkpoint and pass in your Batch Request (your data) and your Expectation Suite (your tests):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint"
   ```
 
   Your Checkpoint configuration includes the `store_validation_result` and `update_data_docs` actions. The `store_validation_result` action saves your validation results from the Checkpoint run and allows the results to be persisted for future use. The  `update_data_docs` action builds Data Docs files for the validations run in the Checkpoint.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_configure_your_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_configure_your_datasource.mdx
@@ -13,24 +13,24 @@ Using this example configuration, add in your S3 bucket and path to a directory 
 
 <TabItem value="yaml">
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py datasource_yaml"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py datasource_yaml"
 ```
 
 Run this code to test your configuration.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py test_yaml_config"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py test_yaml_config"
 ```
 
 </TabItem>
 
 <TabItem value="python">
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py datasource_config"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py datasource_config"
 ```
 
 Run this code to test your configuration.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py test_yaml_config"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py test_yaml_config"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_instantiate_your_projects_datacontext.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_instantiate_your_projects_datacontext.mdx
@@ -1,10 +1,10 @@
 
 Run the following code to import the packages and modules:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py imports"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py imports"
 ```
 
 Run the following code to load your DataContext:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py get_context"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py get_context"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_save_the_datasource_configuration_to_your_datacontext.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_save_the_datasource_configuration_to_your_datacontext.mdx
@@ -13,14 +13,14 @@ Run the following code to use the `add_datasource()` function to save the config
 
 <TabItem value="yaml">
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py add_datasource"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py add_datasource"
 ```
 
 </TabItem>
 
 <TabItem value="python">
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py add_datasource"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py add_datasource"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_test_your_new_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_pandas/_test_your_new_datasource.mdx
@@ -19,12 +19,12 @@ Add the S3 path to your CSV in the `path` key under `runtime_parameters` in your
 The path you will want to use is your S3 URI, not the URL.
 :::
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py path batch_request"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py path batch_request"
 ```
 
 Then load data into the `Validator`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator 1"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator 1"
 ```
 
 </TabItem>
@@ -33,12 +33,12 @@ Then load data into the `Validator`.
 
 Add the name of the <TechnicalTag tag="data_asset" text="Data Asset" /> to the `data_asset_name` in your `BatchRequest`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py batch_request"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py batch_request"
 ```
 
 Then load data into the `Validator`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_add_csv_asset_to_spark_s3_datasource.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_add_csv_asset_to_spark_s3_datasource.md
@@ -1,6 +1,6 @@
 Add a CSV `Asset` into your `Data Source` by using the `add_csv_asset` function.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_spark_s3_asset"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_spark_s3_asset"
 ```
 
 Here we have added a `Asset` named `csv_taxi_s3_asset` using the `add_csv_asset` function. The `batching_regex` is a regular expression that 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_configure_your_datasource.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_configure_your_datasource.md
@@ -3,7 +3,7 @@ import Tabs from '@theme/Tabs';
 
 Using this example configuration, add in your S3 bucket and path to a directory that contains some of your data:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_s3_datasource"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_s3_datasource"
 ```
 
 In the example, we have added a Data Source that connects to data in S3 using a Spark dataframe. The name of

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_instantiate_your_projects_datacontext.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_instantiate_your_projects_datacontext.md
@@ -2,7 +2,7 @@ import SparkDataContextNote from '../../../components/spark_data_context_note.md
 
 Import these necessary packages and modules.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py imports for spark data context"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py imports for spark data context"
 ```
 
 <SparkDataContextNote />

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_save_the_datasource_configuration_to_your_datacontext.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_save_the_datasource_configuration_to_your_datacontext.md
@@ -13,14 +13,14 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
 
 <TabItem value="yaml">
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py add datasource config"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py add datasource config"
 ```
 
 </TabItem>
 
 <TabItem value="python">
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py add datasource config"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py add datasource config"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_test_your_new_datasource.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/_test_your_new_datasource.md
@@ -19,20 +19,20 @@ Add the S3 path to your CSV in the `path` key under `runtime_parameters` in your
 The path you will want to use is your S3 URI, not the URL.
 :::
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 1"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 1"
 ```
 
 Then load data into the `Validator`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 1"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 1"
 ```
 </TabItem>
 <TabItem value="batch_request">
 Add the name of the <TechnicalTag tag="data_asset" text="Data Asset" /> to the `data_asset_name` in your `BatchRequest`.
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 2"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 2"
 ```
 Then load data into the `Validator`.
-```python name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 2"
+```python name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 2"
 ```
 </TabItem>
 </Tabs>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py
@@ -21,7 +21,7 @@ data_context_config = DataContextConfig(
 )
 context = get_context(project_config=data_context_config)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py datasource config">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py datasource config">
 datasource_config = {
     "name": "my_s3_datasource",
     "class_name": "Datasource",
@@ -53,19 +53,19 @@ datasource_config["data_connectors"]["default_inferred_data_connector_name"][
     "prefix"
 ] = "data/taxi_yellow_tripdata_samples/"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py test datasource config">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py test datasource config">
 context.test_yaml_config(yaml.dump(datasource_config))
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py add datasource config">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/cloud/s3/components_spark/inferred_and_runtime_python_example.py add datasource config">
 context.add_datasource(**datasource_config)
 # </snippet>
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="<YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
     runtime_parameters={"path": "<PATH_TO_YOUR_DATA_HERE>"},  # Add your S3 path here.
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
@@ -76,11 +76,9 @@ batch_request.runtime_parameters[
     "path"
 ] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 
@@ -89,9 +87,9 @@ assert isinstance(validator, gx.validator.validator.Validator)
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_DATA_ASSET_NAME>",
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="<YOUR_DATA_ASSET_NAME>",
     batch_spec_passthrough={"reader_method": "csv", "reader_options": {"header": True}},
 )
 
@@ -101,11 +99,9 @@ batch_request.data_asset_name = (
     "data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01"
 )
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_athena_test.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_athena_test.md
@@ -1,19 +1,19 @@
 Run the following code to connect to Athena, add an asset for your table, and build a batch request for your table:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Connect and Build Batch Request"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py Connect and Build Batch Request"
 
 ```
 
 Run the following code to prepare an empty Expectation suite:
 
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Create Expectation Suite"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py Create Expectation Suite"
 
 ```
 
 Run the following code to load data into a `Validator`:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Test Datasource with Validator"
+```python name="docs/docusaurus/docs/snippets/athena_python_example.py Test Datasource with Validator"
 
 ```
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_redshift_configuration.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_redshift_configuration.md
@@ -13,12 +13,12 @@ import TabItem from '@theme/TabItem';
 
 Put your connection string in this template:
 
-```yaml name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py datasource config"
+```yaml name="docs/docusaurus/docs/snippets/redshift_yaml_example.py datasource config"
 ```
 
 Run this code to test your configuration.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py test datasource config"
+```python name="docs/docusaurus/docs/snippets/redshift_yaml_example.py test datasource config"
 ```
 </TabItem>
 
@@ -26,12 +26,12 @@ Run this code to test your configuration.
 
 Put your connection string in this template:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py datasource config"
+```python name="docs/docusaurus/docs/snippets/redshift_python_example.py datasource config"
 ```
 
 Run this code to test your configuration.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py test datasource config"
+```python name="docs/docusaurus/docs/snippets/redshift_python_example.py test datasource config"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_redshift_test.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/database/components/_datasource_redshift_test.md
@@ -15,7 +15,7 @@ Verify your new <TechnicalTag tag="datasource" text="Data Source" /> by loading 
 
 Here is an example of loading data by specifying a SQL query.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py load data with query"
+```python name="docs/docusaurus/docs/snippets/redshift_yaml_example.py load data with query"
 ```
 
 </TabItem>
@@ -24,7 +24,7 @@ Here is an example of loading data by specifying a SQL query.
 
 Here is an example of loading data by specifying an existing table name.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py load data with table name"
+```python name="docs/docusaurus/docs/snippets/redshift_python_example.py load data with table name"
 ```
 
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_base_directory_for_filesystem.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_base_directory_for_filesystem.mdx
@@ -1,5 +1,5 @@
 For the base directory, you will want to put the relative path of your data from the folder that contains your Data Context.  Since we are manually entering this value rather than letting the CLI generate it, the key/value pair will look like:
 
-```python name="version-0.18 inferred data connector add base_directory"
+```python name="inferred data connector add base_directory"
         "base_directory": "../data",
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_batch_spec_passthrough.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_batch_spec_passthrough.mdx
@@ -1,30 +1,30 @@
 The parameter `batch_spec_passthrough` is used to access some native capabilities of your Execution Engine.  If you do not specify it, your Execution Engine will attempt to determine the values based off of file extensions and defaults.  If you do define it, it will contain two keys: `reader_method` and `reader_options`.  These will correspond to a string and a dictionary, respectively.
 
-```python name="version-0.18 empty batch_spec_passthrough"
+```python name="empty batch_spec_passthrough"
 ```
 
 #### Configuring your `reader_method`:
 
 The `reader_method` is used to specify which of Spark's `spark.read.*`  methods will be used to read your data.  For our example, we are using `.csv` files as our Data Source, so we will specify the `csv` method of `spark.reader` as our `reader_method`, like so:
 
-```python name="version-0.18 set reader_method to csv"
+```python name="set reader_method to csv"
 ```
 
 #### Configuring your `reader_options`:
 
 Start by adding a blank dictionary as the value of the `reader_options` parameter.  This dictionary will hold two key/value pairs: `header` and `inferSchema`.
 
-```python name="version-0.18 empty keys for reader_options"
+```python name="empty keys for reader_options"
 ```
 
 The first key is `header`, and the value should be either `True` or `False`.  This will indicate to the Data Connector whether or not the first row of each Data Source file is a header row.  For our example, we will set this to `True`.
 
-```python name="version-0.18 populate header for reader_options as True"
+```python name="populate header for reader_options as True"
 ```
 
 The second key to include is `inferSchema`.  Again, the value should be either `True` or `False`.  This will indicate to the Data Connector whether or not the Execution Engine should attempt to infer the data type contained by each column in the Data Source files.  Again, we will set this to `True` for the purpose of this guide's example.
 
-```python name="version-0.18 populate inferSchema for reader_options as True"
+```python name="populate inferSchema for reader_options as True"
 ```
 
 :::caution
@@ -34,5 +34,5 @@ The second key to include is `inferSchema`.  Again, the value should be either `
 
 At this point, your `batch_spec_passthrough` configuration should look like:
 
-```python name="version-0.18 fully populated batch_spec_passthrough configuration"
+```python name="fully populated batch_spec_passthrough configuration"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_glob_directive_details.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_part_glob_directive_details.mdx
@@ -12,7 +12,7 @@ To include all of these files, you would need to tell the Data connector to look
 
  You would do this by setting the `glob_directive` key in your Data Connector config to a value of `"*/*"`.  This value will cause the Data Connector to look for regex matches against the file names for all files found in any subfolder of your `base_directory`.  Such an entry would look like:
 
-```python name="version-0.18 datasource_configuration_glob_directive"
+```python name="datasource_configuration_glob_directive"
 ```
 
 The `glob_directive` parameter works off of regex.  You can also use it to limit the files that will be compared against the Data Connector's `default_regex` for a match.  For example, to only permit `.csv` files to be checked for a match, you could specify the `glob_directive` as `"*.csv"`.  To only check for matches against the `.csv` files in subdirectories, you would use the value `*/*.csv`, and so forth.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_add_your_new_datasource_to_your_data_context.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_add_your_new_datasource_to_your_data_context.mdx
@@ -1,6 +1,6 @@
 Now that you have verified that you have a valid configuration you can add your new Data Source to your Data Context with the command:
 
-```python name="version-0.18 add your datasource to your data_context"
+```python name="add your datasource to your data_context"
 ```
 
 :::caution
@@ -13,7 +13,7 @@ If the value of `datasource_config["name"]` corresponds to a Data Source that is
 
 If you want to ensure that you only add a Data Source when it won't overwrite an existing one, you can use the following code instead:
 
-```python name="version-0.18 add your datasource to your data_context only if it does not already exit"
+```python name="add your datasource to your data_context only if it does not already exit"
 ```
 
 :::

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_create_a_new_datasource_configuration.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_create_a_new_datasource_configuration.mdx
@@ -4,7 +4,7 @@ To start, create an empty dictionary.  You will be populating it with keys as yo
 
 At this point, the configuration for your Data Source is merely:
 
-```python name="version-0.18 datasource_configuration_empty_dictionary"
+```python name="datasource_configuration_empty_dictionary"
 ```
 
 However, from this humble beginning you will be able to build a full Data Source configuration.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_name_your_datasource.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_name_your_datasource.mdx
@@ -2,12 +2,12 @@ The first key that you will need to define for your new Data Source is its `name
 
 For the purposes of this example, we will name this Data Source:
 
-```python name="version-0.18 datasource_configuration_name_key"
+```python name="datasource_configuration_name_key"
 ```
 
 You should, however, name your Datsource something more relevant to your data.
 
 At this point, your configuration should now look like:
 
-```python name="version-0.18 datasource_configuration_post_name_key"
+```python name="datasource_configuration_post_name_key"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_specify_the_datasource_class_and_module.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_specify_the_datasource_class_and_module.mdx
@@ -1,9 +1,9 @@
 The `class_name` and `module_name` for your Data Source will almost always indicate the `Datasource` class found at `great_expectations.datasource`.  You may replace this with a specialized subclass, or a custom class, but for almost all regular purposes these two default values will suffice.  For the purposes of this guide, add those two values to their corresponding keys.
 
-```python name="version-0.18 datasource_configuration_class_and_module_keys"
+```python name="datasource_configuration_class_and_module_keys"
 ```
 
 Your full configuration should now look like:
 
-```python name="version-0.18 datasource_configuration_post_class_and_module_keys"
+```python name="datasource_configuration_post_class_and_module_keys"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_test_your_configuration_with_test_yaml_config.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/components/_section_test_your_configuration_with_test_yaml_config.mdx
@@ -1,6 +1,6 @@
 Now that you have a full Data Source configuration, you can confirm that it is valid by testing it with the `.test_yaml_config(...)` method.  To do this, execute the Python code:
 
-```python name="version-0.18 test your config with test_yaml_config"
+```python name="test your config with test_yaml_config"
 ```
 
 When executed, `test_yaml_config` will instantiate the component described by the yaml configuration that is passed in and then run a self check procedure to verify that the component works as expected.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_configured_multi.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_configured_multi.mdx
@@ -13,7 +13,7 @@ First, you need to add an empty dictionary entry into the `assets` dictionary.  
 
 At this point, your entry in the `assets dictionary will look like:
 
-```python name="version-0.18 empty data asset for configured, multi batch datasource"
+```python name="empty data asset for configured, multi batch datasource"
 ```
 
 Next, you will need to define the `pattern` value and `group_names` value for this Data Asset.
@@ -22,12 +22,12 @@ Since you want this Data Asset to all of the 2020 files, the value for `pattern`
 
 Looking back at the files in our `data` directory, you can see that each file differs from the others only in the digits indicating the month of the file.  Therefore, the regular expression we create will separate those specific characters into a group, and will define the content of that group using special characters capable of matching on any values, like so:
 
-```python name="version-0.18 pattern for asset in configured, multi-batch datasource"
+```python name="pattern for asset in configured, multi-batch datasource"
 ```
 
 To correspond to the single group that was defined in your `pattern`, you will define a single entry in the list for the `group_names` key.  Since the `assets` dictionary key is used for this Data Asset's name, you can give this group a name relevant to what it is matching on:
 
-```python name="version-0.18 group_names for asset in configured, multi-batch datasource"
+```python name="group_names for asset in configured, multi-batch datasource"
 ```
 
 Since the group in the above regular expression will match on any characters, this regex will successfully match on each of the file names in our `data` directory, and will associate each file with the identifier `month` that corresponds to the file's grouped characters:
@@ -37,7 +37,7 @@ Since the group in the above regular expression will match on any characters, th
 
 Put entirely together, your `assets` entry will look like:
 
-```python name="version-0.18 multi batch data asset for configured pandas datasource"
+```python name="multi batch data asset for configured pandas datasource"
 ```
 
 Looking back at our sample files, this entry will result in the `ConfiguredAssetFilesystemDataConnector` providing one Data Asset, which can be accessed by the name `yellow_tripdata_2020`.  In future workflows you will be able to refer to this Data Asset and by providing that name, and refer to a specific Batch in this Data Asset by providing your Batch Request with a `batch_identifier` entry using the key `month` and the value corresponding to the month portion of the filename of the file that corresponds to the Batch in question.
@@ -46,5 +46,5 @@ Looking back at our sample files, this entry will result in the `ConfiguredAsset
 
 With all of these values put together into a single dictionary, your Data Connector configuration will look like this:
 
-```python name="version-0.18 data connector for configured, multi-batch, Pandas datasource"
+```python name="data connector for configured, multi-batch, Pandas datasource"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_configured_single.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_configured_single.mdx
@@ -15,14 +15,14 @@ First, you need to add an empty dictionary entry into the `assets` dictionary.  
 
 At this point, your entry in the `assets dictionary will look like:
 
-```python name="version-0.18 empty_data_asset_configuration_configured_single_batch"
+```python name="empty_data_asset_configuration_configured_single_batch"
 ```
 
 Next, you will need to define the `pattern` value and `group_names` value for this Data Asset.
 
 Since you want this Data Asset to only match the file `yellow_tripdata_sample_2020-01.csv` value for the `pattern` key should be one that does not contain any regex special characters that can match on more than one value.  An example follows:
 
-```python name="version-0.18 pattern_for_single_batch_configured_data_asset_configuration"
+```python name="pattern_for_single_batch_configured_data_asset_configuration"
 ```
 
 :::note
@@ -33,17 +33,17 @@ Since none of the characters in this regex can possibly match more than one valu
 
 To correspond to the single group that was defined in your regex, you will define a single entry in the list for the `group_names` key.  Since the `assets` dictionary key is used for this Data Asset's name, you can give this group a name relevant to what it is matching on:
 
-```python name="version-0.18 group_names for single batch configured assets configuration"
+```python name="group_names for single batch configured assets configuration"
 ```
 
 Put entirely together, your `assets` entry will look like:
 
-```python name="version-0.18 full_data_asset_for_single_batch_configured_data_connector"
+```python name="full_data_asset_for_single_batch_configured_data_connector"
 ```
 
 Looking back at our sample files, this entry will result in the `ConfiguredAssetFilesystemDataConnector` providing one Data Asset, which can be accessed by the name `yellow_tripdata_jan`.  In future workflows you will be able to refer to this Data Asset and its single corresponding Batch by providing that name.
 
 With all of these values put together into a single dictionary, your Data Connector configuration will look like this:
 
-```python name="version-0.18 full_single_batch_configured_data_connector_configuration"
+```python name="full_single_batch_configured_data_connector_configuration"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_inferred_multi.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_inferred_multi.mdx
@@ -12,7 +12,7 @@ For this example, lets assume you have the following files in our `data` directo
 - `yellow_tripdata_sample_2020-03.csv`
 
 You can configure a Data Asset that groups these files together and differentiates each batch by month by defining a `pattern` in the dictionary for the `default_regex` key:
-```python name="version-0.18 datasource_configuration_inferred_multi_batch_regex_pattern"
+```python name="datasource_configuration_inferred_multi_batch_regex_pattern"
 ```
 
 This regex will group together all files that match the content of the first group as a single Data Asset.  Since the first group does not include any special regex characters, this means that all of the `.csv` files that start with "yellow_tripdata_sample_2020" will be combined into one Data Asset, and that all other files will be ignored.
@@ -21,7 +21,7 @@ The second defined group consists of the numeric characters after the last dash 
 
 Since you have defined two groups in your regex, you will need to provide two corresponding group names in your `group_names` key.  Since the first group in an Inferred Asset Data Connector is used to generate the names for the inferred Data Assets provided by the Data Connector and the second group you defined corresponds to the month of data that each file contains, you should name those groups as follows:
 
-```python name="version-0.18 group_names for inferred multi batch default_regex key"
+```python name="group_names for inferred multi batch default_regex key"
 ```
 
 Looking back at our sample files, this regex will result in the `InferredAssetFilesystemDataConnector` providing a single Data Asset, which will contain three batches.  In future workflows you will be able to refer to a specific Batch in this Data Asset in a Batch Request py providing the  `data_asset_name` of `"yellow_tripdata_sample_2020"` and one of the following `month`s:
@@ -39,6 +39,6 @@ Any characters that are not included in a group when you define your regex will 
 
 With all of these values put together into a single dictionary, your Data Connector configuration will look like this:
 
-```python name="version-0.18 data connector config for inferred filesystem data connector multi batch"
+```python name="data connector config for inferred filesystem data connector multi batch"
 ```
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_inferred_single.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_inferred_single.mdx
@@ -9,7 +9,7 @@ For this example, lets assume we have the following files in our `data` director
 
 In this case you could define the `pattern` key as follows:
 
-```python name="version-0.18 datasource_configuration_inferred_single_batch_regex_pattern"
+```python name="datasource_configuration_inferred_single_batch_regex_pattern"
 ```
 
 This regex will match the full name of any file that has the `.csv` extension, and will put everything prior to `.csv` extension into a group.
@@ -18,7 +18,7 @@ Since each `.csv` file will necessarily have a unique name preceeding its extens
 
 To correspond to the single group that was defined in your regex, you will define a single entry in the list for the `group_names` key.  Since the first group in an Inferred Asset Data Connector is used to generate names for the inferred Data Assets, you should name that group as follows:
 
-```python name="version-0.18 datasource_configuration_inferred_single_batch_group_names"
+```python name="datasource_configuration_inferred_single_batch_group_names"
 ```
 
 Looking back at our sample files, this regex will result in the `InferredAssetFilesystemDataConnector` providing three Data Assets, which can be accessed by the portion of the file that matches the first group in our regex.  In future workflows you will be able to refer to one of these Data Assets in a Batch Request py providing one of the following `data_asset_name`s:
@@ -34,5 +34,5 @@ Since we did not include `.csv` in the first group of the regex we defined, the 
 
 With all of these values put together into a single dictionary, your Data Connector configuration will look like this:
 
-```python name="version-0.18 data_connector_configuration_post_single_batch_regex"
+```python name="data_connector_configuration_post_single_batch_regex"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_runtime.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_config_for_assets_runtime.mdx
@@ -15,7 +15,7 @@ For instance, let's assume you are getting a daily update to your data, and so y
 
 To do this, you would simply add a `batch_timestamp` entry in your `batch_identifiers` list.  This would look like:
 
-```python name="version-0.18 batch_identifiers for filesystem runtime data connector"
+```python name="batch_identifiers for filesystem runtime data connector"
 ```
 
 Then, when you create your Batch Request you would populate the `batch_timestamp` value in its `batch_identifiers` dictionary with the value of the current date and time.  This will attach the current date and time to the returned Batch, allowing you to reference the Batch again in the future even if the current data (the data that would be provided by the Runtime Data Connector if you requested a new Batch) had changed.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_section_import_necessary_modules_and_initialize_your_data_context.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/_section_import_necessary_modules_and_initialize_your_data_context.mdx
@@ -1,4 +1,4 @@
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps imports and data context"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps imports and data context"
 ```
 
 The `great_expectations` module will give you access to your Data Context, which is the entry point for working with a Great Expectations project.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps.py
@@ -23,7 +23,7 @@ def section_1_import_necessary_modules_and_initialize_your_data_context():
     Returns:
         a Great Expectations DataContext object
     """
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps imports and data context">
+    # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/datasource_configuration/filesystem_components/how_to_configure_a_datasource_universal_steps imports and data context">
     import great_expectations as gx
     from great_expectations.core.yaml_handler import YAMLHandler
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_configured.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_configured.mdx
@@ -21,7 +21,7 @@ import NoteExplicitConfiguredAssetsMulti from '../filesystem_components/_note_ex
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_single_batch_full_snippet"
+```python name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_single_batch_full_snippet"
 ```
 
 <NoteExplicitConfiguredAssetsSingle />
@@ -34,7 +34,7 @@ And the full configuration for your Data Source should look like:
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_multi_batch_full_snippet"
+```python name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_multi_batch_full_snippet"
 datasource_config = {
     "name": "my_datasource_name",
     "class_name": "Data Source",

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_inferred.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_inferred.mdx
@@ -19,7 +19,7 @@ import ConfigForAssetsInferredMulti from '../filesystem_components/_config_for_a
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_single_batch_full_snippet"
+```python name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_single_batch_full_snippet"
 datasource_config = {
     "name": "my_datasource_name",
     "class_name": "Data Source",
@@ -48,7 +48,7 @@ datasource_config = {
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_multi_batch_full_snippet"
+```python name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_multi_batch_full_snippet"
 ```
 
   </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_runtime.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_assets_runtime.mdx
@@ -5,7 +5,7 @@ import CautionRuntimeBatchIdentifierValues from '../components/_caution_runtime_
 
 The full configuration for your Data Source should now look like:
 
-```python name="version-0.18 full pandas runtime Data Source configuration"
+```python name="full pandas runtime Data Source configuration"
 ```
 
 <CautionRuntimeBatchIdentifierValues />

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_glob_directive_details.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_part_glob_directive_details.mdx
@@ -4,5 +4,5 @@ import PartGlobDirectiveDetails from '../components/_part_glob_directive_details
 
 In this guide's examples, all of our data is assumed to be in the `base_directory` folder.  Therefore, you will not need to add an entry for `glob_directive` to your configuration.  However, if you were to include the example `glob_directive` from above, your full configuration would currently look like:
 
-```python name="version-0.18 datasource_configuration_post_glob_directive"
+```python name="datasource_configuration_post_glob_directive"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
@@ -4,5 +4,5 @@ import PartAddADictionaryAsTheValueOfTheDataConnectorsKey from '../components/_p
 
 Your current configuration should look like:
 
-```python name="version-0.18 datasource_configuration_add_empty_data_connectors_key"
+```python name="datasource_configuration_add_empty_data_connectors_key"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
@@ -4,10 +4,10 @@ import PartAddTheBackendExecutionEngineToYourDatasourceConfiguration from '../co
 
 For the purposes of this guide, these will consist of the `PandasExecutionEngine` found at `great_expectations.execution_engine`.  The `execution_engine` key and its corresponding value will therefore look like this:
 
-```python name="version-0.18 datasource_configuration_add_execution_engine"
+```python name="datasource_configuration_add_execution_engine"
 ```
 
 After adding the above snippet to your Data Source configuration, your full configuration dictionary should now look like:
 
-```python name="version-0.18 datasource_configuration_post_execution_engine"
+```python name="datasource_configuration_post_execution_engine"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_configure_batch_spec_passthrough.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_section_configure_batch_spec_passthrough.mdx
@@ -17,20 +17,20 @@ And your full configuration will look like:
 
   <TabItem value="inferred">
 
-```python name="version-0.18 inferred datasource_config up to batch_spec_passthrough"
+```python name="inferred datasource_config up to batch_spec_passthrough"
 ```
 
   </TabItem>
   <TabItem value="configured">
 
-```python name="version-0.18 configured datasource_config up to batch_spec_passthrough"
+```python name="configured datasource_config up to batch_spec_passthrough"
 ```
 
       
   </TabItem>
   <TabItem value="runtime">
 
-```python name="version-0.18 runtime datasource_config up to batch_spec_passthrough"
+```python name="runtime datasource_config up to batch_spec_passthrough"
 ```
 
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_tab_data_connector_example_configurations_configured.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_tab_data_connector_example_configurations_configured.mdx
@@ -6,18 +6,18 @@ import PartFilesystemBaseDirectory from '../components/_part_base_directory_for_
 
 <TipConfiguredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_configured_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_configured_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 datasource_configuration_add_empty_configured_data_connector"
+```python name="datasource_configuration_add_empty_configured_data_connector"
 ```
 
-<PartDataConnectorKeysOverview data_connector_type="ConfiguredAssetFilesystemDataConnector" data_connector_name="version-0.18 name_of_my_configured_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={false} />
+<PartDataConnectorKeysOverview data_connector_type="ConfiguredAssetFilesystemDataConnector" data_connector_name="name_of_my_configured_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={false} />
 
 For this example, you will be using the `ConfiguredAssetFilesystemDataConnector` as your `class_name`.  This is a subclass of the `ConfiguredAssetDataConnector` that is specialized to support filesystem Execution Engines, such as the `PandasExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 data_connector_configuration_configured_class_name"
+```python name="data_connector_configuration_configured_class_name"
 ```
 
 <TipCustomDataConnectorModuleName />
@@ -26,5 +26,5 @@ For this example, you will be using the `ConfiguredAssetFilesystemDataConnector`
 
 With these values added, along with blank dictionaries for `assets` and `batch_spec_passthrough`, your full configuration should now look like:
 
-```python name="version-0.18 datasource_config_configured_data_connector_empty_data_asset"
+```python name="datasource_config_configured_data_connector_empty_data_asset"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_tab_data_connector_example_configurations_inferred.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/pandas_components/_tab_data_connector_example_configurations_inferred.mdx
@@ -7,18 +7,18 @@ import PartFilesystemBaseDirectory from '../components/_part_base_directory_for_
 
 <TipInferredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_inferred_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_inferred_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 datasource_config add empty inferred_data_connector"
+```python name="datasource_config add empty inferred_data_connector"
 ```
 
-<PartDataConnectorKeysOverview data_connector_type="InferredAssetFilesystemDataConnector" data_connector_name="version-0.18 name_of_my_inferred_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={true} />
+<PartDataConnectorKeysOverview data_connector_type="InferredAssetFilesystemDataConnector" data_connector_name="name_of_my_inferred_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={true} />
 
 For this example, you will be using the `InferredAssetFilesystemDataConnector` as your `class_name`.  This is a subclass of the `InferredAssetDataConnector` that is specialized to support filesystem Execution Engines, such as the `SparkDFExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 inferred data connector populate class_name"
+```python name="inferred data connector populate class_name"
 ```
 
 <TipCustomDataConnectorModuleName />
@@ -27,7 +27,7 @@ For this example, you will be using the `InferredAssetFilesystemDataConnector` a
 
 With these values added, along with blank dictionary for `default_regex` (we will define it in the next step) and `batch_spec_passthrough`, your full configuration should now look like:
 
-```python name="version-0.18 datasource_configuration_pandas_inferred_empty_regex"
+```python name="datasource_configuration_pandas_inferred_empty_regex"
 ```
 :::info Optional parameter: `glob_directive`
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_configured.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_configured.mdx
@@ -20,7 +20,7 @@ import NoteExplicitConfiguredAssetsMulti from '../filesystem_components/_note_ex
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 full datasource_config for configured spark single batch datasource"
+```python name="full datasource_config for configured spark single batch datasource"
 ```
 
 <NoteExplicitConfiguredAssetsSingle />
@@ -33,7 +33,7 @@ And the full configuration for your Data Source should look like:
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 full datasource_config for configured spark multi batch datasource"
+```python name="full datasource_config for configured spark multi batch datasource"
 ```
 
 <NoteExplicitConfiguredAssetsMulti />

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_inferred.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_inferred.mdx
@@ -18,7 +18,7 @@ import ConfigForAssetsInferredMulti from '../filesystem_components/_config_for_a
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 full datasource_config for inferred spark single batch datasource"
+```python name="full datasource_config for inferred spark single batch datasource"
 ```
 
   </TabItem>
@@ -28,7 +28,7 @@ And the full configuration for your Data Source should look like:
 
 And the full configuration for your Data Source should look like:
 
-```python name="version-0.18 full datasource_config for inferred spark multi batch datasource"
+```python name="full datasource_config for inferred spark multi batch datasource"
 ```
 
   </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_runtime.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_assets_runtime.mdx
@@ -5,7 +5,7 @@ import CautionRuntimeBatchIdentifierValues from '../components/_caution_runtime_
 
 The full configuration for your Data Source should now look like:
 
-```python name="version-0.18 full datasource_config for runtime spark datasource"
+```python name="full datasource_config for runtime spark datasource"
 ```
 
 <CautionRuntimeBatchIdentifierValues />

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_glob_directive_details.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_part_glob_directive_details.mdx
@@ -4,5 +4,5 @@ import PartGlobDirectiveDetails from '../components/_part_glob_directive_details
 
 In this guide's examples, all of our data is assumed to be in the `base_directory` folder.  Therefore, you will not need to add an entry for `glob_directive` to your configuration.  However, if you were to include the example `glob_directive` from above, your full configuration would currently look like:
 
-```python name="version-0.18 spark inferred datasource_config post glob_directive definition"
+```python name="spark inferred datasource_config post glob_directive definition"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
@@ -4,5 +4,5 @@ import PartAddADictionaryAsTheValueOfTheDataConnectorsKey from '../components/_p
 
 Your current configuration should look like:
 
-```python name="version-0.18 spark datasource_config up to adding an empty data_connectors dictionary"
+```python name="spark datasource_config up to adding an empty data_connectors dictionary"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
@@ -4,10 +4,10 @@ import PartAddTheBackendExecutionEngineToYourDatasourceConfiguration from '../co
 
 For the purposes of this guide, these will consist of the `SparkDFExecutionEngine` found at `great_expectations.execution_engine`.  The `execution_engine` key and its corresponding value will therefore look like this:
 
-```python name="version-0.18 define spark execution engine"
+```python name="define spark execution engine"
 ```
 
 After adding the above snippet to your Data Source configuration, your full configuration dictionary should now look like:
 
-```python name="version-0.18 spark datasource_config up to definition of Spark execution engine"
+```python name="spark datasource_config up to definition of Spark execution engine"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_configure_batch_spec_passthrough.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_section_configure_batch_spec_passthrough.mdx
@@ -17,20 +17,20 @@ And your full configuration will look like:
 
   <TabItem value="inferred">
 
-```python name="version-0.18 inferred spark datasource_config post batch_spec_passthrough definition"
+```python name="inferred spark datasource_config post batch_spec_passthrough definition"
 ```
 
   </TabItem>
   <TabItem value="configured">
 
-```python name="version-0.18 configured spark datasource_config post batch_spec_passthrough definition"
+```python name="configured spark datasource_config post batch_spec_passthrough definition"
 ```
 
       
   </TabItem>
   <TabItem value="runtime">
 
-```python name="version-0.18 runtime spark datasource_config post batch_spec_passthrough definition"
+```python name="runtime spark datasource_config post batch_spec_passthrough definition"
 ```
 
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_tab_data_connector_example_configurations_configured.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_tab_data_connector_example_configurations_configured.mdx
@@ -6,18 +6,18 @@ import PartFilesystemBaseDirectory from '../components/_part_base_directory_for_
 
 <TipConfiguredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_configured_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_configured_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 spark Data Source configuration up to adding an empty configured data connector"
+```python name="spark Data Source configuration up to adding an empty configured data connector"
 ```
 
-<PartDataConnectorKeysOverview data_connector_type="ConfiguredAssetFilesystemDataConnector" data_connector_name="version-0.18 name_of_my_configured_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={false} />
+<PartDataConnectorKeysOverview data_connector_type="ConfiguredAssetFilesystemDataConnector" data_connector_name="name_of_my_configured_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={false} />
 
 For this example, you will be using the `ConfiguredAssetFilesystemDataConnector` as your `class_name`.  This is a subclass of the `ConfiguredAssetDataConnector` that is specialized to support filesystem Execution Engines, such as the `SparkDFExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 configured data connector define class_name as ConfiguredAssetFilesystemDataConnector"
+```python name="configured data connector define class_name as ConfiguredAssetFilesystemDataConnector"
 ```
 
 <TipCustomDataConnectorModuleName />
@@ -26,5 +26,5 @@ For this example, you will be using the `ConfiguredAssetFilesystemDataConnector`
 
 With these values added, along with blank dictionaries for `assets` and `batch_spec_passthrough`, your full configuration should now look like:
 
-```python name="version-0.18 configured spark datasource_config up to adding empty assets and batch_spec_passthrough dictionaries"
+```python name="configured spark datasource_config up to adding empty assets and batch_spec_passthrough dictionaries"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_tab_data_connector_example_configurations_inferred.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/spark_components/_tab_data_connector_example_configurations_inferred.mdx
@@ -7,18 +7,18 @@ import PartFilesystemBaseDirectory from '../components/_part_base_directory_for_
 
 <TipInferredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_inferred_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_inferred_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 spark Data Source configuration up to adding an empty inferred data connector"
+```python name="spark Data Source configuration up to adding an empty inferred data connector"
 ```
 
-<PartDataConnectorKeysOverview data_connector_type="InferredAssetFilesystemDataConnector" data_connector_name="version-0.18 name_of_my_inferred_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={true} />
+<PartDataConnectorKeysOverview data_connector_type="InferredAssetFilesystemDataConnector" data_connector_name="name_of_my_inferred_data_connector" runtime={false} batch_spec_passthrough={true} glob_directive={true} />
 
 For this example, you will be using the `InferredAssetFilesystemDataConnector` as your `class_name`.  This is a subclass of the `InferredAssetDataConnector` that is specialized to support filesystem Execution Engines, such as the `SparkDFExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 inferred data connector define class_name as InferredAssetFilesystemDataConnector"
+```python name="inferred data connector define class_name as InferredAssetFilesystemDataConnector"
 ```
 
 <TipCustomDataConnectorModuleName />
@@ -27,7 +27,7 @@ For this example, you will be using the `InferredAssetFilesystemDataConnector` a
 
 With these values added, along with blank dictionary for `default_regex` (we will define it in the next step) and `batch_spec_passthrough`, your full configuration should now look like:
 
-```python name="version-0.18 inferred spark datasource_config up to adding empty default_regex and batch_spec_passthrough dictionaries"
+```python name="inferred spark datasource_config up to adding empty default_regex and batch_spec_passthrough dictionaries"
 ```
 :::info Optional parameter: `glob_directive`
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_config_for_assets_runtime.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_config_for_assets_runtime.mdx
@@ -15,7 +15,7 @@ For instance, let's assume you are getting a daily update to your data, and so y
 
 To do this, you would simply add a `batch_timestamp` entry in your `batch_identifiers` list.  This would look like:
 
-```python name="version-0.18 runtime sql data asset define batch_identifiers"
+```python name="runtime sql data asset define batch_identifiers"
 ```
 
 Then, when you create your Batch Request you would populate the `batch_timestamp` value in its `batch_identifiers` dictionary with the value of the current date and time.  This will attach the current date and time to the returned Batch, allowing you to reference the Batch again in the future even if the current data (the data that would be provided by the Runtime Data Connector if you requested a new Batch) had changed.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_part_assets_runtime.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_part_assets_runtime.mdx
@@ -5,7 +5,7 @@ import CautionRuntimeBatchIdentifierValues from '../components/_caution_runtime_
 
 The full configuration for your Data Source should now look like:
 
-```python name="version-0.18 full configuration for sql runtime Data Source"
+```python name="full configuration for sql runtime Data Source"
 ```
 
 <CautionRuntimeBatchIdentifierValues />

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_section_add_a_dictionary_as_the_value_of_the_data_connectors_key.mdx
@@ -4,5 +4,5 @@ import PartAddADictionaryAsTheValueOfTheDataConnectorsKey from '../components/_p
 
 Your current configuration should look like:
 
-```python name="version-0.18 sql datasource configuration post execution engine defined with empty data_connectors"
+```python name="sql datasource configuration post execution engine defined with empty data_connectors"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_section_add_the_execution_engine_to_your_datasource_configuration.mdx
@@ -4,12 +4,12 @@ import PartAddTheBackendExecutionEngineToYourDatasourceConfiguration from '../co
 
 For the purposes of this guide, these will consist of the `SqlAlchemyExecutionEngine` found at `great_expectations.execution_engine`.  The `execution_engine` key and its corresponding value will therefore look like this:
 
-```python name="version-0.18 sql datasource define execution_engine class_name and module_name"
+```python name="sql datasource define execution_engine class_name and module_name"
 ```
 
 Additionally, your `execution_engine` dictionary will require a values for either `connection_string` or `credentials`.  You will only need to use one of these keys as they each serve the same purpose: to provide the parameters necessary for the SqlAlchemyExecutionEngine to connect to your desired database.  For the purposes of this guide we will use the `connection_string` key, the value of which will be the string representation of the information necessary to connect to your SQL database.  At this point your configuration should look like:
 
-```python name="version-0.18 sql datasource define CONNECTION_STRING"
+```python name="sql datasource define CONNECTION_STRING"
 ```
 
 :::tip
@@ -18,7 +18,7 @@ Your connection string will vary depending on the type of SQL database you are c
 
 After adding the above snippets to your Data Source configuration, your full configuration dictionary should now look like:
 
-```python name="version-0.18 sql datasource configuration post execution engine defined"
+```python name="sql datasource configuration post execution engine defined"
 ```
 
 :::tip Tip: Using `credentials` instead of `connection_string`

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_tab_data_connector_example_configurations_configured.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_tab_data_connector_example_configurations_configured.mdx
@@ -6,27 +6,27 @@ import NoteOptionalDataConnectorKeys from './_note_optional_data_connector_keys.
 
 <TipConfiguredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_configured_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_configured_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 sql datasource configuration with empty configured sql data_connector"
+```python name="sql datasource configuration with empty configured sql data_connector"
 ```
 
 #### Required Data Connector configuration keys
 
-<PartDataConnectorRequiredKeysOverview data_connector_type="ConfiguredAssetSqlDataConnector" data_connector_name="version-0.18 name_of_my_configured_data_connector" inferred={false} configured={true} runtime={false} />
+<PartDataConnectorRequiredKeysOverview data_connector_type="ConfiguredAssetSqlDataConnector" data_connector_name="name_of_my_configured_data_connector" inferred={false} configured={true} runtime={false} />
 
 For this example, you will be using the `ConfiguredAssetSqlDataConnector` as your `class_name`.  This is a subclass of the `ConfiguredAssetDataConnector` that is specialized to support SQL Execution Engines, such as the `SqlAlchemyExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 define data_connector class_name for configured sql datasource"
+```python name="define data_connector class_name for configured sql datasource"
 ```
 
 <TipCustomDataConnectorModuleName />
 
 With this value added, along with a blank dictionary for `assets`, your full configuration should now look like:
 
-```python name="version-0.18 configured sql datasource configuration with data_connector class_name defined"
+```python name="configured sql datasource configuration with data_connector class_name defined"
 ```
 
 #### Optional Data Connector configuration keys for splitting Data Assets into Batches

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_tab_data_connector_example_configurations_inferred.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/datasource_configuration/sql_components/_tab_data_connector_example_configurations_inferred.mdx
@@ -6,27 +6,27 @@ import NoteOptionalDataConnectorKeys from './_note_optional_data_connector_keys.
 
 <TipInferredDataConnectorOverview />
 
-<PartNameTheDataConnector data_connector_name="version-0.18 name_of_my_inferred_data_connector" />
+<PartNameTheDataConnector data_connector_name="name_of_my_inferred_data_connector" />
 
 At this point, your configuration should look like:
 
-```python name="version-0.18 sql datasource configuration with empty inferred sql data_connector"
+```python name="sql datasource configuration with empty inferred sql data_connector"
 ```
 
 #### Required Data Connector configuration keys
 
-<PartDataConnectorRequiredKeysOverview data_connector_type="InferredAssetSqlDataConnector" data_connector_name="version-0.18 name_of_my_inferred_data_connector" inferred={true} configured={false} runtime={false} />
+<PartDataConnectorRequiredKeysOverview data_connector_type="InferredAssetSqlDataConnector" data_connector_name="name_of_my_inferred_data_connector" inferred={true} configured={false} runtime={false} />
 
 For this example, you will be using the `InferredAssetSqlDataConnector` as your `class_name`.  This is a subclass of the `InferredAssetDataConnector` that is specialized to support SQL Execution Engines, such as the `SqlAlchemyExecutionEngine`.  This key/value entry will therefore look like:
 
-```python name="version-0.18 define data_connector class_name for inferred sql datasource"
+```python name="define data_connector class_name for inferred sql datasource"
 ```
 
 <TipCustomDataConnectorModuleName />
 
 With this value added your full configuration should now look like:
 
-```python name="version-0.18 inferred sql datasource configuration with data_connector class_name defined"
+```python name="inferred sql datasource configuration with data_connector class_name defined"
 ```
 
 #### Optional Data Connector configuration key for defining introspection behaviour

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/batch_requests/how_to_request_data_from_a_data_asset.md
@@ -40,7 +40,7 @@ An `options` dictionary can be used to limit the Batches returned by a Batch Req
 
 The structure of the `options` dictionary will depend on the type of Data Asset being used.  The valid keys for the `options` dictionary can be found by checking the Data Asset's `batch_request_options` property.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request_options"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request_options"
 ```
 
 The `batch_request_options` property is a tuple that contains all the valid keys that can be used to limit the Batches returned in a Batch Request.
@@ -51,12 +51,12 @@ You can create a dictionary of keys pulled from the `batch_request_options` tupl
 
 Use the `build_batch_request(...)` method of your Data Asset to generate a Batch Request.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request"
 ```
 
 For `dataframe` Data Assets, the `dataframe` is always specified as the argument of exactly one API method:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe"
 ```
 
 ## Extract a Batch from a Batch Request (Optional)
@@ -65,27 +65,27 @@ You can use the Python slice function to remove a subset of data from a Batch Re
 
 1. Run the following code to retrieve an entire table of data from a SQL datasource:
 
-    ```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource"
+    ```python name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource"
     ```
 2. Run the following code to define the column to slice:
 
-    ```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py add_vendor_id_splitter"
+    ```python name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py add_vendor_id_splitter"
     ```
 3. Run the following code to slice and filter the column:
 
-    ```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py build_vendor_id_batch_request"
+    ```python name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py build_vendor_id_batch_request"
     ```
 
 ## Verify that the correct Batches were returned
 
 The `get_batch_list_from_batch_request(...)` method will return a list of the Batches a given Batch Request refers to.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_list"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_list"
 ```
 
 Because Batch definitions are quite verbose, it is easiest to determine what data the Batch Request will return by printing just the `batch_spec` of each Batch.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py print_batch_spec"
+```python name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py print_batch_spec"
 ```
 
 ## Next steps

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset.md
@@ -43,7 +43,7 @@ For this guide, we will use a previously defined Data Source named `"my_datasour
 
 To retrieve this Data Source, we will supply the `get_datasource(...)` method of our Data Context with the name of the Data Source we wish to retrieve:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_datasource"
 ```
 
 ## Create a `batching_regex`
@@ -57,7 +57,7 @@ For this example, our Data Source points to a folder that contains the following
 
 To create a `batching_regex` that matches multiple files, we will include a named group in our regular expression:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batching_regex"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batching_regex"
 ```
 
 In the above example, the named group "`year`" will match any four numeric characters in a file name.  This will result in each of our Data Source files matching the regular expression.
@@ -78,7 +78,7 @@ For more information on how to format regular expressions, we recommend referenc
 
 Now that we have put together a regular expression that will match one or more of the files in our Data Source's `base_folder`, we can use it to create our Data Asset.  Since the files in this particular Data Source's `base_folder` are csv files, we will use the `add_pandas_csv(...)` method of our Data Source to create the new Data Asset:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_asset"
 ```
 
 :::tip What if I don't provide a `batching_regex`?
@@ -97,19 +97,19 @@ When there are multiple named groups, we can include multiple items in our sorte
 
 In this example we have two named groups, `"year"` and `"month"`, so our list of sorters can have up to two elements.  We will add an ascending sorter based on the contents of the regex group `"year"` and a descending sorter based on the contents of the regex group `"month"`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py add_sorters"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py add_sorters"
 ```
 
 ## Use a Batch Request to verify the Data Asset works as desired
 
 To verify that our Data Asset will return the desired files as Batches, we will define a quick Batch Request that will include all the Batches available in the Data asset.  Then we will use that Batch Request to get a list of the returned Batches.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batch_list"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batch_list"
 ```
 
 Because a Batch List contains a lot of metadata, it will be easiest to verify which files were included in the returned Batches if we only look at the `batch_spec` of each returned Batch:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py print_batch_spec"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py print_batch_spec"
 ```
 
 ## Related documentation

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_sql_based_data_asset.md
@@ -73,14 +73,14 @@ For this guide, we will use a previously defined SQL Data Source named `"my_data
 
 To retrieve this Data Source, we will supply the `get_datasource(...)` method of our Data Context with the name of the Data Source we wish to retrieve:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource"
 ```
 
 ### 3. Add a Splitter to the Data Asset
 
 Our table has a datetime column called "`pickup_datetime`" which we will use to split our TableAsset into Batches.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month"
 ```
 
 ### 4. (Optional) Add Batch Sorters to the Data Asset
@@ -89,19 +89,19 @@ We will now add Batch Sorters to our Data Asset.  This will allow us to explicit
 
 In this example we split `"pickup_datetime"` column on `"year"` and `"month"`, so our list of sorters can have up to two elements.  We will add an ascending sorter based on the contents of the splitter group `"year"` and a descending sorter based on the contents of the splitter group `"month"`:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters"
 ```
 
 ### 5. Use a Batch Request to verify the Data Asset works as desired
 
 To verify that our Data Asset will return the desired files as Batches, we will define a quick Batch Request that will include all the Batches available in the Data asset.  Then we will use that Batch Request to get a list of the returned Batches.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list"
 ```
 
 Because a Batch List contains a lot of metadata, it will be easiest to verify which files were included in the returned Batches if we only look at the `batch_spec` of each returned Batch:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec"
 ```
 
 ## Next steps

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py
@@ -21,35 +21,35 @@ context = gx.get_context()
 
 # data_directory is the full path to a directory containing csv files
 context.sources.add_pandas_filesystem(
-    name="version-0.18 my_datasource", base_directory=data_directory
+    name="my_datasource", base_directory=data_directory
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_datasource">
 my_datasource = context.get_datasource("my_datasource")
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batching_regex">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batching_regex">
 my_batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_asset">
 my_asset = my_datasource.add_csv_asset(
-    name="version-0.18 my_taxi_data_asset", batching_regex=my_batching_regex
+    name="my_taxi_data_asset", batching_regex=my_batching_regex
 )
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py add_sorters">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py add_sorters">
 my_asset = my_asset.add_sorters(["+year", "-month"])
 # </snippet>
 
 assert my_asset.batch_request_options == ("year", "month", "path")
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batch_list">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py my_batch_list">
 my_batch_request = my_asset.build_batch_request()
 batches = my_asset.get_batch_list_from_batch_request(my_batch_request)
 # </snippet>
@@ -67,7 +67,7 @@ for batch in batches:
     assert batch.data.dataframe.shape == (10000, 18)
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py print_batch_spec">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/data_assets/organize_batches_in_pandas_filesystem_datasource.py print_batch_spec">
 for batch in batches:
     print(batch.batch_spec)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/connect_sql_source_data.md
@@ -76,7 +76,7 @@ For more information on both methods, see [Account Identifiers](https://docs.sno
 1. Run the following Python code to set the `name` and `connection_string` variables:
 
     ```python
-    datasource_name = "version-0.18 my_snowflake_datasource"
+    datasource_name = "my_snowflake_datasource"
     ```
 
 2. Run the following Python code to create a Snowflake Data Source:
@@ -115,8 +115,8 @@ For more information, check out Snowflake's official documentation on [the Snowf
 1. Run the following Python code to set the `asset_name` and `asset_table_name` variables:
 
     ```python
-    asset_name = "version-0.18 my_asset"
-    asset_table_name = "version-0.18 my_table_name"
+    asset_name = "my_asset"
+    asset_table_name = "my_table_name"
     ```
 
 2. Run the following Python code to create the Data Asset:
@@ -130,7 +130,7 @@ For more information, check out Snowflake's official documentation on [the Snowf
 1. Run the following Python code to define a Query Data Asset:
 
     ```python
-    asset_name = "version-0.18 my_query_asset"
+    asset_name = "my_query_asset"
     query = "SELECT * from yellow_tripdata_sample_2019_01"
     ```
 2. Run the following Python code to create the Data Asset:
@@ -170,7 +170,7 @@ The following code examples use a PostgreSQL connection string. A PostgreSQL con
 
 The following code is an example of a PostgreSQL connection string format:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string"
 ```
 
 :::tip Is there a more secure way to store my credentials than plain text in a connection string?
@@ -183,12 +183,12 @@ The following code is an example of a PostgreSQL connection string format:
 
 1. Run the following Python code to set the `name` and `connection_string` variables:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string2"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string2"
     ```
 
 2. Run the following Python code to create a PostgreSQL Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_postgres"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_postgres"
     ```
 
 ### Connect to a specific set of data with a Data Asset
@@ -207,24 +207,24 @@ Although there isn't a maximum number of Data Assets you can define for a Data S
 
 1. Run the following Python code to identify the table to connect to with a Table Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_name"
     ```
 
 2.  Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_table_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_table_asset"
     ```
 
 ### Connect a Data Asset to the data returned by a query (Optional)
 
 1. Run the following Python code to define a Query Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_query"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_query"
     ```
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_query_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_query_asset"
     ```
 
 ### Connect to additional tables or queries (Optional)
@@ -257,19 +257,19 @@ The following code examples use a SQLite connection string. A SQLite connection 
 
 The following code is an example of a SQLite connection string format:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py connection_string"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py connection_string"
 ```
 
 ### Create a SQLite Data Source
 
 1. Run the following Python code to set the `name` and `connection_string` variables:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource_name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource_name"
     ```
 
 2. Run the following Python code to create a SQLite Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource"
     ```
 
     :::caution Using `add_sql(...)` instead of `add_sqlite(...)`
@@ -285,23 +285,23 @@ The following code is an example of a SQLite connection string format:
 
 1. Run the following Python code to set the `asset_name` and `asset_table_name` variables:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name"
     ```
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset"
     ```
 
 ### Connect to the data in a query (Optional)
 
 1. Run the following Python code to define a Query Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query"
     ```
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset"
     ```
 
 ### Add additional tables or queries (Optional)
@@ -344,7 +344,7 @@ my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?htt
 1. Run the following Python code to set the `name` and `connection_string` variables:
 
     ```python
-    datasource_name = "version-0.18 my_databricks_sql_datasource"
+    datasource_name = "my_databricks_sql_datasource"
     ```
 
 2. Run the following Python code to create a Snowflake Data Source:
@@ -361,7 +361,7 @@ my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?htt
 1. Run the following Python code to set the `asset_name` and `asset_table_name` variables:
 
     ```python
-    asset_name = "version-0.18 my_asset"
+    asset_name = "my_asset"
     asset_table_name = my_table_name
     ```
 
@@ -376,7 +376,7 @@ my_connection_string = f"databricks://token:{token}@{host}:{port}/{database}?htt
 1. Run the following Python code to define a Query Data Asset:
 
     ```python
-    asset_name = "version-0.18 my_query_asset"
+    asset_name = "my_query_asset"
     query = "SELECT * from yellow_tripdata_sample_2019_01"
     ```
 2. Run the following Python code to create the Data Asset:
@@ -453,7 +453,7 @@ pip install great-expectations --upgrade
 
 Run the following code to create a new <TechnicalTag relative="../../../" tag="data_context" text="Data Context" />: 
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py get_context"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py get_context"
 ```
 
 The `full_path_to_project_directory` parameter can be an empty directory where you intend to build your GX configuration.
@@ -472,24 +472,24 @@ The code examples are located in the [`great-expectations` repository](https://g
 
 By default, newly profiled Expectations are stored in JSON format in the `expectations/` subdirectory of your `gx/` folder. A new Expectations Store can be configured by adding the following lines to your `great_expectations.yml` file. Replace the `project`, `bucket` and `prefix` with your values.
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_expectation_store"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_expectation_store"
 ```
 
 To configure GX to use this new Expectations Store, `expectations_GCS_store`, set the `expectations_store_name` value in the `great_expectations.yml` file.
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_expectation_store"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_expectation_store"
 ```
 
 ### Add a Validations Store
 
 By default, Validations are stored in JSON format in the `uncommitted/validations/` subdirectory of your `gx/` folder. You can connfigure a new Validations Store by adding the following lines to your `great_expectations.yml` file. Replace the `project`, `bucket` and `prefix` with your values.
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_validations_store"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_validations_store"
 ```
 
 To configure GX to use the new `validations_GCS_store` Validations Store, set the `validations_store_name` value in the `great_expectations.yml` file.
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_validations_store"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_validations_store"
 ```
 
 ### Add a Data Docs Store
@@ -498,7 +498,7 @@ To host and share Data Docs on GCS, see [Host and share Data Docs](../../../setu
 
 After you have hosted and shared Data Docs, your `great-expectations.yml` contains the following configuration below `data_docs_sites`:
 
-```YAML name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_data_docs_store"
+```YAML name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_data_docs_store"
 ```
 
 Run the following command in the gcloud CLI to view the deployed DataDocs site:
@@ -524,7 +524,7 @@ Connect to a GCS or BigQuery Data Source.
 
 Run the following code to add the name of your GCS bucket to the `add_pandas_gcs` function:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py datasource"
 ```
 
 In the example, you've added a Data Source that connects to data in GCS using a Pandas dataframe. The name of the new datasource is `gcs_datasource` and it refers to a GCS bucket named `test_docs_data`.
@@ -540,7 +540,7 @@ Tables that are created by BigQuery queries are automatically set to expire afte
 
 Run the following code to create a Data Source that connects to data in BigQuery:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_datasource"
 ```
 
 In the example, you created a Data Source named `my_bigquery_datasource`, using the `add_or_update_sql` method and passed it in a connection string.
@@ -562,7 +562,7 @@ Use the `add_csv_asset` function to add a CSV `Asset` to your `Data Source`.
 
 Configure the `prefix` and `batching_regex`. The `prefix` is the path to the GCS bucket where the files are located. `batching_regex` is a regular expression that indicates which files should be treated as Batches in the Asset, and how to identify them. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py prefix_and_batching_regex"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py prefix_and_batching_regex"
 ```
 
 In the example, the pattern `r"data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"` builds a Batch for the following files in the GCS bucket:
@@ -576,7 +576,7 @@ The `batching_regex` pattern matches the four digits of the year portion and ass
 
 Run the following code to use the `add_csv_asset` function to add an `Asset` named `csv_taxi_gcs_asset` to your Data Source: 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py asset"
 ```
 
 </TabItem>
@@ -586,12 +586,12 @@ You can add a BigQuery `Asset` into your `Data Source` as a table asset or query
 
 In the following example, a table `Asset` named `my_table_asset` is built by naming the table in your BigQuery Database. 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_table_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_table_asset"
 ```
 
 In the following example, a query `Asset` named `my_query_asset` is built by submitting a query to the `taxi_data` table.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_query_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_query_asset"
 ```
 
 </TabItem>
@@ -610,18 +610,18 @@ In the following example, a query `Asset` named `my_query_asset` is built by sub
 
 1. Use the `add_or_update_expectation_suite` method on your Data Context to create an Expectation Suite:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py add_expectation_suite"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py add_expectation_suite"
     ```
 
 2. Use the `Validator` method to run Expectations on the Batch and automatically add them to the Expectation Suite. 
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py validator_calls"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py validator_calls"
     ```
     In this example, you're adding `expect_column_values_to_not_be_null` and `expect_column_values_to_be_between`. You can replace the `passenger_count` and `congestion_surcharge` test data columns with your own data columns.
 
 3. Run the following code to save the Expectation Suite:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py save_expectation_suite"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py save_expectation_suite"
     ```
 
 </TabItem>
@@ -629,24 +629,24 @@ In the following example, a query `Asset` named `my_query_asset` is built by sub
 
 1. Use the `table_asset` you created previously to build a `BatchRequest`: 
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py batch_request"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py batch_request"
     ```
 
 2. Use the `add_or_update_expectation_suite` method on your Data Context to create an Expectation Suite and get a `Validator`: 
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_or_update_expectation_suite"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_or_update_expectation_suite"
     ```
 
 3. Use the `Validator` to run expectations on the batch and automatically add them to the Expectation Suite: 
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py validator_calls"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py validator_calls"
     ```
     In this example, you're adding `expect_column_values_to_not_be_null` and `expect_column_values_to_be_between`. You can replace the `passenger_count` and `congestion_surcharge` test data columns with your own data columns.
     
     
 4. Run the following code to save the Expectation Suite containing the two Expectations:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py save_expectation_suite"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py save_expectation_suite"
     ```
 
 </TabItem>
@@ -665,13 +665,13 @@ In the following example, a query `Asset` named `my_query_asset` is built by sub
 
 1. Run the following code to add the `gcs_checkpoint` Checkpoint to the Data Context:  
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py checkpoint"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py checkpoint"
     ```
     In this example, you're using the `BatchRequest` and `ExpectationSuite` names that you used when you created your Validator.
 
 2. Run the Checkpoint by calling `checkpoint.run()`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py run_checkpoint"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py run_checkpoint"
     ```
 
 </TabItem>
@@ -679,13 +679,13 @@ In the following example, a query `Asset` named `my_query_asset` is built by sub
 
 1. Run the following code to add the `bigquery_checkpoint` Checkpoint to the Data Context:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py checkpoint"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py checkpoint"
     ```
     In this example, you're using the `BatchRequest` and `ExpectationSuite` names that you used when you created your Validator.
 
 2. Run the Checkpoint by calling `checkpoint.run()`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py run_checkpoint"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py run_checkpoint"
     ```
 
 </TabItem>
@@ -759,7 +759,7 @@ To migrate your local configuration, you can move the local `gx/` folder to the 
 
 1. Run the following code to create a DAG with a single node (`t1`) that runs a `BashOperator`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py full"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py full"
     ```
     The DAG is stored in a file named: [`ge_checkpoint_gcs.py`](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py)
 
@@ -784,7 +784,7 @@ To add the DAG to Cloud Composer, you move `ge_checkpoint_gcs.py` to the environ
 
 1. Run the following code to create a DAG with a single node (`t1`) that runs a `BashOperator`
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py full"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py full"
     ```
     The DAG is stored in a file named: [`ge_checkpoint_bigquery.py`](https://github.com/great-expectations/great_expectations/blob/develop/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py)
 
@@ -870,14 +870,14 @@ The following are some of the connection strings that are available for differen
 
 Run one of the connection strings in your preferred SQL dialect to store the connection string in the `connection_string` variable with plain text credentials. The following code is an example of the PostgreSQL connection string format:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py sql_connection_string"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py sql_connection_string"
 ```
 
 :::tip Is there a more secure way to include my credentials?
 
 You can use environment variables or a key in `config_variables.yml` to store connection string passwords.  After you define your password, you reference it in your connection string similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py connection_string"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py connection_string"
 ```
 
 In the previous example `MY_PASSWORD` is the name of the environment variable, or the key to the value in `config_variables.yml` that corresponds to your password.
@@ -890,30 +890,30 @@ If you include a password as plain text in your connection string when you defin
 
 Run the following Python code to create a SQL Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py add_sql"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py add_sql"
 ```
 
 ### Connect to the data in a table (Optional)
 
 1. Run the following Python code to set the `asset_name` and `asset_table_name` variables:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name"
     ```
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset"
     ```
 
 ### Connect to the data in a query (Optional)
 
 1. Run the following Python code to define a Query Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query"
     ```
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset"
     ```
 
 ### Add additional tables or queries (Optional)

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py
@@ -11,7 +11,7 @@ temp_dir = tempfile.TemporaryDirectory()
 full_path_to_project_directory = pathlib.Path(temp_dir.name).resolve()
 yaml: YAMLHandler = YAMLHandler()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py get_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py get_context">
 import great_expectations as gx
 
 context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
@@ -51,7 +51,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
 ]
 
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py existing_expectations_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py existing_expectations_store">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -225,66 +225,62 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 CONNECTION_STRING = f"bigquery://{GCP_PROJECT_NAME}/{BIGQUERY_DATASET}"
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_datasource">
 datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_bigquery_datasource",
+    name="my_bigquery_datasource",
     connection_string="bigquery://<GCP_PROJECT_NAME>/<BIGQUERY_DATASET>",
 )
 # </snippet>
 
 # For tests, we are replacing the `connection_string`
 datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_bigquery_datasource", connection_string=CONNECTION_STRING
+    name="my_bigquery_datasource", connection_string=CONNECTION_STRING
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_table_asset">
-table_asset = datasource.add_table_asset(
-    name="my_table_asset", table_name="version-0.18 taxi_data"
-)
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_table_asset">
+table_asset = datasource.add_table_asset(name="my_table_asset", table_name="taxi_data")
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_query_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_bigquery_query_asset">
 query_asset = datasource.add_query_asset(
-    name="version-0.18 my_query_asset", query="SELECT * from taxi_data"
+    name="my_query_asset", query="SELECT * from taxi_data"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py batch_request">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py batch_request">
 request = table_asset.build_batch_request()
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_or_update_expectation_suite">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_bigquery_suite"
-)
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py add_or_update_expectation_suite">
+context.add_or_update_expectation_suite(expectation_suite_name="test_bigquery_suite")
 
 validator = context.get_validator(
-    batch_request=request, expectation_suite_name="version-0.18 test_bigquery_suite"
+    batch_request=request, expectation_suite_name="test_bigquery_suite"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py validator_calls">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py validator_calls">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 validator.expect_column_values_to_be_between(
     column="congestion_surcharge", min_value=0, max_value=1000
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py save_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py save_expectation_suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 bigquery_checkpoint",
+    name="bigquery_checkpoint",
     validations=[
         {"batch_request": request, "expectation_suite_name": "test_bigquery_suite"}
     ],
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py run_checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_bigquery.py run_checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 assert checkpoint_result.success is True

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py
@@ -12,7 +12,7 @@ full_path_to_project_directory = pathlib.Path(temp_dir.name).resolve()
 
 yaml = YAMLHandler()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py get_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py get_context">
 import great_expectations as gx
 
 context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
@@ -51,7 +51,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
     "expectations_store_name"
 ]
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_expectation_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_expectation_store">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -69,7 +69,7 @@ assert actual_existing_expectations_store == yaml.load(
 
 # adding expectations store
 configured_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_expectation_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_expectation_store">
 stores:
   expectations_GCS_store:
     class_name: ExpectationsStore
@@ -137,7 +137,7 @@ actual_existing_validations_store["validations_store_name"] = great_expectations
 ]
 
 expected_existing_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_validations_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py expected_validations_store">
 stores:
   validations_store:
     class_name: ValidationsStore
@@ -154,7 +154,7 @@ assert actual_existing_validations_store == yaml.load(
 
 # adding validations store
 configured_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_validations_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_validations_store">
 stores:
   validations_GCS_store:
     class_name: ValidationsStore
@@ -196,7 +196,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
 
 # adding data docs store
 data_docs_site_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_data_docs_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py new_data_docs_store">
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
@@ -234,27 +234,27 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 # adding datasource
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py datasource">
 datasource = context.sources.add_pandas_gcs(
-    name="gcs_datasource", bucket_or_name="version-0.18 test_docs_data"
+    name="gcs_datasource", bucket_or_name="test_docs_data"
 )
 # </snippet>
 
 ### Add GCS data to the Datasource as a Data Asset
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py prefix_and_batching_regex">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py prefix_and_batching_regex">
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 prefix = "data/taxi_yellow_tripdata_samples/"
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py asset">
 data_asset = datasource.add_csv_asset(
-    name="version-0.18 csv_taxi_gcs_asset",
+    name="csv_taxi_gcs_asset",
     batching_regex=batching_regex,
     gcs_prefix=prefix,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py batch_request">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py batch_request">
 batch_request = data_asset.build_batch_request(
     options={
         "month": "03",
@@ -262,20 +262,18 @@ batch_request = data_asset.build_batch_request(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py add_expectation_suite">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_gcs_suite"
-)
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py add_expectation_suite">
+context.add_or_update_expectation_suite(expectation_suite_name="test_gcs_suite")
 
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_gcs_suite"
+    batch_request=batch_request, expectation_suite_name="test_gcs_suite"
 )
 # </snippet>
 
 # NOTE: The following code is only for testing and can be ignored by users.
 assert isinstance(validator, gx.validator.validator.Validator)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py validator_calls">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py validator_calls">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 
 validator.expect_column_values_to_be_between(
@@ -283,13 +281,13 @@ validator.expect_column_values_to_be_between(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py save_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py save_expectation_suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 gcs_checkpoint",
+    name="gcs_checkpoint",
     validations=[
         {"batch_request": batch_request, "expectation_suite_name": "test_gcs_suite"}
     ],
@@ -297,7 +295,7 @@ checkpoint = context.add_or_update_checkpoint(
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py run_checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/gcp_deployment_patterns_file_gcs.py run_checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py
@@ -1,4 +1,4 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py full">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_bigquery.py full">
 from datetime import timedelta
 
 import airflow

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py
@@ -1,4 +1,4 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py full">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/ge_checkpoint_gcs.py full">
 from datetime import timedelta
 
 import airflow

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py
@@ -30,7 +30,7 @@ csv_path = str(
 )
 
 load_data_into_test_database(
-    table_name="version-0.18 postgres_taxi_data",
+    table_name="postgres_taxi_data",
     csv_path=csv_path,
     connection_string=PG_CONNECTION_STRING,
     load_full_dataset=True,
@@ -44,15 +44,15 @@ assert len(df) == 10000
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string">
 my_connection_string = (
     "postgresql+psycopg2://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>"
 )
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string2">
-datasource_name = "version-0.18 my_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py connection_string2">
+datasource_name = "my_datasource"
 my_connection_string = (
     "postgresql+psycopg2://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>"
 )
@@ -61,31 +61,31 @@ my_connection_string = (
 my_connection_string = PG_CONNECTION_STRING
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_postgres">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_postgres">
 datasource = context.sources.add_postgres(
     name=datasource_name, connection_string=my_connection_string
 )
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_name">
-asset_name = "version-0.18 my_table_asset"
-asset_table_name = "version-0.18 postgres_taxi_data"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_name">
+asset_name = "my_table_asset"
+asset_table_name = "postgres_taxi_data"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_table_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_table_asset">
 table_asset = datasource.add_table_asset(name=asset_name, table_name=asset_table_name)
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_query">
-asset_name = "version-0.18 my_query_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py asset_query">
+asset_name = "my_query_asset"
 asset_query = "SELECT * from postgres_taxi_data"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_query_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_postgresql_data.py add_query_asset">
 query_asset = datasource.add_query_asset(name=asset_name, query=asset_query)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py
@@ -23,15 +23,15 @@ sqlite_database_path = str(
     ).resolve(strict=True)
 )
 
-my_table_name = "version-0.18 yellow_tripdata_sample_2019_01"
+my_table_name = "yellow_tripdata_sample_2019_01"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py sql_connection_string">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py sql_connection_string">
 connection_string = "postgresql+psycopg2://username:my_password@localhost/test"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py connection_string">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py connection_string">
 connection_string = (
     "postgresql+psycopg2://<USERNAME>:${MY_PASSWORD}@<HOST>:<PORT>/<DATABASE>"
 )
@@ -40,16 +40,16 @@ connection_string = (
 connection_string = f"sqlite:///{sqlite_database_path}"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py add_sql">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data.py add_sql">
 datasource = context.sources.add_sql(
-    name="version-0.18 my_datasource", connection_string=connection_string
+    name="my_datasource", connection_string=connection_string
 )
 # </snippet>
 
 assert datasource
 assert datasource.name == "my_datasource"
 
-asset_name = "version-0.18 my_asset"
+asset_name = "my_asset"
 datasource.add_table_asset(name=asset_name, table_name=my_table_name)
 
 assert datasource.get_asset_names() == {asset_name}

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py
@@ -31,20 +31,20 @@ with warnings.catch_warnings():
     # TODO: Remove create_temp_table=True once the bug fix goes in to develop that's equivalent of this PR for 0.18.6:
     #       https://github.com/great-expectations/great_expectations/pull/9148
     datasource = context.sources.add_sql(
-        name="version-0.18 my_datasource",
+        name="my_datasource",
         connection_string=connection_string,
         create_temp_table=True,
     )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py datasource">
 datasource = context.get_datasource("my_datasource")
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py add_query_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py add_query_asset">
 query_asset = datasource.add_query_asset(
-    name="version-0.18 my_asset",
+    name="my_asset",
     query="SELECT passenger_count, total_amount FROM yellow_tripdata_sample_2019_01",
 )
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py
@@ -22,24 +22,24 @@ sqlite_database_path = str(
     ).resolve(strict=True)
 )
 
-my_table_name = "version-0.18 yellow_tripdata_sample_2019_01"
+my_table_name = "yellow_tripdata_sample_2019_01"
 
 
 import great_expectations as gx
 
 context = gx.get_context()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py connection_string">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py connection_string">
 my_connection_string = "sqlite:///<PATH_TO_DB_FILE>"
 # </snippet>
 
 my_connection_string = f"sqlite:///{sqlite_database_path}"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource_name">
-datasource_name = "version-0.18 my_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource_name">
+datasource_name = "my_datasource"
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py datasource">
 datasource = context.sources.add_sqlite(
     name=datasource_name, connection_string=my_connection_string
 )
@@ -50,23 +50,23 @@ assert "name: my_datasource" in str(datasource)
 assert "type: sqlite" in str(datasource)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name">
-asset_name = "version-0.18 my_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_name">
+asset_name = "my_asset"
 asset_table_name = my_table_name
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py table_asset">
 table_asset = datasource.add_table_asset(name=asset_name, table_name=asset_table_name)
 # </snippet>
 
 assert table_asset
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query">
-asset_name = "version-0.18 my_query_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py asset_query">
+asset_name = "my_query_asset"
 query = "SELECT * from yellow_tripdata_sample_2019_01"
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sqlite_data.py query_table_asset">
 query_asset = datasource.add_query_asset(name=asset_name, query=query)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/sql_data_assets.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/database/sql_data_assets.md
@@ -59,7 +59,7 @@ The following code examples use a previously defined Data Source named `"my_data
 
 Run the following Python code to retrieve the Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py datasource"
+```python name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py datasource"
 ```
 
 ### Add a table to the Data Source as a Data Asset
@@ -68,7 +68,7 @@ You create a Data Asset to identify the table to connect to.
 
 Run the following Python code to define the `name` and `table_name` variables:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource"
+```python name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource"
 ```
 
 ### Add additional tables (Optional)
@@ -107,14 +107,14 @@ The following code examples use a previously defined Data Source named `"my_data
 
 Run the following Python code to retrieve the Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py datasource"
 ```
 
 ### Add a query to the Data Source as a Data Asset
 
 Run the following Python code to define a Data Asset and the `name` and `query` variables:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py add_query_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/database/how_to_connect_to_sql_data_using_a_query.py add_query_asset"
 ```
 
 ### Add additional queries (Optional)
@@ -154,14 +154,14 @@ The following code examples use a previously defined Data Source named `"my_data
 
 Run the following Python code to retrieve the Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource"
 ```
 
 ### Add a Splitter to the Data Asset
 
 Run the following Python code to split the TableAsset into Batches:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month"
 ```
 
 ### Add Batch Sorters to the Data Asset (Optional) 
@@ -170,19 +170,19 @@ Adding Batch Sorters to your Data Asset lets you explicitly state the order in w
 
 Run the following Python code to split the `"pickup_datetime"` column on `"year"` and `"month"`, so your list of sorters can have up to two elements. The code also adds an ascending sorter based on the contents of the splitter group `"year"` and a descending sorter based on the contents of the splitter group `"month"`:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters"
 ```
 
 ### Use a Batch Request to verify Data Asset functionality
 
 Run the following Python code to verify that your Data Asset returns the necessary files as Batches:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list"
 ```
 
 A Batch List can contain a lot of metadata. To verify which files were included in the returned Batches, run the following Python code to review the `batch_spec` for each returned Batch:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec"
+```python name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec"
 ```
 
 ### Related documentation

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
@@ -77,7 +77,7 @@ The following information is required when you create an Amazon S3 Data Source:
 
 1. Run the following Python code to define `name`, `bucket_name` and `boto3_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py define_add_pandas_s3_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py define_add_pandas_s3_args"
     ```
 
     :::tip Additional options for `boto3_options`
@@ -90,14 +90,14 @@ The following information is required when you create an Amazon S3 Data Source:
 
 2. Run the following Python code to pass `name`, `bucket_name`, and `boto3_options` as parameters when you create your Data Source::
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py create_datasource"
     ```
 
 ### Add data to the Data Source as a Data Asset
 
 Run the following Python code:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py add_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py add_asset"
 ```
 
 <BatchingRegexExplaination storage_location_type="S3 bucket" />
@@ -136,7 +136,7 @@ The following information is required when you create an Amazon S3 Data Source:
 
 1. Run the following Python code to define `name`, `bucket_name`, and `boto3_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py define_add_spark_s3_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py define_add_spark_s3_args"
     ```
 
     :::tip Additional options for `boto3_options`
@@ -149,14 +149,14 @@ The following information is required when you create an Amazon S3 Data Source:
 
 2. Run the following Python code to pass `name`, `bucket_name`, and `boto3_options` as parameters when you create your Data Source::
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py create_datasource"
     ```
 
 ### Add data to the Data Source as a Data Asset
 
 Run the following Python code:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py add_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py add_asset"
 ```
 
 <BatchingRegexExplaination storage_location_type="S3 bucket" />
@@ -208,11 +208,11 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 1. Run the following Python code to define `name` and `azure_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py define_add_pandas_abs_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py define_add_pandas_abs_args"
     ```
 2. Run the following Python code to pass `name` and `azure_options` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py create_datasource"
     ```
 
     :::tip Where did that connection string come from?
@@ -225,7 +225,7 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py add_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py add_asset"
     ```
 
 <AbsBatchingRegexExample />
@@ -262,11 +262,11 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 1. Run the following Python code to define `name` and `azure_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py define_add_spark_abs_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py define_add_spark_abs_args"
     ```
 2. Run the following Python code to pass `name` and `azure_options` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py create_datasource"
     ```
 
     :::tip Where did that connection string come from?
@@ -279,7 +279,7 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py add_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py add_asset"
     ```
 
 <AbsBatchingRegexExample />
@@ -333,19 +333,19 @@ The following information is required when you create a GCS Data Source:
 
 1. Run the following Python code to define `name`, `bucket_or_name`, and `gcs_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py define_add_pandas_gcs_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py define_add_pandas_gcs_args"
     ```
 
 2. Run the following Python code to pass `name`, `bucket_or_name`, and `gcs_options` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py create_datasource"
     ```
 
 ### Add GCS data to the Data Source as a Data Asset
 
 Run the following Python code:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py add_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py add_asset"
 ```
 
 <BatchingRegexExplaination storage_location_type="GCS bucket" />
@@ -391,19 +391,19 @@ The following information is required when you create a GCS Data Source:
 
 1. Run the following Python code to define `name`, `bucket_or_name`, and `gcs_options`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py define_add_spark_gcs_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py define_add_spark_gcs_args"
     ```
 
 2. Run the following Python code to pass `name`, `bucket_or_name`, and `gcs_options` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py create_datasource"
     ```
 
 ### Add GCS data to the Data Source as a Data Asset
 
 Run the following Python code:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py add_asset"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py add_asset"
 ```
 
 :::info Optional parameters: `header` and `infer_schema`
@@ -462,7 +462,7 @@ Connect to filesystem Data Assets.
 
 Run the following Python code to read the data in individual files directly into a Validator with Pandas:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py get_validator"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py get_validator"
 ```
 
 <InfoUsingPandasToConnectToDifferentFileTypes this_example_file_extension="csv"/>
@@ -522,14 +522,14 @@ The following information is required when you create a Filesystem Data Source:
 
 1. Run the following Python code to define `name` and `base_directory` and store the information in the Python variables `datasource_name` and `path_to_folder_containing_csv_files`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_pandas_filesystem_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_pandas_filesystem_args"
     ```
 
 <InfoFilesystemDatasourceRelativeBasePaths />
 
 2. Run the following Python code to pass `name` and `base_directory` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource"
     ```
 
 <TipFilesystemDatasourceNestedSourceDataFolders />
@@ -546,12 +546,12 @@ A Data Asset requires the following information to be defined:
 
 1. Run the following Python code to define `name` and `batching_regex` and store the information in the Python variables `asset_name` and `batching_regex`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_csv_asset_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_csv_asset_args"
     ```
 
 2. Run the following Python code to pass `name` and `batching_regex` as parameters when you create your Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py add_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py add_asset"
     ```
 
     <TipUsingPandasToConnectToDifferentFileTypes this_example_file_extension="csv" />
@@ -596,14 +596,14 @@ The following information is required when you create a Filesystem Data Source:
 
 1. Run the following Python code to define `name` and `base_directory` and store the information in the Python variables `datasource_name` and `path_to_folder_containing_csv_files`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_spark_filesystem_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_spark_filesystem_args"
     ```
 
     <InfoFilesystemDatasourceRelativeBasePaths />
 
 2. Run the following Python code to pass `name` and `base_directory` as parameters when you create your Data Source:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py create_datasource"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py create_datasource"
     ```
 
     <TipFilesystemDatasourceNestedSourceDataFolders />
@@ -620,14 +620,14 @@ A Data Asset requires the following information to be defined:
 
 1. Run the following Python code to define `name` and `batching_regex` and store the information in the Python variables `asset_name` and `batching_regex`:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_csv_asset_args"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_csv_asset_args"
     ```
 
     In addition, the argument `header` informs the Spark `DataFrame` reader that the files contain a header column, while the argument `infer_schema` instructs the Spark `DataFrame` reader to make a best effort to determine the schema of the columns automatically.
 
 2. Run the following Python code to pass `name` and `batching_regex` and the optional `header` and `infer_schema` arguments as parameters when you create your Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py add_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py add_asset"
     ```
 
 ### Add additional files as Data Assets (Optional)

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
@@ -14,18 +14,18 @@ context = gx.get_context()
 os.environ["AZURE_STORAGE_ACCOUNT_URL"] = "superconductivetesting.blob.core.windows.net"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py define_add_pandas_abs_args">
-datasource_name = "version-0.18 my_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py define_add_pandas_abs_args">
+datasource_name = "my_datasource"
 azure_options = {
     "account_url": "${AZURE_STORAGE_ACCOUNT_URL}",
     "credential": "${AZURE_CREDENTIAL}",
 }
 # </snippet>
 
-bucket_or_name = "version-0.18 test_docs_data"
+bucket_or_name = "test_docs_data"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py create_datasource">
 datasource = context.sources.add_pandas_abs(
     name=datasource_name, azure_options=azure_options
 )
@@ -33,13 +33,13 @@ datasource = context.sources.add_pandas_abs(
 
 assert datasource_name in context.datasources
 
-asset_name = "version-0.18 my_taxi_data_asset"
+asset_name = "my_taxi_data_asset"
 abs_container = "superconductive-public"
 abs_name_starts_with = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py add_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py add_asset">
 data_asset = datasource.add_csv_asset(
     name=asset_name,
     batching_regex=batching_regex,

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
@@ -14,17 +14,17 @@ context = gx.get_context()
 os.environ["AZURE_STORAGE_ACCOUNT_URL"] = "superconductivetesting.blob.core.windows.net"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py define_add_spark_abs_args">
-datasource_name = "version-0.18 my_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py define_add_spark_abs_args">
+datasource_name = "my_datasource"
 azure_options = {
     "account_url": "${AZURE_STORAGE_ACCOUNT_URL}",
 }
 # </snippet>
 
-bucket_or_name = "version-0.18 test_docs_data"
+bucket_or_name = "test_docs_data"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py create_datasource">
 datasource = context.sources.add_spark_abs(
     name=datasource_name, azure_options=azure_options
 )
@@ -32,13 +32,13 @@ datasource = context.sources.add_spark_abs(
 
 assert datasource_name in context.datasources
 
-asset_name = "version-0.18 my_taxi_data_asset"
+asset_name = "my_taxi_data_asset"
 abs_container = "superconductive-public"
 abs_name_starts_with = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py add_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py add_asset">
 data_asset = datasource.add_csv_asset(
     name=asset_name,
     batching_regex=batching_regex,

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
@@ -10,16 +10,16 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py define_add_pandas_gcs_args">
-datasource_name = "version-0.18 my_gcs_datasource"
-bucket_or_name = "version-0.18 my_bucket"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py define_add_pandas_gcs_args">
+datasource_name = "my_gcs_datasource"
+bucket_or_name = "my_bucket"
 gcs_options = {}
 # </snippet>
 
-bucket_or_name = "version-0.18 test_docs_data"
+bucket_or_name = "test_docs_data"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py create_datasource">
 datasource = context.sources.add_pandas_gcs(
     name=datasource_name, bucket_or_name=bucket_or_name, gcs_options=gcs_options
 )
@@ -28,8 +28,8 @@ datasource = context.sources.add_pandas_gcs(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py add_asset">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py add_asset">
+asset_name = "my_taxi_data_asset"
 gcs_prefix = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 data_asset = datasource.add_csv_asset(

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
@@ -10,16 +10,16 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py define_add_spark_gcs_args">
-datasource_name = "version-0.18 my_gcs_datasource"
-bucket_or_name = "version-0.18 my_bucket"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py define_add_spark_gcs_args">
+datasource_name = "my_gcs_datasource"
+bucket_or_name = "my_bucket"
 gcs_options = {}
 # </snippet>
 
-bucket_or_name = "version-0.18 test_docs_data"
+bucket_or_name = "test_docs_data"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py create_datasource">
 datasource = context.sources.add_spark_gcs(
     name=datasource_name, bucket_or_name=bucket_or_name, gcs_options=gcs_options
 )
@@ -28,8 +28,8 @@ datasource = context.sources.add_spark_gcs(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py add_asset">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py add_asset">
+asset_name = "my_taxi_data_asset"
 gcs_prefix = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 data_asset = datasource.add_csv_asset(

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
@@ -10,16 +10,16 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py define_add_pandas_s3_args">
-datasource_name = "version-0.18 my_s3_datasource"
-bucket_name = "version-0.18 my_bucket"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py define_add_pandas_s3_args">
+datasource_name = "my_s3_datasource"
+bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
 
-bucket_name = "version-0.18 superconductive-docs-test"
+bucket_name = "superconductive-docs-test"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py create_datasource">
 datasource = context.sources.add_pandas_s3(
     name=datasource_name, bucket=bucket_name, boto3_options=boto3_options
 )
@@ -28,8 +28,8 @@ datasource = context.sources.add_pandas_s3(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py add_asset">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py add_asset">
+asset_name = "my_taxi_data_asset"
 s3_prefix = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 data_asset = datasource.add_csv_asset(

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
@@ -10,16 +10,16 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py define_add_spark_s3_args">
-datasource_name = "version-0.18 my_s3_datasource"
-bucket_name = "version-0.18 my_bucket"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py define_add_spark_s3_args">
+datasource_name = "my_s3_datasource"
+bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
 
-bucket_name = "version-0.18 superconductive-docs-test"
+bucket_name = "superconductive-docs-test"
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py create_datasource">
 datasource = context.sources.add_spark_s3(
     name=datasource_name, bucket=bucket_name, boto3_options=boto3_options
 )
@@ -28,8 +28,8 @@ datasource = context.sources.add_spark_s3(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py add_asset">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py add_asset">
+asset_name = "my_taxi_data_asset"
 s3_prefix = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 data_asset = datasource.add_csv_asset(

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -11,8 +11,8 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_pandas_filesystem_args">
-datasource_name = "version-0.18 my_new_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_pandas_filesystem_args">
+datasource_name = "my_new_datasource"
 path_to_folder_containing_csv_files = "<INSERT_PATH_TO_FILES_HERE>"
 # </snippet>
 
@@ -28,7 +28,7 @@ path_to_folder_containing_csv_files = str(
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource">
 datasource = context.sources.add_pandas_filesystem(
     name=datasource_name, base_directory=path_to_folder_containing_csv_files
 )
@@ -37,13 +37,13 @@ datasource = context.sources.add_pandas_filesystem(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_csv_asset_args">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py define_add_csv_asset_args">
+asset_name = "my_taxi_data_asset"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py add_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py add_asset">
 datasource.add_csv_asset(name=asset_name, batching_regex=batching_regex)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py
@@ -11,8 +11,8 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_spark_filesystem_args">
-datasource_name = "version-0.18 my_new_datasource"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_spark_filesystem_args">
+datasource_name = "my_new_datasource"
 path_to_folder_containing_csv_files = "<INSERT_PATH_TO_FILES_HERE>"
 # </snippet>
 
@@ -28,7 +28,7 @@ path_to_folder_containing_csv_files = str(
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py create_datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py create_datasource">
 datasource = context.sources.add_spark_filesystem(
     name=datasource_name, base_directory=path_to_folder_containing_csv_files
 )
@@ -37,13 +37,13 @@ datasource = context.sources.add_spark_filesystem(
 assert datasource_name in context.datasources
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_csv_asset_args">
-asset_name = "version-0.18 my_taxi_data_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py define_add_csv_asset_args">
+asset_name = "my_taxi_data_asset"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py add_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py add_asset">
 datasource.add_csv_asset(
     name=asset_name, batching_regex=batching_regex, header=True, infer_schema=True
 )

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py
@@ -10,7 +10,7 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py get_validator">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_quickly_connect_to_a_single_file_with_pandas.py get_validator">
 validator = context.sources.pandas_default.read_csv(
     "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
 )

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/connect_in_memory_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/connect_in_memory_data.md
@@ -44,7 +44,7 @@ pandas can read many types of data into its DataFrame class, but the following e
 
 Run the following Python code to create a Pandas Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py datasource"
 ```
 
 ### Read your data into a Pandas DataFrame
@@ -53,7 +53,7 @@ In the following example, a parquet file is read into a Pandas DataFrame that wi
 
 Run the following Python code to create the Pandas DataFrame:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py dataframe"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py dataframe"
 ```
 
 ### Add a Data Asset to the Data Source
@@ -68,17 +68,17 @@ The DataFrame you created previously is the value you'll enter for `dataframe` p
 
 1. Run the following Python code to define the `name` parameter and store it as a Python variable:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py name"
     ```
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py data_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py data_asset"
     ```
 
     For `dataframe` Data Assets, the `dataframe` is always specified as the argument of one API method. For example:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe"
     ```
 
 ### Next steps
@@ -113,7 +113,7 @@ Connect to in-memory Data Assets using Spark.
 
 Run the following Python code to create a Spark Data Source:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py datasource"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py datasource"
 ```
 
 ### Read your data into a Spark DataFrame
@@ -122,7 +122,7 @@ In the following example, you'll create a simple Spark DataFrame that is used in
 
 Run the following Python code to create the Spark DataFrame:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py dataframe"
+```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py dataframe"
 ```
 
 ### Add a Data Asset to the Data Source
@@ -137,17 +137,17 @@ The DataFrame you created previously is the value you'll enter for `dataframe` p
 
 1. Run the following Python code to define the `name` parameter and store it as a Python variable:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py name"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py name"
     ```
 
 2. Run the following Python code to create the Data Asset:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py data_asset"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py data_asset"
     ```
 
     For `dataframe` Data Assets, the `dataframe` is always specified as the argument of one API method. For example:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py build_batch_request_with_dataframe"
+    ```python name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py build_batch_request_with_dataframe"
     ```
 
 ## Next steps

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py
@@ -10,13 +10,13 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py datasource">
-datasource = context.sources.add_pandas(name="version-0.18 my_pandas_datasource")
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py datasource">
+datasource = context.sources.add_pandas(name="my_pandas_datasource")
 # </snippet>
 
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py dataframe">
 import pandas as pd
 
 dataframe = pd.read_parquet(
@@ -25,17 +25,17 @@ dataframe = pd.read_parquet(
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py name">
-name = "version-0.18 taxi_dataframe"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py name">
+name = "taxi_dataframe"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py data_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py data_asset">
 data_asset = datasource.add_dataframe_asset(name=name)
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_pandas.py build_batch_request_with_dataframe">
 my_batch_request = data_asset.build_batch_request(dataframe=dataframe)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py
@@ -23,13 +23,13 @@ context = gx.get_context()
 spark = gx.core.util.get_or_create_spark_application()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py datasource">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py datasource">
 datasource = context.sources.add_spark("my_spark_datasource")
 # </snippet>
 
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py dataframe">
 df = pd.DataFrame(
     {
         "a": [1, 2, 3, 4, 5, 6],
@@ -43,17 +43,17 @@ dataframe = spark.createDataFrame(data=df)
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py name">
-name = "version-0.18 my_df_asset"
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py name">
+name = "my_df_asset"
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py data_asset">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py data_asset">
 data_asset = datasource.add_dataframe_asset(name=name)
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py build_batch_request_with_dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/in_memory/how_to_connect_to_in_memory_data_using_spark.py build_batch_request_with_dataframe">
 my_batch_request = data_asset.build_batch_request(dataframe=dataframe)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/config_variables.yml
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/config_variables.yml
@@ -1,4 +1,4 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/config_variables.yml my_query_store_creds">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/config_variables.yml my_query_store_creds">
 my_query_store_creds:
   drivername: postgresql
   host: localhost

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_pandas.py
@@ -16,19 +16,19 @@ folder_path = str(
 file_path: str = folder_path + "/visits.csv"
 
 # get context
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get context">
 import great_expectations as gx
 
 context = gx.get_context(project_root_dir=".")
 # </snippet>
 
 # add datasource and asset
-data_asset = context.sources.add_pandas(
-    name="version-0.18 visits_datasource"
-).add_csv_asset(name="version-0.18 visits", filepath_or_buffer=file_path, sep="\t")
+data_asset = context.sources.add_pandas(name="visits_datasource").add_csv_asset(
+    name="visits", filepath_or_buffer=file_path, sep="\t"
+)
 
 # get checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get checkpoint">
 my_checkpoint = context.get_checkpoint("my_checkpoint")
 # </snippet>
 
@@ -54,14 +54,14 @@ assert (evrs[0]["results"][0]["result"]) == {
 
 
 # Example 2 - 1 unexpected_index_column_names defined. Output will contain unexpected_index_list and unexpected_index_query.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py set unexpected_index_column_names">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py set unexpected_index_column_names">
 result_format: dict = {
     "result_format": "COMPLETE",
     "unexpected_index_column_names": ["event_id"],
 }
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py run checkpoint">
 results = my_checkpoint.run(result_format=result_format)
 # </snippet>
 evrs = results.list_validation_results()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_spark.py
@@ -14,7 +14,7 @@ folder_path = str(
 )
 
 # get context
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get context">
 import great_expectations as gx
 
 context = gx.get_context(project_root_dir=".")
@@ -22,9 +22,9 @@ context = gx.get_context(project_root_dir=".")
 
 # add datasource and asset
 data_asset = context.sources.add_spark_filesystem(
-    name="version-0.18 visits_datasource", base_directory=folder_path
+    name="visits_datasource", base_directory=folder_path
 ).add_csv_asset(
-    name="version-0.18 visits",
+    name="visits",
     glob_directive="*.csv",
     header=True,
     sep="\t",
@@ -32,7 +32,7 @@ data_asset = context.sources.add_spark_filesystem(
 )
 
 # get checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get checkpoint">
 my_checkpoint = context.get_checkpoint("my_checkpoint")
 # </snippet>
 
@@ -57,13 +57,13 @@ assert (evrs[0]["results"][0]["result"]) == {
 
 
 # Example 2 - 1 unexpected_index_column_names defined. Output will contain unexpected_index_list and unexpected_index_query.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py set unexpected_index_column_names">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py set unexpected_index_column_names">
 result_format: dict = {
     "result_format": "COMPLETE",
     "unexpected_index_column_names": ["event_id"],
 }
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py run checkpoint">
 results = my_checkpoint.run(result_format=result_format)
 # </snippet>
 evrs = results.list_validation_results()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_sql.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/failed_rows_sql.py
@@ -15,7 +15,7 @@ folder_path = str(
 connection_string: str = f"sqlite:///{folder_path}/visits.db"
 
 # get context
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get context">
 import great_expectations as gx
 
 context = gx.get_context(project_root_dir=".")
@@ -23,16 +23,16 @@ context = gx.get_context(project_root_dir=".")
 
 # add datasource and asset
 datasource = context.sources.add_sqlite(
-    name="version-0.18 visits_datasource",
+    name="visits_datasource",
     connection_string=connection_string,
 )
 asset = datasource.add_table_asset(
-    name="version-0.18 visits",
-    table_name="version-0.18 event_names",
+    name="visits",
+    table_name="event_names",
 )
 
 # get checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get checkpoint">
 my_checkpoint = context.get_checkpoint("my_checkpoint")
 # </snippet>
 
@@ -57,13 +57,13 @@ assert (evrs[0]["results"][0]["result"]) == {
 
 
 # Example 2 - 1 unexpected_index_column_names defined. Output will contain unexpected_index_list and unexpected_index_query.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py set unexpected_index_column_names">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py set unexpected_index_column_names">
 result_format: dict = {
     "result_format": "COMPLETE",
     "unexpected_index_column_names": ["event_id"],
 }
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py run checkpoint">
 results = my_checkpoint.run(result_format=result_format)
 # </snippet>
 evrs = results.list_validation_results()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/great_expectations.yml
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/great_expectations.yml
@@ -53,7 +53,7 @@ stores:
       suppress_store_backend_id: true
       base_directory: checkpoints/
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/great_expectations.yml my_query_store">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/great_expectations.yml my_query_store">
   my_query_store:
     class_name: SqlAlchemyQueryStore
     credentials: ${my_query_store_creds}

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.md
@@ -23,7 +23,7 @@ This guide will help you create <TechnicalTag tag="expectation" text="Expectatio
 
 Run the following Python code in a notebook:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get_context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get_context"
 ```
 
 ## Instantiate two Validators, one for each Data Asset
@@ -31,33 +31,33 @@ Run the following Python code in a notebook:
 We'll call one of these <TechnicalTag tag="validator" text="Validators" /> the *upstream* Validator and the other the *downstream* Validator. Evaluation Parameters will allow us to use <TechnicalTag tag="validation_result" text="Validation Results" /> from the upstream Validator as parameters passed into Expectations on the downstream.
 
 
- ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get validators"
+ ```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get validators"
 ```
 
 ## Create the Expectation Suite for the upstream Validator
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py create upstream_expectation_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py create upstream_expectation_suite"
 ```
 
 This suite will be used on the upstream batch. The observed value for number of rows will be used as a parameter in the Expectation Suite for the downstream batch.
 
 ## Disable interactive evaluation for the downstream Validator
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py disable interactive_evaluation"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py disable interactive_evaluation"
 ```
 
 Disabling interactive evaluation allows you to declare an Expectation even when it cannot be evaluated immediately.
 
 ## Define an Expectation using an Evaluation Parameter on the downstream Validator
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py add expectation with evaluation parameter"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py add expectation with evaluation parameter"
 ```
 
 The core of this is a ``$PARAMETER : URN`` pair. When Great Expectations encounters a ``$PARAMETER`` flag during <TechnicalTag tag="validation" text="Validation" />, it will replace the ``URN`` with a value retrieved from an Evaluation Parameter Store or <TechnicalTag tag="metric_store" text="Metrics Store" /> (see also [How to configure a MetricsStore](/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_metricsstore.md)).
 
 When executed in the notebook, this Expectation will generate a Validation Result. Most values will be missing, since interactive evaluation was disabled.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py expected_validation_result"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py expected_validation_result"
  ```
 
 :::warning
@@ -68,7 +68,7 @@ Your URN must be exactly correct in order to work in production. Unfortunately, 
 
 ## Save your Expectation Suite
 
- ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py save downstream_expectation_suite"
+ ```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py save downstream_expectation_suite"
  ```
 
 This step is necessary because your ``$PARAMETER`` will only function properly when invoked within a Validation operation with multiple Validators. The simplest way to execute such an operation is through a :ref:`Validation Operator <reference__core_concepts__validation__validation_operator>`, and Validation Operators are configured to load Expectation Suites from <TechnicalTag tag="expectation_store" text="Expectation Stores" />, not memory.
@@ -77,14 +77,14 @@ This step is necessary because your ``$PARAMETER`` will only function properly w
 
 This will execute both validations and pass the evaluation parameter from the upstream validation to the downstream.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py run checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py run checkpoint"
 ```
 
 ## Rebuild Data Docs and review results in docs
 
 You can do this within your notebook by running:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py build data docs"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py build data docs"
 ```
 
 Once your <TechnicalTag tag="data_docs" text="Data Docs" /> rebuild, open them in a browser and navigate to the page for the new Validation Result.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py
@@ -1,6 +1,6 @@
 import pathlib
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get_context">
 import great_expectations as gx
 
 context = gx.get_context()
@@ -15,9 +15,9 @@ data_directory = pathlib.Path(
 ).resolve(strict=True)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get validators">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py get validators">
 datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 demo_pandas", base_directory=data_directory
+    name="demo_pandas", base_directory=data_directory
 )
 
 asset = datasource.add_csv_asset(
@@ -31,25 +31,25 @@ downstream_batch_request = asset.build_batch_request({"year": "2020", "month": "
 
 upstream_validator = context.get_validator(
     batch_request=upstream_batch_request,
-    create_expectation_suite_with_name="version-0.18 upstream_expectation_suite",
+    create_expectation_suite_with_name="upstream_expectation_suite",
 )
 downstream_validator = context.get_validator(
     batch_request=downstream_batch_request,
-    create_expectation_suite_with_name="version-0.18 downstream_expectation_suite",
+    create_expectation_suite_with_name="downstream_expectation_suite",
 )
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py create upstream_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py create upstream_expectation_suite">
 upstream_validator.expect_table_row_count_to_be_between(min_value=5000, max_value=20000)
 upstream_validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py disable interactive_evaluation">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py disable interactive_evaluation">
 downstream_validator.interactive_evaluation = False
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py add expectation with evaluation parameter">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py add expectation with evaluation parameter">
 eval_param_urn = "urn:great_expectations:validations:upstream_expectation_suite:expect_table_row_count_to_be_between.result.observed_value"
 downstream_validator_validation_result = downstream_validator.expect_table_row_count_to_equal(
     value={
@@ -58,7 +58,7 @@ downstream_validator_validation_result = downstream_validator.expect_table_row_c
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py expected_validation_result">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py expected_validation_result">
 expected_validation_result = {
     "success": None,
     "expectation_config": {
@@ -85,13 +85,13 @@ assert (
     actual_validation_result == expected_validation_result
 ), f"Validation result does not match expected result: {actual_validation_result}"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py save downstream_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py save downstream_expectation_suite">
 downstream_validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py run checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 checkpoint",
+    name="checkpoint",
     validations=[
         {
             "batch_request": upstream_batch_request,
@@ -109,6 +109,6 @@ checkpoint_result = checkpoint.run()
 
 assert checkpoint_result.success
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py build data docs">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.py build data docs">
 context.build_data_docs()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.md
@@ -25,27 +25,27 @@ Find the ``stores`` section in your ``great_expectations.yml`` file, and add the
 
 By default, query results will be returned as a list. If instead you need a scalar for your expectation, you can specify the return_type
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/great_expectations.yml my_query_store"
+```yaml name="docs/docusaurus/docs/oss/guides/expectations/advanced/great_expectations.yml my_query_store"
 ```
 
 Ensure you have added valid credentials to the ``config-variables.yml`` file (replacing the values with your database credentials):
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/config_variables.yml my_query_store_creds"
+```yaml name="docs/docusaurus/docs/oss/guides/expectations/advanced/config_variables.yml my_query_store_creds"
 ```
 
 ## In a notebook, get a test Batch of data to use for Validation
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py get_validator"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py get_validator"
 ```
 
 ## Define an Expectation that relies on a dynamic query
 
 Great Expectations recognizes several types of Evaluation Parameters that can use advanced features provided by the <TechnicalTag tag="data_context" text="Data Context" />. To dynamically load data, we will be using a store-style URN, which starts with `urn:great_expectations:stores`. The next component of the URN is the name of the store we configured above (``my_query_store``), and the final component is the name of the query we defined above (``unique_passenger_counts``):
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py define expectation"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py define expectation"
 ```
 
 The SqlAlchemyQueryStore that you configured above will execute the defined query and return the results as the value of the ``value_set`` parameter to evaluate your Expectation:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py expected_validator_results"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py expected_validator_results"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py
@@ -11,7 +11,7 @@ PG_CONNECTION_STRING = "postgresql+psycopg2://postgres:@localhost/test_ci"
 csv_path = "./data/yellow_tripdata_sample_2019-01.csv"
 
 load_data_into_test_database(
-    table_name="version-0.18 postgres_taxi_data",
+    table_name="postgres_taxi_data",
     csv_path=csv_path,
     connection_string=PG_CONNECTION_STRING,
     load_full_dataset=True,
@@ -24,27 +24,27 @@ assert len(df) == 10000
 
 # Tutorial content resumes here.
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py get_validator">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py get_validator">
 import great_expectations as gx
 
 context = gx.get_context()
 
 pg_datasource = context.sources.add_postgres(
-    name="version-0.18 pg_datasource", connection_string=PG_CONNECTION_STRING
+    name="pg_datasource", connection_string=PG_CONNECTION_STRING
 )
 table_asset = pg_datasource.add_table_asset(
-    name="postgres_taxi_data", table_name="version-0.18 postgres_taxi_data"
+    name="postgres_taxi_data", table_name="postgres_taxi_data"
 )
 batch_request = table_asset.build_batch_request()
 
 validator = context.get_validator(
     batch_request=batch_request,
-    create_expectation_suite_with_name="version-0.18 my_suite_name",
+    create_expectation_suite_with_name="my_suite_name",
 )
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py define expectation">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py define expectation">
 validator_results = validator.expect_column_values_to_be_in_set(
     column="passenger_count",
     value_set={
@@ -54,7 +54,7 @@ validator_results = validator.expect_column_values_to_be_in_set(
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py expected_validator_results">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/advanced/how_to_dynamically_load_evaluation_parameters_from_a_database.py expected_validator_results">
 expected_validator_results = """
 {
   "expectation_config": {

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/identify_failed_rows_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/advanced/identify_failed_rows_expectations.md
@@ -51,14 +51,14 @@ Identify failed rows using pandas.
 
 Use the `get_context()` method to create a new Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get context"
 ```
 
 ### Import the Checkpoint 
 
 Run the following code to import the example Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py get checkpoint"
 ```
 
 ### Set the `unexpected_index_column_names` parameter
@@ -67,14 +67,14 @@ The failed rows are defined as values in the `unexpected_index_column_names` par
 
 In the following example, you're setting the `result_format` to `COMPLETE` to return the full set of results. For more information about `result_format`, see [Result format](https://docs.greatexpectations.io/docs/reference/learn/expectations/result_format/#configure-result-format).
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py set unexpected_index_column_names"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py set unexpected_index_column_names"
 ```
 
 ### Run Checkpoint using `result_format`
 
 Run the following code to apply the updated `result_format` to every Expectation in your Suite and pass it directly to the `run()` method: 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py run checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_pandas.py run checkpoint"
 ```
 
 ### Review Validation Results
@@ -138,14 +138,14 @@ Identify failed rows using Spark.
 
 Use the `get_context()` method to create a new Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get context"
 ```
 
 ### Import the Checkpoint 
 
 Run the following code to import the example Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py get checkpoint"
 ```
 
 ### Set the `unexpected_index_column_names` parameter
@@ -154,14 +154,14 @@ The failed rows are defined as values in the `unexpected_index_column_names` par
 
 In the following example, you're setting the `result_format` to `COMPLETE` to return the full set of results. For more information about `result_format`, see [Result format](https://docs.greatexpectations.io/docs/reference/learn/expectations/result_format/#configure-result-format).
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py set unexpected_index_column_names"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py set unexpected_index_column_names"
 ```
 
 ### Run Checkpoint using `result_format`
 
 Run the following code to apply the updated `result_format` to every Expectation in your Suite and pass it directly to the `run()` method: 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py run checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_spark.py run checkpoint"
 ```
 
 ### Review Validation Results
@@ -226,14 +226,14 @@ Identify failed rows using SQLAlchemy.
 
 Use the `get_context()` method to create a new Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get context"
 ```
 
 ### Import the Checkpoint 
 
 Run the following code to import the example Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py get checkpoint"
 ```
 
 ### Set the `unexpected_index_column_names` parameter
@@ -242,14 +242,14 @@ The failed rows are defined as values in the `unexpected_index_column_names` par
 
 In the following example, you're setting the `result_format` to `COMPLETE` to return the full set of results. For more information about `result_format`, see [Result format](https://docs.greatexpectations.io/docs/reference/learn/expectations/result_format/#configure-result-format).
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py set unexpected_index_column_names"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py set unexpected_index_column_names"
 ```
 
 ### Run Checkpoint using `result_format`
 
 Run the following code to apply the updated `result_format` to every Expectation in your Suite and pass it directly to the `run()` method: 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py run checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/expectations/advanced/failed_rows_sql.py run checkpoint"
 ```
 
 ### Review Validation Results

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/add_custom_parameters.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/add_custom_parameters.md
@@ -51,7 +51,7 @@ After the attributes are added to the Expectation and the Metric, the custom par
 
 ```python
 classColumnValuesBetween(ColumnMapMetricProvider):   
-condition_metric_name = "version-0.18 column_values.between"   
+condition_metric_name = "column_values.between"   
 condition_value_keys = (       
    "min_value",       
    "max_value",       

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py
@@ -25,17 +25,17 @@ from great_expectations.expectations.metrics.table_metric_provider import (
 
 # This class defines a Metric to support your Expectation.
 # For most BatchExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py BatchMeetsSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py BatchMeetsSomeCriteria class_def">
 class BatchMeetsSomeCriteria(TableMetricProvider):
     # </snippet>
 
     # This is the id string that will be used to reference your Metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_name">
-    metric_name = "version-0.18 METRIC NAME GOES HERE"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_name">
+    metric_name = "METRIC NAME GOES HERE"
     # </snippet>
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py pandas">
     @metric_value(engine=PandasExecutionEngine)
     def _pandas(
         cls,
@@ -88,21 +88,21 @@ class BatchMeetsSomeCriteria(TableMetricProvider):
 
 # This class defines the Expectation itself
 # The main business logic for calculation lives here.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py ExpectBatchToMeetSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py ExpectBatchToMeetSomeCriteria class_def">
 class ExpectBatchToMeetSomeCriteria(BatchExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py docstring">
     """TODO: add a docstring here"""
     # </snippet>
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py examples">
     examples = []
     # </snippet>
 
     # This is a tuple consisting of all Metrics necessary to evaluate the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_dependencies">
     metric_dependencies = ("METRIC NAME GOES HERE",)
     # </snippet>
 
@@ -138,7 +138,7 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py validate">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py validate">
     def _validate(
         self,
         metrics: Dict,
@@ -149,7 +149,7 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
         raise NotImplementedError
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -162,6 +162,6 @@ class ExpectBatchToMeetSomeCriteria(BatchExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py diagnostics">
     ExpectBatchToMeetSomeCriteria().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py
@@ -22,17 +22,17 @@ from great_expectations.expectations.metrics import (
 
 # This class defines a Metric to support your Expectation.
 # For most ColumnAggregateExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ColumnAggregateMatchesSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ColumnAggregateMatchesSomeCriteria class_def">
 class ColumnAggregateMatchesSomeCriteria(ColumnAggregateMetricProvider):
     # </snippet>
 
     # This is the id string that will be used to reference your Metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_name">
-    metric_name = "version-0.18 METRIC NAME GOES HERE"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_name">
+    metric_name = "METRIC NAME GOES HERE"
     # </snippet>
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py pandas">
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         raise NotImplementedError
@@ -49,21 +49,21 @@ class ColumnAggregateMatchesSomeCriteria(ColumnAggregateMetricProvider):
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ExpectColumnAggregateToMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ExpectColumnAggregateToMatchSomeCriteria class_def">
 class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py docstring">
     """TODO: add a docstring here"""
     # </snippet>
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py examples">
     examples = []
     # </snippet>
 
     # This is a tuple consisting of all Metrics necessary to evaluate the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_dependencies">
     metric_dependencies = ("METRIC NAME GOES HERE",)
     # </snippet>
 
@@ -99,7 +99,7 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py validate">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py validate">
     def _validate(
         self,
         metrics: Dict,
@@ -110,7 +110,7 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
         raise NotImplementedError
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -123,6 +123,6 @@ class ExpectColumnAggregateToMatchSomeCriteria(ColumnAggregateExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py diagnostics">
     ExpectColumnAggregateToMatchSomeCriteria().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py
@@ -21,17 +21,17 @@ from great_expectations.expectations.metrics import (
 
 # This class defines a Metric to support your Expectation.
 # For most ColumnMapExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ColumnValuesMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ColumnValuesMatchSomeCriteria class_def">
 class ColumnValuesMatchSomeCriteria(ColumnMapMetricProvider):
     # </snippet>
 
     # This is the id string that will be used to reference your metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py metric_name">
-    condition_metric_name = "version-0.18 METRIC NAME GOES HERE"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py metric_name">
+    condition_metric_name = "METRIC NAME GOES HERE"
     # </snippet>
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py pandas">
     @column_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         raise NotImplementedError
@@ -50,22 +50,22 @@ class ColumnValuesMatchSomeCriteria(ColumnMapMetricProvider):
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ExpectColumnValuesToMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ExpectColumnValuesToMatchSomeCriteria class_def">
 class ExpectColumnValuesToMatchSomeCriteria(ColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py examples">
     examples = []
     # </snippet>
 
     # This is the id string of the Metric used by this Expectation.
     # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py map_metric">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py map_metric">
     map_metric = "METRIC NAME GOES HERE"
     # </snippet>
 
@@ -101,7 +101,7 @@ class ExpectColumnValuesToMatchSomeCriteria(ColumnMapExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -114,6 +114,6 @@ class ExpectColumnValuesToMatchSomeCriteria(ColumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py diagnostics">
     ExpectColumnValuesToMatchSomeCriteria().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py
@@ -21,12 +21,12 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 
 # This class defines a Metric to support your Expectation.
 # For most ColumnPairMapExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ColumnPairValuesMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ColumnPairValuesMatchSomeCriteria class_def">
 class ColumnPairValuesMatchSomeCriteria(ColumnPairMapMetricProvider):
     # </snippet>
     # This is the id string that will be used to reference your metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py metric_name">
-    condition_metric_name = "version-0.18 METRIC NAME GOES HERE"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py metric_name">
+    condition_metric_name = "METRIC NAME GOES HERE"
     # </snippet>
     # These point your metric at the provided keys to facilitate calculation
     condition_domain_keys = (
@@ -36,7 +36,7 @@ class ColumnPairValuesMatchSomeCriteria(ColumnPairMapMetricProvider):
     condition_value_keys = ()
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py pandas">
     @column_pair_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column_A, column_B, **kwargs):
         raise NotImplementedError
@@ -55,10 +55,10 @@ class ColumnPairValuesMatchSomeCriteria(ColumnPairMapMetricProvider):
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ExpectColumnPairValuesToMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ExpectColumnPairValuesToMatchSomeCriteria class_def">
 class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
@@ -68,7 +68,7 @@ class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
 
     # This is the id string of the Metric used by this Expectation.
     # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py map_metric">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py map_metric">
     map_metric = "METRIC NAME GOES HERE"
     # </snippet>
 
@@ -108,7 +108,7 @@ class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -119,6 +119,6 @@ class ExpectColumnPairValuesToMatchSomeCriteria(ColumnPairMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet  name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py diagnostics">
+    # <snippet  name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py diagnostics">
     ExpectColumnPairValuesToMatchSomeCriteria().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py
@@ -22,17 +22,17 @@ from great_expectations.validator.metric_configuration import MetricConfiguratio
 
 
 # This class defines a Metric to support your Expectation.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py BatchColumnsUnique class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py BatchColumnsUnique class_def">
 class BatchColumnsUnique(TableMetricProvider):
     # </snippet>
 
     # This is the id string that will be used to reference your Metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_name">
-    metric_name = "version-0.18 table.columns.unique"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_name">
+    metric_name = "table.columns.unique"
     # </snippet>
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py pandas">
     @metric_value(engine=PandasExecutionEngine)
     def _pandas(
         cls,
@@ -88,10 +88,10 @@ class BatchColumnsUnique(TableMetricProvider):
         }
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py ExpectBatchColumnsToBeUnique class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py ExpectBatchColumnsToBeUnique class_def">
 class ExpectBatchColumnsToBeUnique(BatchExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py docstring">
     """Expect batch to contain columns with unique contents."""
     # </snippet>
 
@@ -99,7 +99,7 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py examples">
     examples = [
         {
             "dataset_name": "expect_batch_columns_to_be_unique_1",
@@ -145,7 +145,7 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
     ]
     # </snippet>
     # This is a tuple consisting of all Metrics necessary to evaluate the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_dependencies">
     metric_dependencies = ("table.columns.unique", "table.columns")
     # </snippet>
 
@@ -180,7 +180,7 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
             raise InvalidExpectationConfigurationError(str(e))
 
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py validate">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py validate">
     def _validate(
         self,
         metrics: Dict,
@@ -205,7 +205,7 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
         # </snippet>
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py library_metadata">
     library_metadata = {
         "tags": ["uniqueness"],
         "contributors": ["@joegargery"],
@@ -214,7 +214,7 @@ class ExpectBatchColumnsToBeUnique(BatchExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py diagnostics">
     ExpectBatchColumnsToBeUnique().print_diagnostic_checklist()
 #     </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py
@@ -23,13 +23,13 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ColumnPairValuesDiffThree class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ColumnPairValuesDiffThree class_def">
 class ColumnPairValuesDiffThree(ColumnPairMapMetricProvider):
     # </snippet>
     """MetricProvider Class for Pair Values Diff Three MetricProvider"""
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py condition_metric_name">
-    condition_metric_name = "version-0.18 column_pair_values.diff_three"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py condition_metric_name">
+    condition_metric_name = "column_pair_values.diff_three"
     # </snippet>
     condition_domain_keys = (
         "column_A",
@@ -37,7 +37,7 @@ class ColumnPairValuesDiffThree(ColumnPairMapMetricProvider):
     )
     condition_value_keys = ()
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py _pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py _pandas">
     @column_pair_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column_A, column_B, **kwargs):
         return abs(column_A - column_B) == 3
@@ -57,19 +57,19 @@ class ColumnPairValuesDiffThree(ColumnPairMapMetricProvider):
         return row_wise_cond
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ExpectColumnPairValuesToHaveADifferenceOfThree class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ExpectColumnPairValuesToHaveADifferenceOfThree class_def">
 class ExpectColumnPairValuesToHaveADifferenceOfThree(ColumnPairMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_docstring">
     """Expect two columns to have a row-wise difference of three."""
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py complete_map_metric">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py complete_map_metric">
     map_metric = "column_pair_values.diff_three"
     # </snippet>
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_examples">
     examples = [
         {
             "data": {
@@ -124,7 +124,7 @@ class ExpectColumnPairValuesToHaveADifferenceOfThree(ColumnPairMapExpectation):
             raise InvalidExpectationConfigurationError(str(e))
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_library_metadata">
     library_metadata = {
         "tags": [
             "basic math",
@@ -136,7 +136,7 @@ class ExpectColumnPairValuesToHaveADifferenceOfThree(ColumnPairMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_print_diagnostic_checklist">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_print_diagnostic_checklist">
     ExpectColumnPairValuesToHaveADifferenceOfThree().print_diagnostic_checklist()
     # </snippet>
 # Note to users: code below this line is only for integration testing -- ignore!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
@@ -3,13 +3,13 @@ from great_expectations.expectations.set_based_column_map_expectation import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py ExpectColumnValuesToBeInSolfegeScaleSet class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py ExpectColumnValuesToBeInSolfegeScaleSet class_def">
 class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py docstring">
     """Expect values in this column should be valid members of the Solfege scale: do, re, mi, etc."""
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py set">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py set">
     set_ = [
         "do",
         "re",
@@ -34,12 +34,12 @@ class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
         "TI",
     ]
 
-    set_camel_name = "version-0.18 SolfegeScale"
+    set_camel_name = "SolfegeScale"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py semantic_name">
-    set_semantic_name = "version-0.18 the Solfege scale"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py semantic_name">
+    set_semantic_name = "the Solfege scale"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py examples">
     examples = [
         {
             "data": {
@@ -113,7 +113,7 @@ class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
         set_camel_name=set_camel_name,
         set_=set_,
     )
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py library_metadata">
     library_metadata = {
         "tags": ["set-based"],
         "contributors": ["@joegargery"],
@@ -122,7 +122,7 @@ class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py diagnostics">
     ExpectColumnValuesToBeInSolfegeScaleSet(
         column="lowercase_solfege_scale"
     ).print_diagnostic_checklist()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py
@@ -3,20 +3,20 @@ from great_expectations.expectations.regex_based_column_map_expectation import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py ExpectColumnValuesToOnlyContainVowels class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py ExpectColumnValuesToOnlyContainVowels class_def">
 class ExpectColumnValuesToOnlyContainVowels(RegexBasedColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py docstring">
     """Expect values in this column to only contain vowels."""
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py definition">
-    regex_camel_name = "version-0.18 Vowel"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py definition">
+    regex_camel_name = "Vowel"
     regex = "^[aeiouyAEIOUY]*$"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py plural">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py plural">
     semantic_type_name_plural = "vowels"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py examples">
     examples = [
         {
             "data": {
@@ -99,7 +99,7 @@ class ExpectColumnValuesToOnlyContainVowels(RegexBasedColumnMapExpectation):
         regex_camel_name=regex_camel_name,
         regex_=regex,
     )
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py library_metadata">
     library_metadata = {
         "tags": ["regex"],
         "contributors": ["@joegargery"],
@@ -108,7 +108,7 @@ class ExpectColumnValuesToOnlyContainVowels(RegexBasedColumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py diagnostics">
     ExpectColumnValuesToOnlyContainVowels(
         column="only_vowels"
     ).print_diagnostic_checklist()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py
@@ -21,17 +21,17 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py MulticolumnValuesMultipleThree class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py MulticolumnValuesMultipleThree class_def">
 class MulticolumnValuesMultipleThree(MulticolumnMapMetricProvider):
     # </snippet>
     """MetricProvider Class for Multicolumn Values Multiple Of Three MetricProvider"""
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py condition_metric_name">
-    condition_metric_name = "version-0.18 multicolumn_values.multiple_three"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py condition_metric_name">
+    condition_metric_name = "multicolumn_values.multiple_three"
     # </snippet>
     condition_domain_keys = ("column_list",)
     condition_value_keys = ()
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py _pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py _pandas">
 
     @multicolumn_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column_list, **kwargs):
@@ -47,19 +47,19 @@ class MulticolumnValuesMultipleThree(MulticolumnMapMetricProvider):
         raise NotImplementedError
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py ExpectMulticolumnValuesToBeMultiplesOfThree class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py ExpectMulticolumnValuesToBeMultiplesOfThree class_def">
 class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py docstring">
     """Expect a set of columns to contain multiples of three."""
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py map_metric">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py map_metric">
     map_metric = "multicolumn_values.multiple_three"
     # </snippet>
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py examples">
     examples = [
         {
             "data": {
@@ -111,7 +111,7 @@ class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
             raise InvalidExpectationConfigurationError(str(e))
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py library_metadata">
     library_metadata = {
         "tags": [
             "basic math",
@@ -123,7 +123,7 @@ class ExpectMulticolumnValuesToBeMultiplesOfThree(MulticolumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py print_diagnostic_checklist">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py print_diagnostic_checklist">
     ExpectMulticolumnValuesToBeMultiplesOfThree(
         column_list=["col_a", "col_b", "col_c"]
     ).print_diagnostic_checklist()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py
@@ -21,17 +21,17 @@ from great_expectations.expectations.expectation_configuration import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py ExpectQueriedColumnValueFrequencyToMeetThreshold class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py ExpectQueriedColumnValueFrequencyToMeetThreshold class_def">
 class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py docstring">
     """Expect the frequency of occurrences of a specified value in a queried column to be at least <threshold> percent of values in that column."""
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py metric_dependencies">
     metric_dependencies = ("query.column",)
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py query">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py query">
     query: str = """
             SELECT {col},
             CAST(COUNT({col}) AS float) / (SELECT COUNT({col}) FROM {active_batch})
@@ -39,7 +39,7 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
             GROUP BY {col}
             """
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py success_keys">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py success_keys">
     success_keys = (
         "column",
         "value",
@@ -72,8 +72,8 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function">
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function signature">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function signature">
     def _validate(
         self,
         metrics: dict,
@@ -111,7 +111,7 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
         }
         # </snippet>
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py examples">
     examples = [
         {
             "data": [
@@ -195,7 +195,7 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
         },
     ]
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function library_metadata">
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {
         "tags": ["query-based"],
@@ -205,7 +205,7 @@ class ExpectQueriedColumnValueFrequencyToMeetThreshold(QueryExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py print_diagnostic_checklist()">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py print_diagnostic_checklist()">
     ExpectQueriedColumnValueFrequencyToMeetThreshold().print_diagnostic_checklist()
     # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py
@@ -21,23 +21,23 @@ from great_expectations.expectations.expectation_configuration import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py ExpectQueriedTableRowCountToBe class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py ExpectQueriedTableRowCountToBe class_def">
 class ExpectQueriedTableRowCountToBe(QueryExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py docstring">
     """Expect the expect the number of rows returned from a queried table to equal a specified value."""
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py metric_dependencies">
     metric_dependencies = ("query.table",)
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py query">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py query">
     query: str = """
             SELECT COUNT(*)
             FROM {active_batch}
             """
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py success_keys">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py success_keys">
     success_keys = (
         "value",
         "query",
@@ -60,8 +60,8 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function">
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function signature">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function signature">
     def _validate(
         self,
         metrics: dict,
@@ -81,7 +81,7 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
         }
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py examples">
     examples = [
         {
             "data": [
@@ -151,7 +151,7 @@ class ExpectQueriedTableRowCountToBe(QueryExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py print_diagnostic_checklist">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py print_diagnostic_checklist">
     ExpectQueriedTableRowCountToBe().print_diagnostic_checklist()
     # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_batch_expectations.md
@@ -76,27 +76,27 @@ By convention, your <TechnicalTag tag="metric" text="Metric"/> class is defined 
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py ExpectBatchToMeetSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py ExpectBatchToMeetSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py ExpectBatchColumnsToBeUnique class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py ExpectBatchColumnsToBeUnique class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py diagnostics"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -126,7 +126,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -175,7 +175,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@metric_value` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to find the unique columns of a Batch with the PandasExecutionEngine.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py pandas"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py pandas"
 ```
 
 :::note
@@ -198,22 +198,22 @@ The remainder of the Metric Identifier simply describes what the Metric computes
 
 You'll need to substitute this metric into two places in the code. First, in the Metric class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_name"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_name"
 ```
 
 Second, in the Expectation class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py metric_dependencies"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py metric_dependencies"
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -222,12 +222,12 @@ Finally, rename the Metric class name itself, using the camel case version of th
 
 For example, replace:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py BatchMeetsSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py BatchMeetsSomeCriteria class_def"
 ```
 
 with 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py BatchColumnsUnique class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py BatchColumnsUnique class_def"
 ```
 
 ## Validate
@@ -236,7 +236,7 @@ In this step, we simply need to validate that the results of our Metrics meet ou
 
 The validate method is implemented as `_validate(...)`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py validate"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py validate"
 ```
 
 This method takes a dictionary named `metrics`, which contains all Metrics requested by your Metric dependencies, 
@@ -245,7 +245,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `table.columns.unique` Metric against our success keys:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py validate"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py validate"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -295,12 +295,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/batch_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_batch_columns_to_be_unique.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
@@ -76,27 +76,27 @@ By convention, your Metric class is defined first in a Custom Expectation. For n
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ExpectColumnAggregateToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ExpectColumnAggregateToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ExpectColumnMaxToBeBetween class_def"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ExpectColumnMaxToBeBetween class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py docstring"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py diagnostics"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py diagnostics"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -126,7 +126,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -178,7 +178,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@column_aggregate_value` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to calculate the max of a column using the PandasExecutionEngine.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _pandas"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _pandas"
 ```
 
 This is all that you need to define for now. In the next step, we will implement the method to validate the results of this Metric.
@@ -198,22 +198,22 @@ The remainder of the Metric Identifier simply describes what the Metric computes
 
 You'll need to substitute this metric into two places in the code. First, in the Metric class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_name"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_name"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_name"
 ```
 
 Second, in the Expectation class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py metric_dependencies"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_dependencies"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_dependencies"
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -222,12 +222,12 @@ Finally, rename the Metric class name itself, using the camel case version of th
 
 For example, replace:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ColumnAggregateMatchesSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py ColumnAggregateMatchesSomeCriteria class_def"
 ```
 
 with 
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ColumnCustomMax class_def"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ColumnCustomMax class_def"
 ```
 
 ## Validate
@@ -236,7 +236,7 @@ In this step, we simply need to validate that the results of our Metrics meet ou
 
 The validate method is implemented as `_validate(...)`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py validate"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py validate"
 ```
 
 This method takes a dictionary named `metrics`, which contains all Metrics requested by your Metric dependencies, 
@@ -245,7 +245,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `column.custom_max` Metric against our success keys:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _validate"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _validate"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -296,12 +296,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_aggregate_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py library_metadata"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations.md
@@ -76,28 +76,28 @@ By convention, your <TechnicalTag tag="metric" text="Metric" /> class is defined
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ExpectColumnValuesToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ExpectColumnValuesToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ExpectColumnValuesToEqualThree class_def"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ExpectColumnValuesToEqualThree class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py docstring"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py diagnostics"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py diagnostics"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -125,7 +125,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py examples"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -174,7 +174,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@column_condition_partial` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to calculate whether values equal 3 using the `PandasExecutionEngine`.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py pandas"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py pandas"
 ```
 
 This is all that you need to define for now. The `ColumnMapMetricProvider` and `ColumnMapExpectation` classes have built-in logic to handle all the machinery of data validation, including standard parameters like `mostly`, generation of Validation Results, etc.
@@ -191,22 +191,22 @@ Next, choose a Metric Identifier for your Metric. By convention, Metric Identifi
 
 You'll need to substitute this metric into two places in the code. First, in the Metric class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py metric_name"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py metric_name"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py metric_name"
 ```
 
 Second, in the Expectation class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py map_metric"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py map_metric"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py map_metric"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py map_metric"
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -215,12 +215,12 @@ Finally, rename the Metric class name itself, using the camel case version of th
 
 For example, replace:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ColumnValuesMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py ColumnValuesMatchSomeCriteria class_def"
 ```
 
 with 
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ColumnValuesEqualThree class_def"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ColumnValuesEqualThree class_def"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -277,12 +277,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_map_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py library_metadata"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_pair_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_column_pair_map_expectations.md
@@ -75,28 +75,28 @@ By convention, your <TechnicalTag tag="metric" text="Metric" /> class is defined
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ExpectColumnPairValuesToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ExpectColumnPairValuesToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ExpectColumnPairValuesToHaveADifferenceOfThree class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ExpectColumnPairValuesToHaveADifferenceOfThree class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_print_diagnostic_checklist"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_print_diagnostic_checklist"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -126,7 +126,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -174,7 +174,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@column_pair_condition_partial` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to calculate whether the difference between the values in two columns equals 3 using the `PandasExecutionEngine`.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py _pandas"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py _pandas"
 ```
 
 This is all that you need to define for now. The `ColumnMapMetricProvider` and `ColumnMapExpectation` classes have built-in logic to handle all the machinery of data validation, including standard parameters like `mostly`, generation of Validation Results, etc.
@@ -191,22 +191,22 @@ Next, choose a Metric Identifier for your Metric. By convention, Metric Identifi
 
 You'll need to substitute this metric into two places in the code. First, in the Metric class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py metric_name"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py condition_metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py condition_metric_name"
 ```
 
 Second, in the Expectation class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py map_metric"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py map_metric"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py complete_map_metric"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py complete_map_metric"
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -215,12 +215,12 @@ Finally, rename the Metric class name itself, using the camel case version of th
 
 For example, replace:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ColumnPairValuesMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py ColumnPairValuesMatchSomeCriteria class_def"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ColumnPairValuesDiffThree class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py ColumnPairValuesDiffThree class_def"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -277,12 +277,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/column_pair_map_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_pair_values_to_have_a_difference_of_three.py completed_library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_multicolumn_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_multicolumn_map_expectations.md
@@ -76,28 +76,28 @@ By convention, your <TechnicalTag tag="metric" text="Metric" /> class is defined
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py ExpectMulticolumnValuesToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py ExpectMulticolumnValuesToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py ExpectMulticolumnValuesToBeMultiplesOfThree class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py ExpectMulticolumnValuesToBeMultiplesOfThree class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py print_diagnostic_checklist"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py print_diagnostic_checklist"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -125,7 +125,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -173,7 +173,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@multicolumn_condition_partial` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to calculate whether values across a set of columns are multiples of 3 using the `PandasExecutionEngine`.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py _pandas"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py _pandas"
 ```
 
 This is all that you need to define for now. The `MulticolumnMapMetricProvider` and `MulticolumnMapExpectation` classes have built-in logic to handle all the machinery of data validation, including standard parameters like `mostly`, generation of Validation Results, etc.
@@ -190,22 +190,22 @@ Next, choose a Metric Identifier for your Metric. By convention, Metric Identifi
 
 You'll need to substitute this metric into two places in the code. First, in the Metric class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py metric_name"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py condition_metric_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py condition_metric_name"
 ```
 
 Second, in the Expectation class, replace
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py map_metric"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py map_metric"
 ```
 
 with
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py map_metric"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py map_metric"
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -214,12 +214,12 @@ Finally, rename the Metric class name itself, using the camel case version of th
 
 For example, replace:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py MulticolumnValuesMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py MulticolumnValuesMatchSomeCriteria class_def"
 ```
 
 with 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py MulticolumnValuesMultipleThree class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py MulticolumnValuesMultipleThree class_def"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -276,12 +276,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_multicolumn_values_to_be_multiples_of_three.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_parameterized_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_parameterized_expectations.md
@@ -27,13 +27,13 @@ As can be seen in the implementation below, we have chosen to keep our default m
 
 Notice that we do not need to set `default_kwarg_values` for all kwargs: it is sufficient to set them only for ones for which we would like to set a default value. To keep our implementation simple, we do not override the `metric_dependencies` or `success_keys`.
 
-````python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py ExpectColumnMeanToBePositive_class_def"
+````python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py ExpectColumnMeanToBePositive_class_def"
 ````
 
 :::info
 We could also explicitly override our parent methods to modify the behavior of our new Expectation, for example by updating the configuration validation to require the values we set as defaults not be altered.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py validate_config"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py validate_config"
 ```
 :::
 
@@ -41,14 +41,14 @@ For another example, let's take a look at `expect_column_values_to_be_in_set`.
 
 In this case, we will only be changing our `value_set`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def"
 ```
 
 ## Contribute (Optional)
 
 If you plan to contribute your Expectation to the public open source project, you should include a `library_metadata` object. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations.md
@@ -104,27 +104,27 @@ Now we're going to begin laying the groundwork for the functionality of your Cus
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py ExpectQueriedTableRowCountToBe class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py ExpectQueriedTableRowCountToBe class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py print_diagnostic_checklist"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py print_diagnostic_checklist"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -159,7 +159,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -204,12 +204,12 @@ To implement your query, replace the `query` attribute of your Custom Expectatio
 
 This:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query"
 ```
 
 Becomes something like this:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py query"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py query"
 ```
 
 :::warning
@@ -237,12 +237,12 @@ To connect this Metric to our Custom Expectation, we'll need to include the `met
 
 This tuple:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies"
 ```
 
 Becomes:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py metric_dependencies"
 ```
 
 ### Other parameters
@@ -259,7 +259,7 @@ In this step, we simply need to validate that the results of our Metrics meet ou
 
 The validate method is implemented as `_validate(...)`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function signature"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function signature"
 ```
 
 This method takes a dictionary named `metrics`, which contains all Metrics requested by your Metric dependencies,
@@ -268,7 +268,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `query.table` Metric against our success keys:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_table_row_count_to_be.py _validate function"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -382,27 +382,27 @@ Now we're going to begin laying the groundwork for the functionality of your Cus
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py ExpectQueriedColumnValueFrequencyToMeetThreshold class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py ExpectQueriedColumnValueFrequencyToMeetThreshold class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py docstring"
 ```
 
 You'll also need to change the class name at the bottom of the file, by replacing this line:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py print_diagnostic_checklist()"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py print_diagnostic_checklist()"
 ```
 
 Later, you can go back and write a more thorough docstring.
@@ -436,7 +436,7 @@ Next, we're going to search for `examples = []` in your file, and replace it wit
 
 Your examples will look something like this:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -481,12 +481,12 @@ To implement your query, replace the `query` attribute of your Custom Expectatio
 
 This:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query"
 ```
 
 Becomes something like this:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py query"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py query"
 ```
 
 :::warning
@@ -517,12 +517,12 @@ In this case, we'll be using the `query.column` Metric, allowing us to parameter
 
 This tuple:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies"
 ```
 
 Becomes:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py metric_dependencies"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py metric_dependencies"
 ```
 
 ### Other parameters
@@ -539,7 +539,7 @@ In this step, we simply need to validate that the results of our Metrics meet ou
 
 The validate method is implemented as `_validate(...)`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function signature"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function signature"
 ```
 
 This method takes a dictionary named `metrics`, which contains all Metrics requested by your Metric dependencies,
@@ -548,7 +548,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `query.column` Metric against our success keys:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function"
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -611,12 +611,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_queried_column_value_frequency_to_meet_threshold.py _validate function library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_regex_based_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_regex_based_column_map_expectations.md
@@ -77,28 +77,28 @@ When in doubt, the next step to implement is the first one that doesn't have a â
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py ExpectColumnValuesToMatchSomeRegex class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py ExpectColumnValuesToMatchSomeRegex class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py ExpectColumnValuesToOnlyContainVowels class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py ExpectColumnValuesToOnlyContainVowels class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py diagnostics"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -126,7 +126,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -172,24 +172,24 @@ In the case of your Custom `RegexBasedColumnMapExpectation`, Great Expectations 
 
 To do this, we replace these:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py definition"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py definition"
 ```
 
 with something like this:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py definition"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py definition"
 ```
 
 For more detail when rendering your Custom Expectation, you can optionally specify the plural form of a Semantic Type you're validating.
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py plural"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py plural"
 ```
 
 becomes:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py plural"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py plural"
 ```
 
 Great Expectations will use these values to tell your Custom Expectation to apply your specified regex as a <TechnicalTag tag="metric" text="Metric"/> to be utilized in validating your data.
@@ -256,12 +256,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
@@ -76,28 +76,28 @@ When in doubt, the next step to implement is the first one that doesn't have a â
 Let's start by updating your Expectation's name and docstring.
 
 Replace the Expectation class name
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py ExpectColumnValuesToBeInSomeSet class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py ExpectColumnValuesToBeInSomeSet class_def"
 ```
 
 with your real Expectation class name, in upper camel case:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py ExpectColumnValuesToBeInSolfegeScaleSet class_def"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py ExpectColumnValuesToBeInSolfegeScaleSet class_def"
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py docstring"
 ```
 
 with something like:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py docstring"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py docstring"
 ```
 
 Make sure your one-line docstring begins with "Expect " and ends with a period. You'll also need to change the class name at the bottom of the file, by replacing this line:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py diagnostics"
 ```
 
 with this one:
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py diagnostics"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py diagnostics"
 ```
 
 Later, you can go back and write a more thorough docstring. See [Expectation Docstring Formatting](https://github.com/great-expectations/great_expectations/blob/develop/docs/expectation_gallery/3-expectation-docstring-formatting.md).
@@ -127,7 +127,7 @@ You're going to search for `examples = []` in your file, and replace it with at 
 
 Your examples will look similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py examples"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py examples"
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -173,24 +173,24 @@ In the case of your Custom `SetBasedColumnMapExpectation`, Great Expectations wi
 
 To do this, we replace these:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py set"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py set"
 ```
 
 with something like this:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py set"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py set"
 ```
 
 For more detail when rendering your Custom Expectation, you can optionally specify the semantic name of the set you're validating.
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py semantic_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py semantic_name"
 ```
 
 becomes:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py semantic_name"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py semantic_name"
 ```
 
 Great Expectations will use these values to tell your Custom Expectation to apply your specified set as a <TechnicalTag tag="metric" text="Metric"/> to be utilized in validating your data.
@@ -257,12 +257,12 @@ This guide will leave you with a Custom Expectation sufficient for [contribution
 
 If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py library_metadata"
 ```
 
 would become
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py library_metadata"
+```python name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py library_metadata"
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py
@@ -21,12 +21,12 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 
 # This class defines a Metric to support your Expectation.
 # For most MulticolumnMapExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py MulticolumnValuesMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py MulticolumnValuesMatchSomeCriteria class_def">
 class MulticolumnValuesMatchSomeCriteria(MulticolumnMapMetricProvider):
     # </snippet>
     # This is the id string that will be used to reference your metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py metric_name">
-    condition_metric_name = "version-0.18 METRIC NAME GOES HERE"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py metric_name">
+    condition_metric_name = "METRIC NAME GOES HERE"
     # </snippet>
     # These point your metric at the provided keys to facilitate calculation
     condition_domain_keys = (
@@ -40,7 +40,7 @@ class MulticolumnValuesMatchSomeCriteria(MulticolumnMapMetricProvider):
     condition_value_keys = ()
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py pandas">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py pandas">
     @multicolumn_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column_list, **kwargs):
         raise NotImplementedError
@@ -59,10 +59,10 @@ class MulticolumnValuesMatchSomeCriteria(MulticolumnMapMetricProvider):
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py ExpectMulticolumnValuesToMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py ExpectMulticolumnValuesToMatchSomeCriteria class_def">
 class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
@@ -72,7 +72,7 @@ class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
 
     # This is the id string of the Metric used by this Expectation.
     # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py map_metric">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py map_metric">
     map_metric = "METRIC NAME GOES HERE"
     # </snippet>
 
@@ -111,7 +111,7 @@ class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -122,6 +122,6 @@ class ExpectMulticolumnValuesToMatchSomeCriteria(MulticolumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/multicolumn_map_expectation_template.py diagnostics">
     ExpectMulticolumnValuesToMatchSomeCriteria().print_diagnostic_checklist()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py
@@ -17,27 +17,27 @@ from great_expectations.expectations.expectation_configuration import (
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py ExpectQueryToMatchSomeCriteria class_def">
 class ExpectQueryToMatchSomeCriteria(QueryExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
     # This is the id string of the Metric(s) used by this Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py metric_dependencies">
     metric_dependencies = ("METRIC NAME GOES HERE",)
     # </snippet>
 
     # This is the default, baked-in SQL Query for this QueryExpectation
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py sql_query">
     query: str = """
             SQL QUERY GOES HERE
             """
     # </snippet>
 
     # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py success_keys">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py success_keys">
     success_keys = ("query",)
     # </snippet>
 
@@ -71,7 +71,7 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
         #     raise InvalidExpectationConfigurationError(str(e))
 
     # This method performs a validation of your metrics against your success keys, returning a dict indicating the success or failure of the Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py _validate">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py _validate">
     def _validate(
         self,
         configuration: ExpectationConfiguration,
@@ -85,12 +85,12 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py examples">
     examples = []
     # </snippet>
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -101,6 +101,6 @@ class ExpectQueryToMatchSomeCriteria(QueryExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/query_expectation_template.py print_diagnostic_checklist">
     ExpectQueryToMatchSomeCriteria().print_diagnostic_checklist()
     # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py
@@ -10,19 +10,19 @@ from great_expectations.expectations.regex_based_column_map_expectation import (
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py ExpectColumnValuesToMatchSomeRegex class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py ExpectColumnValuesToMatchSomeRegex class_def">
 class ExpectColumnValuesToMatchSomeRegex(RegexBasedColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
     # These values will be used to configure the metric created by your expectation
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py definition">
-    regex_camel_name = "version-0.18 RegexName"
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py definition">
+    regex_camel_name = "RegexName"
     regex = "regex pattern"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py plural">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py plural">
     semantic_type_name_plural = None
     # </snippet>
 
@@ -37,7 +37,7 @@ class ExpectColumnValuesToMatchSomeRegex(RegexBasedColumnMapExpectation):
     )
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py library_metadata">
     library_metadata = {
         "tags": [],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -48,6 +48,6 @@ class ExpectColumnValuesToMatchSomeRegex(RegexBasedColumnMapExpectation):
 
 # </snippet>
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/regex_based_column_map_expectation_template.py diagnostics">
     ExpectColumnValuesToMatchSomeRegex().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py
@@ -10,26 +10,26 @@ from great_expectations.expectations.set_based_column_map_expectation import (
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py ExpectColumnValuesToBeInSomeSet class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py ExpectColumnValuesToBeInSomeSet class_def">
 class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py docstring">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py docstring">
     """TODO: Add a docstring here"""
     # </snippet>
 
     # These values will be used to configure the metric created by your expectation
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py set">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py set">
     set_ = []
 
-    set_camel_name = "version-0.18 SetName"
+    set_camel_name = "SetName"
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py semantic_name">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py semantic_name">
     set_semantic_name = None
     # </snippet>
 
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py examples">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py examples">
     examples = []
     # </snippet>
 
@@ -40,7 +40,7 @@ class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
     )
 
     # This object contains metadata for display in the public Gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py library_metadata">
     library_metadata = {
         "tags": ["set-based"],  # Tags for this Expectation in the Gallery
         "contributors": [  # Github handles for all contributors to this Expectation.
@@ -51,6 +51,6 @@ class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
 
 # </snippet>
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/set_based_column_map_expectation_template.py diagnostics">
     ExpectColumnValuesToBeInSomeSet().print_diagnostic_checklist()
 #     </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py
@@ -11,7 +11,7 @@ from great_expectations.core.evaluation_parameters import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py ExpectColumnMeanToBePositive_class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py ExpectColumnMeanToBePositive_class_def">
 class ExpectColumnMeanToBePositive(gxe.ExpectColumnMeanToBeBetween):
     """Expect the mean of values in this column to be positive."""
 
@@ -19,7 +19,7 @@ class ExpectColumnMeanToBePositive(gxe.ExpectColumnMeanToBeBetween):
     strict_min = True
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py validate_config">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py validate_config">
     def validate_configuration(self, configuration):
         super().validate_configuration(configuration)
         assert "min_value" not in configuration.kwargs, "min_value cannot be altered"
@@ -28,7 +28,7 @@ class ExpectColumnMeanToBePositive(gxe.ExpectColumnMeanToBeBetween):
         assert "strict_max" not in configuration.kwargs, "strict_max cannot be altered"
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_mean_to_be_positive.py library_metadata">
     library_metadata = {"tags": ["basic stats"], "contributors": ["@joegargery"]}
 
 
@@ -42,15 +42,15 @@ def test_expect_column_mean_to_be_positive(data_context_with_datasource_pandas_e
     df = pd.DataFrame({"a": [0, 1, 3, 4, 5]})
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
 
     result = validator.expect_column_mean_to_be_positive(column="a")

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py
@@ -9,7 +9,7 @@ from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context import AbstractDataContext
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/creating_custom_expectations/test_expect_column_values_to_be_in_set.py ExpectColumnValuesToBeTwoLetterCountryCode_class_def">
 class ExpectColumnValuesToBeTwoLetterCountryCode(gxe.ExpectColumnValuesToBeInSet):
     value_set: List[str] = ["FR", "DE", "CH", "ES", "IT", "BE", "NL", "PL"]
 
@@ -36,15 +36,15 @@ def test_expect_column_values_to_be_in_set_fail(
     )
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
 
     result = validator.expect_column_values_to_be_in_set(
@@ -74,15 +74,15 @@ def test_expect_column_values_in_set_pass(
     )
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
 
     result = validator.expect_column_values_to_be_in_set(
@@ -121,15 +121,15 @@ def test_expect_column_values_country_fail(
     )
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
 
     result = validator.expect_column_values_to_be_two_letter_country_code(column="a")
@@ -146,15 +146,15 @@ def test_expect_column_values_country_pass(
     df = pd.DataFrame({"a": ["FR", "DE", "CH", "ES", "IT", "BE", "NL", "PL"]})
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
 
     result = validator.expect_column_values_to_be_two_letter_country_code(column="a")
@@ -183,15 +183,15 @@ def test_expect_column_values_to_be_in_set_invalid_set(
     )
 
     batch_request = RuntimeBatchRequest(
-        datasource_name="version-0.18 my_datasource",
-        data_connector_name="version-0.18 default_runtime_data_connector_name",
-        data_asset_name="version-0.18 my_data_asset",
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
         runtime_parameters={"batch_data": df},
         batch_identifiers={"default_identifier_name": "my_identifier"},
     )
     validator = context.get_validator(
         batch_request=batch_request,
-        create_expectation_suite_with_name="version-0.18 test",
+        create_expectation_suite_with_name="test",
     )
     with pytest.raises(pydantic.ValidationError):
         _ = validator.expect_column_values_to_be_in_set(column="a", value_set="foo")

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.md
@@ -31,12 +31,12 @@ In the following examples, you'll be using existing New York taxi trip data to c
 
 This is the `Data Source` configuration:
  
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py datasource_config"
+```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py datasource_config"
 ```
 
 This is the `Validator` configuration:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py validator"
+```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py validator"
 ```
 
 :::caution
@@ -49,12 +49,12 @@ To run a Data Assistant, you can call the `run(...)` method for the assistant. T
 
 1. Run the following code to define the columns to exclude:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py exclude_column_names"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py exclude_column_names"
   ```
 
 2. Run the following code to run the Missingness Data Assistant:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py data_assistant_result"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py data_assistant_result"
   ```
 
   In this example, `context` is your Data Context instance.
@@ -75,13 +75,13 @@ To run a Data Assistant, you can call the `run(...)` method for the assistant. T
 
 After executing the Missingness Data Assistant's `run(...)` method and generating Expectations for your data, run the following code to generate an Expectation Suite and save it to your Validator:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py save_validator"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py save_validator"
   ```
 ## Test your Expectation Suite
 
 Run the following code to use a Checkpoint to operate with the Expectation Suite and Validator that you defined:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py checkpoint"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py checkpoint"
   ```
 
 You can check the `"success"` key of the Checkpoint's results to verify that your Expectation Suite worked.
@@ -90,7 +90,7 @@ You can check the `"success"` key of the Checkpoint's results to verify that you
 
 1. Run the following code to view Batch-level visualizations of the Metrics computed by the Missingness Data Assistant:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py plot_metrics"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py plot_metrics"
   ```
 
   ![Plot Metrics](/docs/oss/images/data_assistant_plot_metrics.png)
@@ -101,7 +101,7 @@ You can check the `"success"` key of the Checkpoint's results to verify that you
 
 2. Run the following command to view the Expectations produced and grouped by Expectation type:
 
-  ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py show_expectations_by_expectation_type"
+  ```python name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py show_expectations_by_expectation_type"
   ```
 
 ## Edit your Expectation Suite (Optional)

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py
@@ -21,23 +21,23 @@ context = gx.get_context()
 
 # Configure your datasource (if you aren't using one that already exists)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py datasource_config">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py datasource_config">
 datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 taxi_multi_batch_datasource",  # custom name to assign to new datasource, can be used to retrieve datasource later
+    name="taxi_multi_batch_datasource",  # custom name to assign to new datasource, can be used to retrieve datasource later
     base_directory="./data",  # replace with your data directory
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py validator">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py validator">
 validator = datasource.read_csv(
-    asset_name="version-0.18 all_years",  # custom name to assign to the asset, can be used to retrieve asset later
+    asset_name="all_years",  # custom name to assign to the asset, can be used to retrieve asset later
     batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
 )
 # </snippet>
 
 # Run the Missingness Assistant
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py exclude_column_names">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py exclude_column_names">
 exclude_column_names = [
     "VendorID",
     "pickup_datetime",
@@ -56,7 +56,7 @@ exclude_column_names = [
 ]
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py data_assistant_result">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py data_assistant_result">
 data_assistant_result = context.assistants.missingness.run(
     validator=validator,
     exclude_column_names=exclude_column_names,
@@ -65,19 +65,19 @@ data_assistant_result = context.assistants.missingness.run(
 
 # Save your Expectation Suite
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py save_validator">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py save_validator">
 validator.expectation_suite = data_assistant_result.get_expectation_suite(
-    expectation_suite_name="version-0.18 my_custom_expectation_suite_name"
+    expectation_suite_name="my_custom_expectation_suite_name"
 )
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
 # Use a Checkpoint to verify that your new Expectation Suite works.
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py checkpoint">
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 yellow_tripdata_sample_all_years_checkpoint",
+    name="yellow_tripdata_sample_all_years_checkpoint",
     validator=validator,
 )
 checkpoint_result = checkpoint.run()
@@ -93,11 +93,11 @@ assert checkpoint_result["success"] is True
 # context.open_data_docs(resource_identifier=validation_result_identifier)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py plot_metrics">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py plot_metrics">
 data_assistant_result.plot_metrics()
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py show_expectations_by_expectation_type">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/data_assistants/how_to_create_an_expectation_suite_with_the_missingness_data_assistant.py show_expectations_by_expectation_type">
 data_assistant_result.show_expectations_by_expectation_type()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_example_cases_for_an_expectation.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_example_cases_for_an_expectation.md
@@ -137,7 +137,7 @@ You will need to:
 
 If you are interested in contributing your Custom Expectation back to Great Expectations, you will also need to decide if you want these tests publicly displayed to demonstrate the functionality of your Custom Expectation (`include_in_gallery`).
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
 ```
 
 :::note

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation.md
@@ -43,7 +43,7 @@ To do this, we're going to write a series of `assert` statements to catch invali
 
 To begin with, we want to create our `validate_configuration(...)` method and ensure that a configuration is set:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config"
 ```
 
 Next, we're going to implement the logic for validating the four parameters we identified above.
@@ -52,34 +52,34 @@ Next, we're going to implement the logic for validating the four parameters we i
 
 First we need to access the parameters to be evaluated:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_params"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_params"
 ```
 
 Now we can begin writing the assertions to validate these parameters. 
 
 We're going to ensure that at least one of `min_value` or `max_value` is set:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_values"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_values"
 ```
 
 Check that `min_value` and `max_value` are of the correct type:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_types"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_types"
 ```
 
 Verify that, if both `min_value` and `max_value` are set, `min_value` does not exceed `max_value`:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_comparison"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_comparison"
 ```
 
 And assert that `strict_min` and `strict_max`, if provided, are of the correct type:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_none"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_none"
 ```
 
 If any of these fail, we raise an exception:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_except"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_except"
 ```
 
 Putting this all together, our `validate_configuration(...)` method should verify that all necessary inputs have been provided, 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation.md
@@ -29,7 +29,7 @@ To avoid surprises and help clearly define your Custom Expectation, it can be he
 
 Within the `examples` defined inside your Expectation class, the optional `only_for` and `suppress_test_for` keys specify which backends to use for testing. If a backend is not specified, Great Expectations attempts testing on all supported backends. Run the following command to add entries corresponding to the functionality you want to add: 
     
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
 ```
 
 :::note
@@ -70,7 +70,7 @@ The decorated method takes in a Spark `Column` object and will either return a `
 
 For our Custom Column Aggregate Expectation `ExpectColumnMaxToBeBetweenCustom`, we're going to leverage PySpark's `max` SQL Function and the `@column_aggregate_partial` decorator.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _spark"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _spark"
 ```
 
 If we need a builtin function from `pyspark.sql.functions`, usually aliased to `F`, the import logic in 
@@ -115,7 +115,7 @@ While this approach can result in extra roundtrips to your database, it can also
 For our Custom Column Map Expectation `ExpectColumnValuesToEqualThree`, we're going to implement the `@metric_partial` decorator, 
 specifying the type of value we're computing (`MAP_CONDITION_FN`) and the domain over which we're computing (`COLUMN`):
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_definition"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_definition"
 ```
 
 The decorated method takes in a valid Execution Engine and relevant `kwargs`,
@@ -128,12 +128,12 @@ These will be used to execute our query and compute the results of our metric.
 
 To do this, we need to access our Compute Domain directly:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_selectable"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_selectable"
 ```
 
 This allows us to build and return a query to be executed, providing the result of our metric:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_query"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_query"
 ```
 
 :::note

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation.md
@@ -31,7 +31,7 @@ To avoid surprises, it can be helpful to determine beforehand what backends and 
 
 Within the `examples` defined inside your Expectation class, the optional `only_for` and `suppress_test_for` keys specify which backends to use for testing. If a backend is not specified, Great Expectations attempts testing on all supported backends. Run the following command to add entries corresponding to the functionality you want to add: 
     
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples"
 ```
 
 :::note
@@ -69,7 +69,7 @@ The decorated method takes in an SQLAlchemy `Column` object and will either retu
   
 For our Custom Column Map Expectation `ExpectColumnValuesToEqualThree`, we're going to leverage SQLAlchemy's `in_` ColumnOperator and the `@column_condition_partial` decorator.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py sqlalchemy"
+```python name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py sqlalchemy"
 ```
 
 <details>
@@ -110,7 +110,7 @@ While this approach can result in extra roundtrips to your database, it can also
 For our Custom Column Aggregate Expectation `ExpectColumnMaxToBeBetweenCustom`, we're going to implement the `@metric_value` decorator, 
 specifying the type of value we're computing (`AGGREGATE_VALUE`) and the domain over which we're computing (`COLUMN`):
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_def"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_def"
 ```
 
 The decorated method takes in a valid <TechnicalTag tag="execution_engine" text="Execution Engine"/> and relevant key word arguments,
@@ -118,12 +118,12 @@ and will return a computed value.
 
 To do this, we need to access our Compute Domain directly:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_selectable"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_selectable"
 ```
 
 This allows us to build a query and use our Execution Engine to execute that query against our data to return the actual value we're looking for, instead of returning a query to find that value:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_query"
+```python name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_query"
 ```
 
 <details>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
@@ -14,18 +14,18 @@ data_directory = pathlib.Path(
     "taxi_yellow_tripdata_samples",
 ).resolve(strict=True)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py get_data_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py get_data_context">
 import great_expectations as gx
 
 context = gx.get_context(project_root_dir=full_path_to_project_directory)
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_suite">
-suite = context.add_expectation_suite(expectation_suite_name="version-0.18 my_suite")
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_suite">
+suite = context.add_expectation_suite(expectation_suite_name="my_suite")
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_1">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_1">
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -63,7 +63,7 @@ suite.add_expectation_configuration(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_2">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_2">
 expectation_configuration_2 = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_in_set",
     kwargs={
@@ -77,7 +77,7 @@ suite.add_expectation_configuration(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_3">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_3">
 expectation_configuration_3 = ExpectationConfiguration(
     expectation_type="expect_column_values_to_not_be_null",
     kwargs={
@@ -96,7 +96,7 @@ suite.add_expectation_configuration(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_4">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_4">
 expectation_configuration_4 = ExpectationConfiguration(
     expectation_type="expect_column_values_to_not_be_null",
     kwargs={
@@ -122,6 +122,6 @@ assert suite.expectations[1] == expectation_configuration_2.to_domain_obj()
 assert suite.expectations[2] == expectation_configuration_3.to_domain_obj()
 assert suite.expectations[3] == expectation_configuration_4.to_domain_obj()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py save_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py save_expectation_suite">
 context.save_expectation_suite(expectation_suite=suite)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_based_on_domain_knowledge_without_inspecting_data_directly.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_based_on_domain_knowledge_without_inspecting_data_directly.md
@@ -44,7 +44,7 @@ For this guide we will be working with Python code in a Jupyter Notebook. Jupyte
 
 Run the following code to import Great Expectations and instantiate a Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py get_data_context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py get_data_context"
 ```
 
 :::info Data Contexts and persisting data
@@ -57,26 +57,26 @@ If you're using an Ephemeral Data Context, your configurations will not persist 
 
 We will use the `add_expectation_suite()` method to create an empty ExpectationSuite.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_suite"
 ```
 
 ## Create Expectation Configurations
 
 You are adding Expectation configurations to the suite. Since there is no sample Batch of data, no <TechnicalTag tag="validation" text="Validation" /> happens during this process. To illustrate how to do this, consider a hypothetical example. Suppose that you have a table with the columns ``account_id``, ``user_id``, ``transaction_id``, ``transaction_type``, and ``transaction_amt_usd``. Then the following code snipped adds an Expectation that the columns of the actual table will appear in the order specified above:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_1"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_1"
 ```
 
 Here are a few more example expectations for this dataset:
 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_2"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_2"
 ```
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_3"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_3"
 ```
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_4"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py create_expectation_4"
 ```
 
 You can see all the available Expectations in the [Expectation Gallery](https://greatexpectations.io/expectations).
@@ -85,7 +85,7 @@ You can see all the available Expectations in the [Expectation Gallery](https://
 
 To keep your Expectations for future use, you save them to your Data Context.  A Filesystem or Cloud Data Context persists outside the current Python session, so saving the Expectation Suite in your Data Context's Expectations Store ensures you can access it in the future:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py save_expectation_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py save_expectation_suite"
 ```
 
 :::caution Ephemeral Data Contexts and persistence

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py
@@ -1,51 +1,51 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py imports and data context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py imports and data context">
 import great_expectations as gx
 
 context = gx.get_context()
 # </snippet>
 
 context.sources.add_pandas(
-    name="version-0.18 my_datasource",
+    name="my_datasource",
 ).add_csv_asset(
-    name="version-0.18 my_data_asset",
+    name="my_data_asset",
     filepath_or_buffer="./data/yellow_tripdata_sample_2019-01.csv",
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_data_asset_and_build_batch_request">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_data_asset_and_build_batch_request">
 data_asset = context.get_datasource("my_datasource").get_asset("my_data_asset")
 batch_request = data_asset.build_batch_request()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py create_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py create_expectation_suite">
 context.add_or_update_expectation_suite("my_expectation_suite")
 # Optional. Run assert "my_expectation_suite" in context.list_expectation_suite_names() to veriify the Expectation Suite was created.
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_validator_and_inspect_data">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_validator_and_inspect_data">
 validator = context.get_validator(
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 my_expectation_suite",
+    expectation_suite_name="my_expectation_suite",
 )
 validator.head()
 # </snippet>
 
 # this snippet is only for users who are not using a jupyter notebook
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py inspect_data_no_jupyter">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py inspect_data_no_jupyter">
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation">
 validator.expect_column_values_to_not_be_null(column="vendor_id")
 # </snippet>
 
 # this snippet is only for users who are not using a jupyter notebook
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation_no_jupyter">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation_no_jupyter">
 expectation_validation_result = validator.expect_column_values_to_not_be_null(
     column="vendor_id"
 )
 print(expectation_validation_result)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py save_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py save_expectation_suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md
@@ -32,7 +32,7 @@ For this guide we will be working with Python code in a Jupyter Notebook. Jupyte
 
 Run the following code to import Great Expectations and instantiate a Data Context:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py imports and data context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py imports and data context"
 ```
 
 :::info Data Contexts and persisting data
@@ -45,7 +45,7 @@ If you're using an Ephemeral Data Context, your configurations will not persist 
 
 Add the following method to retrieve a previously configured Data Asset from the Data Context you initialized and create a Batch Request to identify the Batch of data that you'll use to validate your Expectations:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_data_asset_and_build_batch_request"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_data_asset_and_build_batch_request"
 ```
 
 :::info Limit the Batches returned by a Batch Request
@@ -62,26 +62,26 @@ When you use a Validator to interactively create your Expectations, the Validato
 
 If you're using a Jupyter Notebook you'll automatically see the results of the code you run in a new cell when you run the code. If you're using a different interpreter, you might need to explicitly print these results to view them. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py inspect_data_no_jupyter"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py inspect_data_no_jupyter"
 ```
 
 :::
 
 1. Optional. Run the following command if you haven't created an Expectation Suite:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py create_expectation_suite"
+    ```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py create_expectation_suite"
     ```
 
 2. Run the following command to create a Validator:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_validator_and_inspect_data"
+    ```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py get_validator_and_inspect_data"
     ```
 
 ## Use the Validator to create and run an Expectation
 
 The Validator provides access to all the available Expectations as methods.  When an `expect_*()` method is run from the Validator, the Validator adds the specified Expectation to an Expectation Suite (or edits an existing Expectation in the Expectation Suite, if applicable) in its configuration, and then the specified Expectation is run against the data that was provided when the Validator was initialized with a Batch Request.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation"
 ```
 
 Since we are working in a Jupyter Notebook, the results of the Validation are printed after we run an `expect_*()` method.  We can examine those results to determine if the Expectation needs to be edited.
@@ -89,7 +89,7 @@ Since we are working in a Jupyter Notebook, the results of the Validation are pr
 :::info Working outside a Jupyter Notebook
 If you are not working in a Jupyter Notebook you may need to explicitly print your results:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation_no_jupyter"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py interactive_validation_no_jupyter"
 ```
 
 :::
@@ -110,7 +110,7 @@ The Expectations you create with the interactive method are saved in an Expectat
 
 To keep your Expectations for future use, you save them to your Data Context.  A Filesystem or Cloud Data Context persists outside the current Python session, so saving the Expectation Suite in your Data Context's Expectations Store ensures you can access it in the future:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py save_expectation_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_fluent.py save_expectation_suite"
 ```
 
 :::caution Ephemeral Data Contexts and persistence

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_edit_an_existing_expectationsuite.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_edit_an_existing_expectationsuite.md
@@ -27,14 +27,14 @@ All the code used in the examples is available in GitHub at this location: [how_
 
 Run the following code to create a new Data Context with the `get_context()` method:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py get_context"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py get_context"
 ```
 
 ## Create a Validator from Data 
 
 Run the following code to connect to `.csv` data stored in the `great_expectations` GitHub repository:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py create_validator"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py create_validator"
 ```
 
 ## Retrieve an existing Expectation Suite 
@@ -50,7 +50,7 @@ Replace `expectation_suite_name` with the name of your Expectation Suite.
 
 Run the following code to print the Suite to console or Jupyter Notebook the `show_expectations_by_expectation_type()` method:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py show_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py show_suite"
 ```
 
 The output appears similar to the following example: 
@@ -74,32 +74,32 @@ From the Expectation Suite, you can create an ExpectationConfiguration object us
 
 It runs the `expect_column_values_to_be_between` Expectation on the `passenger_count` column and expects the min and max values to be `1` and `6` respectively. 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_dict_1"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_dict_1"
 ```
 
 The following is the same configuration with an `ExpectationConfiguration` object:  
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py import_expectation_configuration"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py import_expectation_configuration"
 ```
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_configuration_1"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_configuration_1"
 ```
 
 ## Update the Configuration and Expectation Suite
 
 In the following example, the `max_value` of the Expectation is adjusted from `4` to `6` with a new `ExpectationConfiguration`: 
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py updated_configuration"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py updated_configuration"
 ```
 
 To update the Expectation Suite you use the `add_expectation()` function. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py add_configuration"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py add_configuration"
 ```
 The `add_expectation()` function performs an 'upsert' into the `ExpectationSuite` and updates the existing Expectation, or adds a new one if it doesn't.
 
 To check that the Expectation Suite has been updated, you can run the `show_expectations_by_expectation_type()` function again, or run `find_expectation()` and then confirm that the expected Expectation exists in the suite. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py find_configuration"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py find_configuration"
 ```
 
 You'll need to perform the search with a new `ExpectationConfiguration`, but you don't need to include all the `kwarg` values.
@@ -108,7 +108,7 @@ You'll need to perform the search with a new `ExpectationConfiguration`, but you
 
 To remove an `ExpectationConfiguration`, you can use the `remove_configuration()` function. Similar to `find_expectation()`, you call the `remove_configuration()` function with `ExpectationConfiguration`. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py remove_configuration"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py remove_configuration"
 ```
 
 The output of `show_expectations_by_expectation_type()` should appear similar to this example: 
@@ -123,7 +123,7 @@ The output of `show_expectations_by_expectation_type()` should appear similar to
 
 After editing an Expectation Suite, you can use the `save_suite()` function to save it to your Data Context. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py save_suite"
+```python name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py save_suite"
 ```
 To make sure your Expectation Suite changes are reflected in the Validator, use `context.get_validator()` to overwrite the `validator`, or create a new one from the updated Data Context.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_edit_an_expectation_suite.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_edit_an_expectation_suite.py
@@ -1,6 +1,6 @@
 # ruff: noqa: I001, E401, B018
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py import_expectation_configuration">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py import_expectation_configuration">
 from great_expectations.expectations.expectation_configuration import (
     ExpectationConfiguration,
 )
@@ -14,14 +14,14 @@ import sys, io
 stdout = sys.stdout
 sys.stdout = io.StringIO()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py get_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py get_context">
 import great_expectations as gx
 import great_expectations.expectations as gxe
 
 context = gx.get_context()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py create_validator">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py create_validator">
 validator = context.sources.pandas_default.read_csv(
     "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
 )
@@ -35,11 +35,11 @@ validator.expect_column_values_to_be_between(
 
 my_suite = validator.get_expectation_suite()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py show_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py show_suite">
 my_suite.show_expectations_by_expectation_type()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_dict_1">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_dict_1">
 
 {
     "expect_column_values_to_be_between": {
@@ -53,7 +53,7 @@ my_suite.show_expectations_by_expectation_type()
 }
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_configuration_1">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py example_configuration_1">
 config = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_between",
     kwargs={
@@ -68,7 +68,7 @@ config = ExpectationConfiguration(
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py updated_configuration">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py updated_configuration">
 updated_config = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_between",
     kwargs={
@@ -83,7 +83,7 @@ updated_config = ExpectationConfiguration(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py add_configuration">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py add_configuration">
 my_suite.add_expectation_configuration(updated_config)
 # </snippet>
 
@@ -93,7 +93,7 @@ assert isinstance(my_suite.expectations[1], gxe.ExpectColumnValuesToBeBetween)
 assert my_suite.expectations[1] == updated_config.to_domain_obj()
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py find_configuration">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py find_configuration">
 config_to_search = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_between",
     kwargs={"column": "passenger_count"},
@@ -105,7 +105,7 @@ assert len(found_expectation) == 1
 # </snippet>
 assert found_expectation[0].to_domain_obj() == updated_config.to_domain_obj()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py remove_configuration">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py remove_configuration">
 config_to_remove = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_between",
     kwargs={"column": "passenger_count"},
@@ -127,6 +127,6 @@ assert my_suite.expectation_configurations[0] == ExpectationConfiguration(
     kwargs={"column": "pickup_datetime"},
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py save_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/expectations/how_to_edit_an_expectation_suite.py save_suite">
 context.save_expectation_suite(my_suite)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.md
@@ -20,12 +20,12 @@ The quickest way to get started is by setting up your credentials as environment
 
 First set values by entering ``export ENV_VAR_NAME=env_var_value`` in the terminal or adding the commands to your ``~/.bashrc`` file:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py export_env_vars"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py export_env_vars"
 ```
 
 These can then be loaded into the `connection_string` parameter when we are adding a `datasource` to the Data Context.
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credentials_as_connection_string"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credentials_as_connection_string"
 ```
 
 
@@ -47,7 +47,7 @@ A more advanced option is to use the config variables YAML file. YAML files make
 
 If using a YAML file, save desired credentials or config values to ``great_expectations/uncommitted/config_variables.yml``:
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py config_variables_yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py config_variables_yaml"
 ```
 
 :::note
@@ -59,7 +59,7 @@ If using a YAML file, save desired credentials or config values to ``great_expec
 
 Then the config variable can be loaded into the `connection_string` parameter when we are adding a `datasource` to the Data Context.
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credential_from_yml"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credential_from_yml"
 ```
 
 ## Additional Notes
@@ -149,12 +149,12 @@ Once configured, the credentials can be loaded into the `connection_string` para
 ```python 
 # We can use a single connection string
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${my_aws_creds}"
+    name="my_postgres_db", connection_string="${my_aws_creds}"
 )
 
 # Or each component of the connection string separately
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
+    name="my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
 )
 ```
 
@@ -223,12 +223,12 @@ Once configured, the credentials can be loaded into the `connection_string` para
 ```python 
 # We can use a single connection string 
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${my_gcp_creds}"
+    name="my_postgres_db", connection_string="${my_gcp_creds}"
 )
 
 # Or each component of the connection string separately
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
+    name="my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
 )
 ```
 
@@ -298,12 +298,12 @@ Once configured, the credentials can be loaded into the `connection_string` para
 ```python 
 # We can use a single connection string
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${my_gcp_creds}"
+    name="my_postgres_db", connection_string="${my_gcp_creds}"
 )
 
 # Or each component of the connection string separately
 pg_datasource = context.sources.add_or_update_sql(
-    name="version-0.18 my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
+    name="my_postgres_db", connection_string="${drivername}://${username}:${password}@${host}:${port}/${database}"
 )
 ```
 </TabItem>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py
@@ -9,14 +9,14 @@ from tests.test_utils import load_data_into_test_database
 yaml = YAMLHandler()
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py export_env_vars">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py export_env_vars">
 export MY_DB_PW=password
 export POSTGRES_CONNECTION_STRING=postgresql://postgres:${MY_DB_PW}@localhost:5432/postgres
 # </snippet>
 """
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py config_variables_yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py config_variables_yaml">
 my_postgres_db_yaml_creds: postgresql://localhost:${MY_DB_PW}@$localhost:5432/postgres
 # </snippet>
 """
@@ -32,7 +32,7 @@ config_variables_file_path: uncommitted/config_variables.yml
 
 # add test_data to database for testing
 load_data_into_test_database(
-    table_name="version-0.18 postgres_taxi_data",
+    table_name="postgres_taxi_data",
     csv_path="./data/yellow_tripdata_sample_2019-01.csv",
     connection_string="postgresql://postgres:${MY_DB_PW}@localhost:5432/postgres",
 )
@@ -57,22 +57,22 @@ context_config_variables_file_path = pathlib.Path(
 with open(context_config_variables_file_path, "w+") as f:
     f.write(config_variables_yaml)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credentials_as_connection_string">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credentials_as_connection_string">
 # The password can be added as an environment variable
 pg_datasource = context.sources.add_or_update_postgres(
-    name="version-0.18 my_postgres_db",
+    name="my_postgres_db",
     connection_string="postgresql://postgres:${MY_DB_PW}@localhost:5432/postgres",
 )
 
 # Alternately, the full connection string can be added as an environment Variable
 pg_datasource = context.sources.add_or_update_postgres(
-    name="version-0.18 my_postgres_db",
+    name="my_postgres_db",
     connection_string="${POSTGRES_CONNECTION_STRING}",
 )
 # </snippet>
 
 pg_datasource.add_table_asset(
-    name="postgres_taxi_data", table_name="version-0.18 postgres_taxi_data"
+    name="postgres_taxi_data", table_name="postgres_taxi_data"
 )
 
 assert context.list_datasources() == [
@@ -94,14 +94,14 @@ assert context.list_datasources() == [
 ]
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credential_from_yml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/how_to_configure_credentials.py add_credential_from_yml">
 # Variables in config_variables.yml can be referenced in the connection string
 pg_datasource = context.sources.add_or_update_postgres(
-    name="version-0.18 my_postgres_db", connection_string="${my_postgres_db_yaml_creds}"
+    name="my_postgres_db", connection_string="${my_postgres_db_yaml_creds}"
 )
 # </snippet>
 pg_datasource.add_table_asset(
-    name="postgres_taxi_data", table_name="version-0.18 postgres_taxi_data"
+    name="postgres_taxi_data", table_name="postgres_taxi_data"
 )
 assert context.list_datasources() == [
     {

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_convert_an_ephemeral_data_context_to_a_filesystem_data_context.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/how_to_convert_an_ephemeral_data_context_to_a_filesystem_data_context.md
@@ -25,7 +25,7 @@ An Ephemeral Data Context is a temporary, in-memory Data Context that will not p
 
 To confirm that you're working with an Ephemeral Data Context, run the following code:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py check_data_context_is_ephemeral"
+```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py check_data_context_is_ephemeral"
 ```
 
 In the example code, it is assumed that your Data Context is stored in the variable `context`.
@@ -40,7 +40,7 @@ You can determine if your current working directory already has a Filesystem Dat
 
 Converting an Ephemeral Data Context into a Filesystem Data Context can be done with one line of code:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context"
+```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context"
 ```
 
 :::info Replacing the Ephemeral Data Context

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py
@@ -12,7 +12,7 @@ from great_expectations.data_context.data_context.file_data_context import (
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py path_to_empty_folder">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py path_to_empty_folder">
 path_to_empty_folder = "/my_gx_project/"
 # </snippet>
 
@@ -22,7 +22,7 @@ path_to_context_root_folder = project_root_dir / FileDataContext.GX_DIR
 path_to_empty_folder = project_root_dir
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context">
 from great_expectations.data_context import FileDataContext
 
 context = FileDataContext.create(project_root_dir=path_to_empty_folder)

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py
@@ -13,7 +13,7 @@ from great_expectations.data_context.data_context.file_data_context import (
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py path_to_project_root">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py path_to_project_root">
 path_to_project_root = "./my_project/"
 # </snippet>
 
@@ -24,7 +24,7 @@ assert context
 assert context.root_directory == str(path_to_context_root_folder)
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py get_filesystem_data_context">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py get_filesystem_data_context">
 context = gx.get_context(project_root_dir=path_to_project_root)
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/instantiate_data_context.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/instantiate_data_context.md
@@ -87,7 +87,7 @@ A <TechnicalTag tag="data_context" text="Data Context" /> is required in almost 
 
 Run the following command to initialize your Filesystem Data Context in an empty folder:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py path_to_empty_folder"
+```python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py path_to_empty_folder"
 ```
 
 ### Create a context
@@ -96,7 +96,7 @@ You provide the path for your empty folder to the GX library's `FileDataContext.
 
 For convenience, the `FileDataContext.create(...)` method instantiates and returns the newly initialized Data Context, which you can keep in a Python variable.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context"
+```python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_initialize_a_filesystem_data_context_in_python.py initialize_filesystem_data_context"
 ```
 
 :::info What if the folder is not empty?
@@ -132,14 +132,14 @@ If you're using GX for multiple projects, you might want to use a different Data
 
 Each Filesystem Data Context has a root folder in which it was initialized.  This root folder identifies the specific Filesystem Data Context to instantiate.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py path_to_project_root"
+```python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py path_to_project_root"
 ```
 
 ### Run the `get_context(...)` method
 
 You provide the path for your empty folder to the GX library's `get_context(...)` method as the `project_root_dir` parameter. Because you are providing a path to an empty folder, the `get_context(...)` method instantiates and return the Data Context at that location.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py get_filesystem_data_context"
+```python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_contexts/instantiating_data_contexts/how_to_instantiate_a_specific_filesystem_data_context.py get_filesystem_data_context"
 ```
 
 :::info Project root vs context root
@@ -192,26 +192,26 @@ To create your Data Context, you'll create a configuration that uses in-memory M
 
 1. Run the following command to import the `DataContextConfig` and the `InMemoryStoreBackendDefaults` classes:
 
-    ```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_data_context_config_with_in_memory_store_backend"
+    ```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_data_context_config_with_in_memory_store_backend"
     ```
 
 2. Run the following command to import the `EphemeralDataContext` class:
 
-    ```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_ephemeral_data_context"
+    ```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_ephemeral_data_context"
     ```
 
 ### Create the Data Context configuration
 
 Run the following command to create a Data Context configuration that specifies the use of in-memory Metadata Stores and pass in an instance of the `InMemoryStoreBackendDefaults` class as a parameter when initializing an instance of the `DataContextConfig` class:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_data_context_config_with_in_memory_store_backend"
+```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_data_context_config_with_in_memory_store_backend"
 ```
 
 ### Instantiate an Ephemeral Data Context
 
 Run the following command to initialize the `EphemeralDataContext` class while passing in the `DataContextConfig` instance you created as the value of the `project_config` parameter.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_ephemeral_data_context"
+```python name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_ephemeral_data_context"
 ```
 
 :::info Saving the contents of an Ephemeral Data Context for future use

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_add_a_new_s3_site_to_the_data_docs_sites_section_of_your_great_expectationsyml.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_add_a_new_s3_site_to_the_data_docs_sites_section_of_your_great_expectationsyml.mdx
@@ -1,5 +1,5 @@
 
 The following example shows the default `local_site` configuration that you will find in your `great_expectations.yml` file, followed by the `s3_site` configuration that you will need to add. To maintain a single S3 Data Docs site, remove the default `local_site` configuration and replace it with the new `s3_site` configuration.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_data_docs_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_data_docs_store"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_test_that_your_configuration_is_correct_by_building_the_site.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_test_that_your_configuration_is_correct_by_building_the_site.mdx
@@ -1,5 +1,5 @@
 
 Run the following code to build and open your newly configured S3 Data Docs site:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py build_docs"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py build_docs"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/data_docs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/data_docs.py
@@ -15,24 +15,24 @@ validator.expect_column_values_to_be_between(
 )
 
 taxi_suite = validator.get_expectation_suite()
-taxi_suite.expectation_suite_name = "version-0.18 taxi_suite"
+taxi_suite.expectation_suite_name = "taxi_suite"
 
 context.add_expectation_suite(expectation_suite=taxi_suite)
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 taxi_checkpoint",
+    name="taxi_checkpoint",
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 taxi_suite",
+    expectation_suite_name="taxi_suite",
 )
 checkpoint.run()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs">
 context.build_data_docs()
 context.open_data_docs()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site">
-site_name = "version-0.18 new_site_name"
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site">
+site_name = "new_site_name"
 context.build_data_docs(site_names=site_name)
 context.open_data_docs(site_name=site_name)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/host_and_share_data_docs.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/host_and_share_data_docs.md
@@ -161,7 +161,7 @@ You can create or modify an <TechnicalTag tag="expectation_suite" text="Expectat
 
 Run the following Python code to build and open your Data Docs:
 
-``` python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site"
+``` python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site"
 ```
 
 ### Limit Data Docs access (Optional)
@@ -198,14 +198,14 @@ To view the code used in the examples, see [how_to_host_and_share_data_docs_on_g
 
 Run the following command to create a GCS bucket: 
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket command"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket command"
 ```
 
 Modify the project name, bucket name, and region.
 
 This is the output after you run the command:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket output"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket output"
 ```
 
 ### Create a directory for your Google App Engine app
@@ -214,31 +214,31 @@ GX recommends adding the directory to your project directory. For example, `grea
 
 1. Create and then open ``app.yaml`` and then add the following entry:
 
-    ```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py app yaml"
+    ```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py app yaml"
     ```
 
 2. Create and then open `requirements.txt` and then add the following entry:
 
-    ```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py requirements.txt"
+    ```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py requirements.txt"
     ```
 
 3. Create and then open `main.py` and then dd the following entry:
 
-    ```python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py imports"
+    ```python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py imports"
     ```
 
 ### Authenticate the gcloud CLI
 
 Run the following command to authenticate the gcloud CLI and set the project:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud login and set project"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud login and set project"
 ```
 
 ### Deploy your Google App Engine app
 
 Run the following CLI command from within the app directory you created previously:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud app deploy"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud app deploy"
 ```
 
 ### Set up the Google App Engine firewall
@@ -249,7 +249,7 @@ See [Creating firewall rules](https://cloud.google.com/appengine/docs/standard/p
 
 Open `great_expectations.yml` and add the following entry:
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py data docs sites yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py data docs sites yaml"
 ```
 
 Replace the default ``local_site`` to maintain a single GCS Data Docs site.
@@ -273,7 +273,7 @@ To host a Data Docs site with a private DNS, you can configure a ``base_public_p
 
 Run the following Python code to build and open your Data Docs:
 
-``` python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site"
+``` python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs_site"
 ```
 
 ### Test the configuration
@@ -319,7 +319,7 @@ data_docs_sites:
 
 Run the following Python code to build and open your Data Docs:
 
-``` python name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs"
+``` python name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py data_docs"
 ```
 
 To share the site, compress and distribute the directory in the ``base_directory`` key in your site configuration.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
@@ -55,7 +55,7 @@ except Exception:
     pass
 
 create_data_docs_directory = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket command">
 gsutil mb -p <YOUR GCP PROJECT NAME> -l US-EAST1 -b on gs://<YOUR GCS BUCKET NAME>/
 # </snippet>
 """
@@ -79,7 +79,7 @@ result = subprocess.run(
 stderr = result.stderr.decode("utf-8")
 
 create_data_docs_directory_output = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py create bucket output">
 Creating gs://<YOUR GCS BUCKET NAME>/...
 # </snippet>
 """
@@ -95,7 +95,7 @@ create_data_docs_directory_output = create_data_docs_directory_output.replace(
 assert create_data_docs_directory_output.strip() in stderr
 
 app_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py app yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py app yaml">
 runtime: python37
 env_variables:
   CLOUD_STORAGE_BUCKET: <YOUR GCS BUCKET NAME>
@@ -120,7 +120,7 @@ with open(app_yaml_file_path, "w") as f:
     yaml.dump(app_yaml, f)
 
 requirements_txt = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py requirements.txt">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py requirements.txt">
 flask>=1.1.0
 google-cloud-storage
 # </snippet>
@@ -137,7 +137,7 @@ with open(requirements_txt_file_path, "w") as f:
     f.write(requirements_txt)
 
 main_py = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py imports">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py imports">
 import logging
 import os
 from flask import Flask, request
@@ -176,7 +176,7 @@ with open(main_py_file_path, "w") as f:
     f.write(main_py)
 
 gcloud_login_command = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud login and set project">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud login and set project">
 gcloud auth login && gcloud config set project <YOUR GCP PROJECT NAME>
 # </snippet>
 """
@@ -187,7 +187,7 @@ gcloud auth login && gcloud config set project <YOUR GCP PROJECT NAME>
 """
 
 gcloud_app_deploy_command = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud app deploy">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py gcloud app deploy">
 gcloud app deploy
 # </snippet>
 """
@@ -205,7 +205,7 @@ with subprocess.Popen(
 
 
 data_docs_site_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py data docs sites yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py data docs sites yaml">
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
@@ -243,7 +243,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 build_data_docs_command = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py build data docs command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py build data docs command">
 great_expectations docs build --site-name new_site_name
 # </snippet>
 """
@@ -261,7 +261,7 @@ with subprocess.Popen(
     result.kill()
 
 build_data_docs_output = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py build data docs output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py build data docs output">
 The following Data Docs sites will be built:
 
  - new_site_name: https://storage.googleapis.com/<YOUR GCS BUCKET NAME>/index.html

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_identify_your_data_context_validation_results_store.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_identify_your_data_context_validation_results_store.mdx
@@ -4,6 +4,6 @@ Your <TechnicalTag tag="validation_result_store" text="Validation Results Store"
 
 The following section in your <TechnicalTag relative="../../../" tag="data_context" text="Data Context" /> ``great_expectations.yml`` file tells Great Expectations to look for Validation Results in a Store named ``validations_store``. It also creates a ``ValidationsStore`` named ``validations_store`` that is backed by a Filesystem and stores Validation Results under the ``base_directory`` ``uncommitted/validations`` (the default).
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_validations_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_validations_store"
 ```
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_validation_results_on_s.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_a_validation_result_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_validation_results_on_s.mdx
@@ -2,7 +2,7 @@ import TechnicalTag from '../../../../../reference/learn/term_tags/_tag.mdx';
 
 To manually add a Validation Results Store, add the following configuration to the `stores` section of your `great_expectations.yml` file:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_validations_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_validations_store"
 ```
 
 As shown in the previous example, you need to change the default ``store_backend`` settings to make the Store work with S3.  The ``class_name`` is set to ``TupleS3StoreBackend``, ``bucket`` is the address of your S3 bucket, and ``prefix`` is the folder in your S3 bucket where Validation Results are located.
@@ -21,7 +21,7 @@ store_backend:
 ```
 In the previous example, the Store name is ``validations_S3_store``. If you use a personalized Store name, you must also update the value of the `validations_store_name` key to match the Store name. For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py set_new_validations_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py set_new_validations_store"
 ```
 When you update the `validations_store_name` key value, Great Expectations uses the new Store for Validation Results.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_identify_your_data_context_expectations_store.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_identify_your_data_context_expectations_store.mdx
@@ -4,7 +4,7 @@ Your <TechnicalTag tag="expectation_store" text="Expectation Store" /> configura
 
 The following section in your <TechnicalTag relative="../../../" tag="data_context" text="Data Context" /> ``great_expectations.yml`` file tells Great Expectations to look for Expectations in a Store named ``expectations_store``:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_expectations_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_expectations_store"
 ```
 
 The default ``base_directory`` for ``expectations_store`` is ``expectations/``.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_expectations_on_s.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/components_how_to_configure_an_expectation_store_in_amazon_s3/_update_your_configuration_file_to_include_a_new_store_for_expectations_on_s.mdx
@@ -2,7 +2,7 @@ import TechnicalTag from '../../../../../reference/learn/term_tags/_tag.mdx';
 
 To manually add an <TechnicalTag tag="expectation_store" text="Expectations Store" /> to your configuration, add the following configuration to the `stores` section of your `great_expectations.yml` file:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_expectations_store"
+```python name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_expectations_store"
 ```
 Change the default ``store_backend`` settings to make the Store work with S3.  The ``class_name`` is set to ``TupleS3StoreBackend``, ``bucket`` is the address of your S3 bucket, and ``prefix`` is the folder in your S3 bucket where Expectations are located.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/configure_expectation_stores.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/configure_expectation_stores.md
@@ -200,7 +200,7 @@ For more information about validating your GCP authentication credentials, see [
 
 The configuration for your Expectations <TechnicalTag tag="store" text="Store" /> is available in your <TechnicalTag tag="data_context" text="Data Context" />. Open ``great_expectations.yml`` and find the following entry: 
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py expected_existing_expectations_store_yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py expected_existing_expectations_store_yaml"
 ```
 
 This configuration tells Great Expectations to look for Expectations in the ``expectations_store`` Store. The default ``base_directory`` for ``expectations_store`` is ``expectations/``.
@@ -209,7 +209,7 @@ This configuration tells Great Expectations to look for Expectations in the ``ex
 
 In the following example, `expectations_store_name` is set to ``expectations_GCS_store``, but it can be personalized.  You also need to change the ``store_backend`` settings. The ``class_name`` is ``TupleGCSStoreBackend``, ``project`` is your GCP project, ``bucket`` is the address of your GCS bucket, and ``prefix`` is the folder on GCS where Expectations are stored.
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py configured_expectations_store_yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py configured_expectations_store_yaml"
 ```
 
 :::warning
@@ -220,12 +220,12 @@ If you are also storing [Validations in GCS](./configure_result_stores.md) or [D
 
 Use the ``gsutil cp`` command to copy Expectations into GCS. For example, the following command copies the Expectation ```my_expectation_suite`` from a local folder into a GCS bucket:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_command"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_command"
 ```
 
 The following confirmation message is returned:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_output"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_output"
 ```
 
 Additional methods for copying Expectations into GCS are available. See [Upload objects from a filesystem](https://cloud.google.com/storage/docs/uploading-objects).
@@ -249,7 +249,7 @@ A list of Expectation Suites you copied to GCS is returned. Expectation Suites t
 
 Run the following command to confirm your Expectations were copied to GCS:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_suites_command"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_suites_command"
 ```
 
 If your Expectations were not copied to Azure Blob Storage, a message indicating no Expectations were found is returned.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/configure_result_stores.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/configure_result_stores.md
@@ -190,7 +190,7 @@ For more information about validating your GCP authentication credentials, see [
 
 The configuration for your <TechnicalTag tag="validation_result_store" text="Validation Results Store" /> is available in your <TechnicalTag tag="data_context" text="Data Context" />. Open ``great_expectations.yml``and find the following entry: 
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py expected_existing_validations_store_yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py expected_existing_validations_store_yaml"
 ```
 This configuration tells Great Expectations to look for Validation Results in the ``validations_store`` Store. The default ``base_directory`` for ``validations_store`` is ``uncommitted/validations/``.
 
@@ -198,7 +198,7 @@ This configuration tells Great Expectations to look for Validation Results in th
 
 In the following example, `validations_store_name` is set to ``validations_GCS_store``, but it can be personalized.  You also need to change the ``store_backend`` settings. The ``class_name`` is ``TupleGCSStoreBackend``, ``project`` is your GCP project, ``bucket`` is the address of your GCS bucket, and ``prefix`` is the folder on GCS where Validation Result files are stored.
 
-```yaml name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py configured_validations_store_yaml"
+```yaml name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py configured_validations_store_yaml"
 ```
 
 :::warning
@@ -209,11 +209,11 @@ If you are also storing [Expectations in GCS](../configuring_metadata_stores/con
 
 Use the ``gsutil cp`` command to copy Validation Results into GCS. For example, the following command copies the Validation results ``validation_1`` and ``validation_2``into a GCS bucket: 
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_command"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_command"
 ```
 The following confirmation message is returned:
 
-```bash name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_output"
+```bash name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_output"
 ```
 Additional methods for copying Validation Results into GCS are available. See [Upload objects from a filesystem](https://cloud.google.com/storage/docs/uploading-objects).
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_metricsstore.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_metricsstore.md
@@ -116,6 +116,6 @@ Run the following command to run your Checkpoint and test `StoreMetricsAction`:
 ```python
 import great_expectations as gx
 context = gx.get_context()
-checkpoint_name = "version-0.18 your checkpoint name here"
+checkpoint_name = "your checkpoint name here"
 context.run_checkpoint(checkpoint_name=checkpoint_name)
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py
@@ -40,10 +40,10 @@ data_connectors:
 """
 datasource = context.add_datasource(**yaml.load(datasource_config))
 
-expectation_suite_name = "version-0.18 my_expectation_suite"
+expectation_suite_name = "my_expectation_suite"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 
-checkpoint_name = "version-0.18 my_checkpoint"
+checkpoint_name = "my_checkpoint"
 context.add_or_update_checkpoint(
     name=checkpoint_name,
     validations=[
@@ -81,7 +81,7 @@ actual_existing_validations_store["validations_store_name"] = great_expectations
 ]
 
 expected_existing_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py expected_existing_validations_store_yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py expected_existing_validations_store_yaml">
 stores:
   validations_store:
     class_name: ValidationsStore
@@ -98,7 +98,7 @@ assert actual_existing_validations_store == yaml.load(
 )
 
 configured_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py configured_validations_store_yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py configured_validations_store_yaml">
 stores:
   validations_GCS_store:
     class_name: ValidationsStore
@@ -153,7 +153,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_command">
 gsutil cp uncommitted/validations/my_expectation_suite/validation_1.json gs://<YOUR GCS BUCKET NAME>/<YOUR GCS PREFIX NAME>/validation_1.json
 gsutil cp uncommitted/validations/my_expectation_suite/validation_2.json gs://<YOUR GCS BUCKET NAME>/<YOUR GCS PREFIX NAME>/validation_2.json
 # </snippet>
@@ -218,13 +218,13 @@ stderr = result.stderr.decode("utf-8")
 assert "Operation completed over 1 objects" in stderr
 
 copy_validation_output = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py copy_validation_output">
 Operation completed over 2 objects
 # </snippet>
 """
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py list_validation_stores_command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py list_validation_stores_command">
 great_expectations store list
 # </snippet>
 """
@@ -243,7 +243,7 @@ result = subprocess.run(
 stdout = result.stdout.decode("utf-8")
 
 list_validation_stores_output = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py list_validation_stores_output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py list_validation_stores_output">
   - name: validations_GCS_store
     class_name: ValidationsStore
     store_backend:

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py
@@ -39,7 +39,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
 ]
 
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py expected_existing_expectations_store_yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py expected_existing_expectations_store_yaml">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -56,7 +56,7 @@ assert actual_existing_expectations_store == yaml.load(
 )
 
 configured_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py configured_expectations_store_yaml">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py configured_expectations_store_yaml">
 stores:
   expectations_GCS_store:
     class_name: ExpectationsStore
@@ -106,12 +106,12 @@ great_expectations_yaml["stores"]["expectations_GCS_store"]["store_backend"].pop
 with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
-expectation_suite_name = "version-0.18 my_expectation_suite"
+expectation_suite_name = "my_expectation_suite"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_command">
 gsutil cp expectations/my_expectation_suite.json gs://<YOUR GCS BUCKET NAME>/<YOUR GCS PREFIX NAME>/my_expectation_suite.json
 # </snippet>
 """
@@ -150,7 +150,7 @@ result = subprocess.run(
 stderr = result.stderr.decode("utf-8")
 
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py copy_expectation_output">
 Operation completed over 1 objects
 # </snippet>
 """
@@ -164,7 +164,7 @@ assert copy_expectation_output.strip() in stderr
 
 # list expectation stores
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_stores_command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_stores_command">
 great_expectations store list
 # </snippet>
 """
@@ -182,7 +182,7 @@ result = subprocess.run(
 stdout = result.stdout.decode("utf-8")
 
 list_expectation_stores_output = """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_stores_output">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_stores_output">
   - name: expectations_GCS_store
     class_name: ExpectationsStore
     store_backend:
@@ -200,7 +200,7 @@ assert "TupleGCSStoreBackend" in stdout
 
 # list expectation suites
 """
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_suites_command">
+# <snippet name="docs/docusaurus/docs/oss/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.py list_expectation_suites_command">
 great_expectations suite list
 # </snippet>
 """

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/installation/install_gx.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/installation/install_gx.md
@@ -250,7 +250,7 @@ Create your GX Python environment, install Great Expectations locally, and then 
 
 ### Install GX with optional dependencies for SQL databases
 
-<InstallDependencies install_key="sqlalchemy" database_name="version-0.18 SQL databases"/>
+<InstallDependencies install_key="sqlalchemy" database_name="SQL databases"/>
 
 :::caution Additional dependencies for some SQL dialects
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/optional_dependencies/cloud/connect_gx_source_data_system.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/optional_dependencies/cloud/connect_gx_source_data_system.md
@@ -203,7 +203,7 @@ Create your GX Python environment, install Great Expectations locally, and then 
 
 ### Install GX with optional dependencies for SQL databases
 
-<InstallDependencies install_key="sqlalchemy" database_name="version-0.18 SQL databases"/>
+<InstallDependencies install_key="sqlalchemy" database_name="SQL databases"/>
 
 :::caution Additional dependencies for some SQL dialects
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/optional_dependencies/sql_databases/how_to_setup_gx_to_work_with_sql_databases.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/optional_dependencies/sql_databases/how_to_setup_gx_to_work_with_sql_databases.md
@@ -53,7 +53,7 @@ This guide will walk you through best practices for creating your GX Python envi
 
 ### 3. Install GX with optional dependencies for SQL databases
 
-<InstallDependencies install_key="sqlalchemy" database_name="version-0.18 SQL databases"/>
+<InstallDependencies install_key="sqlalchemy" database_name="SQL databases"/>
 
 :::caution Additional dependencies for some SQL dialects
 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/advanced/how_to_deploy_a_scheduled_checkpoint_with_cron.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/advanced/how_to_deploy_a_scheduled_checkpoint_with_cron.md
@@ -19,7 +19,7 @@ This guide will help you deploy a scheduled <TechnicalTag tag="checkpoint" text=
 
 Run the following command to verify that your Checkpoint runs:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run"
+```python name="docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run"
 ```
 
 ## Get `great_expectations` full path

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/advanced/how_to_get_data_docs_urls_for_custom_validation_actions.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/advanced/how_to_get_data_docs_urls_for_custom_validation_actions.md
@@ -22,14 +22,14 @@ The code used in this topic is available on GitHub here: [actions.py](https://gi
 
 First, within the `_run` method of your custom Validation Action, instantiate an empty `dict` to hold your sites:
 
-```python name="version-0.18 great_expectations/checkpoint/actions.py empty dict"
+```python name="great_expectations/checkpoint/actions.py empty dict"
 ```
 
 ## Acquire
 
 Next, call `get_docs_sites_urls` to get the urls for all the suites processed by this Checkpoint:
 
-```python name="version-0.18 great_expectations/checkpoint/actions.py get_docs_sites_urls"
+```python name="great_expectations/checkpoint/actions.py get_docs_sites_urls"
 ```
 
 
@@ -37,7 +37,7 @@ Next, call `get_docs_sites_urls` to get the urls for all the suites processed by
 
 The above step returns a list of dictionaries containing the relevant information. Now, we need to iterate through the entries to build the object we want:
 
-```python name="version-0.18 great_expectations/checkpoint/actions.py iterate"
+```python name="great_expectations/checkpoint/actions.py iterate"
 ```
 
 ## Utilize

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.md
@@ -21,14 +21,14 @@ Add validation data or <TechnicalTag tag="expectation_suite" text="Expectation S
 
 To add a second Expectation Suite (in the following example, `users.error`) to your Checkpoint configuration, you update the Validations in your Checkpoint.  The configuration appears similar to this example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_expectation_suite"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_expectation_suite"
 ```
 
 ## Add Validation data to the Checkpoint
 
 In the previous example, you added a Validation and it was paired with the same Batch as the original Expectation Suite.  However, you can also specify different <TechnicalTag tag="batch_request" text="Batch Requests" /> when you add an Expectation Suite.  Adding multiple Validations with different Expectation Suites and specific <TechnicalTag tag="action" text="Actions" /> is shown in the following example:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_validation"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_validation"
 ```
 
 In this Checkpoint configuration, the Expectation Suite `users.warning` runs against the `batch_request` and the results are processed by the Actions specified in the `action_list`. Similarly, the Expectation Suite `users.error` runs against the `batch_request` and the results processed by the actions specified in the `action_list`. In addition, the Expectation Suite `users.delivery` runs against the `batch_request` and the results are processed by the actions in the Validation `action_list` and its `action_list`.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py
@@ -13,11 +13,11 @@ one_validation = [
 ]
 
 checkpoint = context.add_checkpoint(
-    name="version-0.18 my_test_checkpoint",
+    name="my_test_checkpoint",
     validations=one_validation,
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_expectation_suite">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_expectation_suite">
 validations = [
     {
         "batch_request": {
@@ -36,13 +36,13 @@ validations = [
 ]
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_test_checkpoint",
+    name="my_test_checkpoint",
     validations=validations,
 )
 # </snippet>
 assert len(checkpoint.validations) == 2
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_validation">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint.py add_validation">
 validations = [
     {
         "batch_request": {
@@ -82,7 +82,7 @@ validations = [
 ]
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_test_checkpoint", validations=validations
+    name="my_test_checkpoint", validations=validations
 )
 # </snippet>
 assert len(checkpoint.validations) == 3

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_create_a_new_checkpoint.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_create_a_new_checkpoint.md
@@ -15,7 +15,7 @@ import AdditionalResources from './components_how_to_create_a_new_checkpoint/_ad
 
 To modify the following code for your use case, replace `batch_request` and `expectation_suite_name` with your own paremeters.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request"
+```python name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request"
 ```
 
 For other Checkpoint configuration options, see [Manage Checkpoints](/oss/guides/validation/checkpoints/checkpoint_lp.md).
@@ -23,7 +23,7 @@ For other Checkpoint configuration options, see [Manage Checkpoints](/oss/guides
 
 ## Run your Checkpoint (Optional)
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py run checkpoint batch_request"
+```python name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py run checkpoint batch_request"
 ```
 
 The returned `checkpoint_result` contains information about the checkpoint run.
@@ -32,14 +32,14 @@ The returned `checkpoint_result` contains information about the checkpoint run.
 
 Run the following Python code to build <TechnicalTag tag="data_docs" text="Data Docs" /> with the latest checkpoint run results:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py build data docs"
+```python name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py build data docs"
 ```
 
 ## Retrieve your Checkpoint (Optional)
 
 Run the following Python code to retrieve the Checkpoint:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py get checkpoint"
+```python name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py get checkpoint"
 ```
 
 ## Related documentation

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.md
@@ -19,7 +19,7 @@ The full script used in the following code examples, is available in GitHub here
 
 Run the following command to import the required libraries and load your DataContext
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py setup"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py setup"
 ```
 
 ## Read a DataFrame and create a Checkpoint
@@ -27,12 +27,12 @@ Run the following command to import the required libraries and load your DataCon
 The following example uses the `read_*` method on the PandasDatasource to directly return a <TechnicalTag tag="validator" text="Validator" />. To use Validators to interactively build an Expectation Suite, see [How to create Expectations interactively in Python](/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data.md).
 The Validator can be passed directly to a Checkpoint
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py read_dataframe"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py read_dataframe"
 ```
 
 Alternatively, you can use `add_*` methods to add the asset and then retrieve a <TechnicalTag tag="batch_request" text="Batch Request" />. This method is consistent with how other Data Assets work, and can integrate in-memory data with other Batch Request workflows and configurations.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py add_dataframe"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py add_dataframe"
 ```
 
 In both examples, `batch_metadata` is an optional parameter that can associate meta-data with the batch or DataFrame. When you work with DataFrames, this can help you distinguish Validation results.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py
@@ -1,4 +1,4 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py setup">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py setup">
 import pandas
 
 import great_expectations as gx
@@ -6,18 +6,18 @@ import great_expectations as gx
 context = gx.get_context()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py read_dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py read_dataframe">
 df = pandas.read_csv("./data/yellow_tripdata_sample_2019-01.csv")
 
 validator = context.sources.add_pandas("taxi_datasource").read_dataframe(
     df,
-    asset_name="version-0.18 taxi_frame",
+    asset_name="taxi_frame",
     batch_metadata={"year": "2019", "month": "01"},
 )
 validator.save_expectation_suite()  # this allows the checkpoint to reference the expectation suite
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_taxi_validator_checkpoint", validator=validator
+    name="my_taxi_validator_checkpoint", validator=validator
 )
 
 checkpoint_result = checkpoint.run()
@@ -29,11 +29,11 @@ assert checkpoint_result["success"]
 # clean-up between examples
 context.delete_datasource("taxi_datasource")
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py add_dataframe">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py add_dataframe">
 dataframe_asset = context.sources.add_pandas(
     "my_taxi_validator_checkpoint"
 ).add_dataframe_asset(
-    name="version-0.18 taxi_frame",
+    name="taxi_frame",
     dataframe=df,
     batch_metadata={"year": "2019", "month": "01"},
 )
@@ -42,9 +42,9 @@ context.add_or_update_expectation_suite("my_expectation_suite")
 batch_request = dataframe_asset.build_batch_request()
 
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_taxi_dataframe_checkpoint",
+    name="my_taxi_dataframe_checkpoint",
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 my_expectation_suite",
+    expectation_suite_name="my_expectation_suite",
 )
 
 checkpoint_result = checkpoint.run()

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.md
@@ -22,7 +22,7 @@ By default, a Checkpoint only validates the last Batch included in a Batch Reque
 
 The following Python code creates a Batch Request that includes every available Batch in a Data Asset named `asset`:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py build_a_batch_request_with_multiple_batches"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py build_a_batch_request_with_multiple_batches"
 ```
 
 :::tip
@@ -39,33 +39,33 @@ For more information on partitioning a Data Asset into Batches, see [Manage Data
 
 Use the same Data Asset that your Batch Request was built from to retrieve a list of Batches with the following code:
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_list"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_list"
 ```
 
 ## Convert the list of Batches into a list of Batch Requests
 
 A Checkpoint validates Batch Requests, but only validates the last Batch found in a Batch Request. You'll need to convert the list of Batches into a list of Batch Requests that return the corresponding individual Batch.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_request_list"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_request_list"
 ```
 
 ## Build a validations list 
 
 A Checkpoint class's `validations` parameter consists of a list of dictionaries.  Each dictionary pairs one Batch Request with the Expectation Suite it should be validated against.  The following code creates a valid `validations` list and associates each Batch Request with an Expectation Suite named `example_suite`.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_validations"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_validations"
 ```
 
 ## Run Checkpoint
 
 The `validations` list, containing the pairings of Batch Requests and Expectation Suites, can now be passed to a single Checkpoint instance which validates each Batch Request against its corresponding Expectation Suite. This effectively validates each Batch included in the original multiple-Batch Batch Request.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_checkpoint"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_checkpoint"
 ```
 
 ## Review the Validation Results
 
 After the validations run, use the following code to build and view the Validation Results as Data Docs.
 
-```python name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py review data_docs"
+```python name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py review data_docs"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py
@@ -6,7 +6,7 @@ from great_expectations.expectations.expectation_configuration import (
 context = gx.get_context()
 
 datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 example_datasource", base_directory="./data"
+    name="example_datasource", base_directory="./data"
 )
 
 MY_BATCHING_REGEX = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
@@ -18,37 +18,37 @@ ec = ExpectationConfiguration(
     kwargs={"column": "passenger_count"},
 )
 suite = context.add_expectation_suite(
-    expectation_suite_name="version-0.18 example_suite", expectations=[ec]
+    expectation_suite_name="example_suite", expectations=[ec]
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py build_a_batch_request_with_multiple_batches">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py build_a_batch_request_with_multiple_batches">
 batch_request = asset.build_batch_request()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_list">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_list">
 batch_list = asset.get_batch_list_from_batch_request(batch_request)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_request_list">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py batch_request_list">
 batch_request_list = [batch.batch_request for batch in batch_list]
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_validations">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_validations">
 validations = [
     {"batch_request": batch.batch_request, "expectation_suite_name": "example_suite"}
     for batch in batch_list
 ]
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_checkpoint">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py add_checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_taxi_validator_checkpoint", validations=validations
+    name="my_taxi_validator_checkpoint", validations=validations
 )
 
 checkpoint_result = checkpoint.run()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py review data_docs">
+# <snippet name="docs/docusaurus/docs/oss/guides/validation/checkpoints/how_to_validate_multiple_batches_within_single_checkpoint.py review data_docs">
 context.build_data_docs()
 context.open_data_docs()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/validation_actions/how_to_collect_openlineage_metadata_using_a_validation_action.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/validation/validation_actions/how_to_collect_openlineage_metadata_using_a_validation_action.md
@@ -53,7 +53,7 @@ action_list:
 
 Run the following command to retrieve and run a Checkpoint to Validate a <TechnicalTag tag="batch" text="Batch" /> of data and then emit lineage events to the OpenLineage backend:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run"
+```python name="docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run"
 ```
 
 :::note Reminder

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/team_templates/how_to_template.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/team_templates/how_to_template.md
@@ -40,12 +40,12 @@ To complete this how-to, you'll complete the following tasks:
 
 2. Open Jupyter Notebook, a command line, or a terminal and then run the following command to import the `great_expectations` module:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py import_gx"
+    ```python name="tutorials/quickstart/quickstart.py import_gx"
     ```
 
 3. Run the following command to import the `DataContext` object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py get_context"
+    ```python name="tutorials/quickstart/quickstart.py get_context"
     ```
 
 4. Add a comment when the prompt appears:
@@ -60,7 +60,7 @@ To complete this how-to, you'll complete the following tasks:
 
 1. Run the following command to create two Expectations. The first Expectation uses domain knowledge (the `pickup_datetime` shouldn't be null), and the second Expectation uses explicit kwargs with the `passenger_count` column. 
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_expectation"
+    ```python name="tutorials/quickstart/quickstart.py create_expectation"
     ```
     The Expectation assumes the `pickup_datetime` column always contains data.  None of the column's values are null.
 
@@ -72,12 +72,12 @@ To complete this how-to, you'll complete the following tasks:
 
 1. Run the following command to define a Checkpoint and examine the data to determine if it matches the defined Expectations: 
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py create_checkpoint"
     ```
 
 2. Run the following command to return the Validation results:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py run_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py run_checkpoint"
     ```
 
 ## Additional tasks

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/team_templates/tutorial_template.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/team_templates/tutorial_template.md
@@ -32,12 +32,12 @@ title: <!-- Add the topic title here -->
 
 2. Open Jupyter Notebook, a command line, or a terminal and then run the following command to import the `great_expectations` module:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py import_gx"
+    ```python name="tutorials/quickstart/quickstart.py import_gx"
     ```
 
 3. Run the following command to import the `DataContext` object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py get_context"
+    ```python name="tutorials/quickstart/quickstart.py get_context"
     ```
 4. Add a comment when the prompt appears:
 
@@ -51,7 +51,7 @@ title: <!-- Add the topic title here -->
 
 1. Run the following command to create two Expectations. The first Expectation uses domain knowledge (the `pickup_datetime` shouldn't be null), and the second Expectation uses explicit kwargs with the `passenger_count` column. 
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_expectation"
+    ```python name="tutorials/quickstart/quickstart.py create_expectation"
     ```
     The Expectation assumes the `pickup_datetime` column always contains data.  None of the column's values are null.
 
@@ -63,12 +63,12 @@ title: <!-- Add the topic title here -->
 
 1. Run the following command to define a Checkpoint and examine the data to determine if it matches the defined Expectations: 
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py create_checkpoint"
     ```
 
 2. Run the following command to return the Validation results:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py run_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py run_checkpoint"
     ```
 
 ## Additional tasks

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/getting_started/how_to_use_great_expectations_in_databricks.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/getting_started/how_to_use_great_expectations_in_databricks.md
@@ -48,7 +48,7 @@ The full code used in the following examples is available on GitHub:
 
 2. Run the following command to import the Python configurations you'll use in the following steps:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports"
   ```
 
 ## Set up GX
@@ -59,11 +59,11 @@ DBFS is a distributed file system mounted in a Databricks workspace and availabl
 
 1. Run the following code to set up a <TechnicalTag tag="data_context" text="Data Context"/> with the default settings:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir"
   ```
 2. Run the following code to instantiate your Data Context:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context"
   ```
 
 ## Prepare your data
@@ -117,27 +117,27 @@ df = spark.read.format("csv")\
 
 1. Run the following command to set the base directory that contains the data:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory"
   ```
 
 2. Run the following command to create our <TechnicalTag tag="datasource" text="Data Source" />:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource"
   ```
 
 3. Run the following command to set the [batching regex](https://docs.greatexpectations.io/docs/oss/guides/connecting_to_your_data/fluent/data_assets/how_to_organize_batches_in_a_file_based_data_asset/#create-a-batching_regex):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex"
   ```
 
 4. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> with the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset"
   ```
 
 5. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> with the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured earlier:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request"
   ```
 
 </TabItem>
@@ -145,17 +145,17 @@ df = spark.read.format("csv")\
 
 1. Run the following command to create the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource"
   ```
 
 2. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> with the Data Source:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset"
   ```
 
 3. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> with the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured earlier:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request"
   ```
 
 </TabItem>
@@ -169,17 +169,17 @@ Every time you evaluate an Expectation with `validator.expect_*`, it is immediat
 
 1. Run the following command to create the suite and get a `Validator`:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator"
   ```
 
 2. Run the following command to use the `Validator` to add a few Expectations:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations"
   ```
 
 3. Run the following command to save your Expectation Suite (all the unique Expectation Configurations from each run of `validator.expect_*`) to your Expectation Store:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite"
   ```
 
 ## Validate your data
@@ -188,17 +188,17 @@ You'll create and store a <TechnicalTag tag="checkpoint" text="Checkpoint"/> for
 
 1. Run the following command to create the Checkpoint configuration that uses your Data Context, passes in your Batch Request (your data) and your Expectation Suite (your tests):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config"
   ```
 
 2. Run the following command to save the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config"
   ```
 
 3. Run the following command to run the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint"
+  ```python name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint"
   ```
 
   Your Checkpoint configuration includes the `store_validation_result` and `update_data_docs` actions. The `store_validation_result` action saves your validation results from the Checkpoint run and allows the results to be persisted for future use. The  `update_data_docs` action builds Data Docs files for the validations run in the Checkpoint.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/getting_started/how_to_use_great_expectations_with_sql.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/getting_started/how_to_use_great_expectations_with_sql.md
@@ -41,7 +41,7 @@ The full code used in the following examples is available on GitHub:
 
 2. Run the following command to import configuration information that you'll use in the following steps:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports"
   ```
 
 ## Set up GX
@@ -50,7 +50,7 @@ To avoid configuring external resources, you'll use your local filesystem for yo
 
 Run the following code to create a <TechnicalTag tag="data_context" text="Data Context"/> with the default settings:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context"
+```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context"
 ```
 
 ## Connect to your data
@@ -65,19 +65,19 @@ Run the following code to create a <TechnicalTag tag="data_context" text="Data C
 
 2. Run the following command to create a <TechnicalTag tag='datasource' text='Data Source' /> to represent the data available in your PostgreSQL database:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource"
   ```
 
 3. Run the following command to create a <TechnicalTag tag="data_asset" text="Data Asset" /> to represent a discrete set of data: 
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset"
   ```
 
   In this example, the name of a specific table within your database is used.
 
 4. Run the following command to build a <TechnicalTag tag="batch_request" text="Batch Request" /> using the <TechnicalTag tag="data_asset" text="Data Asset" /> you configured previously:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request"
   ```
 
 ## Create Expectations
@@ -88,17 +88,17 @@ Every time you evaluate an Expectation with `validator.expect_*`, it is immediat
 
 1. Run the following command to create the suite and get a `Validator`:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator"
   ```
 
 2. Run the following command to use the `Validator` to add a few Expectations:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations"
   ```
 
 3. Run the following command to save your Expectation Suite (all the unique Expectation Configurations from each run of `validator.expect_*`) to your Expectation Store:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite"
   ```
 ## Validate your data
 
@@ -106,17 +106,17 @@ You'll create and store a <TechnicalTag tag="checkpoint" text="Checkpoint"/> for
 
 1. Run the following command to create the Checkpoint configuration that uses your Data Context:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config"
   ```
 
 2. Run the following command to save the Checkpoint:
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config"
   ```
 
 3. Run the following command to run the Checkpoint and pass in your Batch Request (your data) and your Expectation Suite (your tests):
 
-  ```python name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint"
+  ```python name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint"
   ```
 
   Your Checkpoint configuration includes the `store_validation_result` and `update_data_docs` actions. The `store_validation_result` action saves your validation results from the Checkpoint run and allows the results to be persisted for future use. The  `update_data_docs` action builds Data Docs files for the validations run in the Checkpoint.

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/quickstart.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/tutorials/quickstart.md
@@ -77,19 +77,19 @@ click 7 "#validate-data"
 
 2. Run the following Python code to import the `great_expectations` module:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py import_gx"
+    ```python name="tutorials/quickstart/quickstart.py import_gx"
     ```
 ## Create a Data Context
 
 - Run the following command to create a <TechnicalTag tag="data_context" text="Data Context"/> object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py get_context"
+    ```python name="tutorials/quickstart/quickstart.py get_context"
     ```
 ## Connect to data
 
 - Run the following command to connect to existing `.csv` data stored in the `great_expectations` GitHub repository and create a <TechnicalTag tag="validator" text="Validator"/> object:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py connect_to_data"
+    ```python name="tutorials/quickstart/quickstart.py connect_to_data"
     ```
 
     The code example uses the default <TechnicalTag tag="data_context" text="Data Context"/> <TechnicalTag tag="datasource" text="Data Source"/> for Pandas to access the `.csv` data from the file at the specified URL path.
@@ -98,7 +98,7 @@ click 7 "#validate-data"
 
 - Run the following commands to create two <TechnicalTag tag="expectation" text="Expectations"/> and save them to the <TechnicalTag tag="expectation_suite" text="Expectation Suite"/>:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_expectation"
+    ```python name="tutorials/quickstart/quickstart.py create_expectation"
     ```
 
   The first <TechnicalTag tag="expectation" text="Expectation"/> uses domain knowledge (the `pickup_datetime` shouldn't be null).
@@ -109,17 +109,17 @@ click 7 "#validate-data"
 
 1. Run the following command to define a <TechnicalTag tag="checkpoint" text="Checkpoint"/> and examine the data to determine if it matches the defined <TechnicalTag tag="expectation" text="Expectations"/>:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py create_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py create_checkpoint"
     ```
 
 2. Run the following command to return the <TechnicalTag tag="validation_result" text="Validation Results"/>:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py run_checkpoint"
+    ```python name="tutorials/quickstart/quickstart.py run_checkpoint"
     ```
 
 3. Run the following command to view an HTML representation of the <TechnicalTag tag="validation_result" text="Validation Results"/> in the generated <TechnicalTag tag="data_docs" text="Data Docs"/>:
 
-    ```python name="version-0.18 tutorials/quickstart/quickstart.py view_results"
+    ```python name="tutorials/quickstart/quickstart.py view_results"
     ```
 
 ## Related documentation

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/api/expectations/set_based_column_map_expectation/SetBasedColumnMapExpectation_class.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/api/expectations/set_based_column_map_expectation/SetBasedColumnMapExpectation_class.mdx
@@ -15,7 +15,7 @@ import CodeBlock from '@theme/CodeBlock';
 <p><CodeBlock language="python">{`ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
     set_camel_name = SolfegeScale
     set_ = ['do', 're', 'mi', 'fa', 'so', 'la', 'ti']
-    set_semantic_name = "version-0.18 the Solfege scale"
+    set_semantic_name = "the Solfege scale"
     map_metric = SetBasedColumnMapExpectation.register_metric(
         set_camel_name=set_camel_name,
         set_=set_

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/expectations/result_format.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/expectations/result_format.md
@@ -36,14 +36,14 @@ the configuration is not persisted, and you'll receive a `UserWarning`. GX recom
 
 To apply `result_format` to an Expectation, you pass it into the Expectation configuration on your Validator:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_set"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_set"
 ```
 
 ### Checkpoint-level configuration
 
 Run the following code to apply `result_format` to every Expectation in a Suite:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example"
+```python name="docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example"
 ```
 Your Checkpoint configuration is defined below the `runtime_configuration` key. 
 
@@ -97,7 +97,7 @@ Regardless of how Result Format is configured, `unexpected_list` is never render
 
 The following examples use the data defined in the following Pandas DataFrame:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format pandas_df_for_result_format"
+```python name="docs/docusaurus/docs/snippets/result_format pandas_df_for_result_format"
 ```
 
 ### Behavior for `BOOLEAN_ONLY`
@@ -106,12 +106,12 @@ When the `result_format` is `BOOLEAN_ONLY`, no `result` is returned. The result 
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_boolean_example"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_boolean_example"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_boolean_example_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_boolean_example_output"
 ```
 
 ### Behavior for `BASIC`
@@ -140,12 +140,12 @@ The basic `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_set"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_set"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_set_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_set_output"
 ```
 
 `ColumnAggregateExpectation` computes a single aggregate value for the column, and so returns a single 
@@ -164,12 +164,12 @@ The basic `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg_output"
 ```
 
 ### Behavior for `SUMMARY`
@@ -201,12 +201,12 @@ The summary `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_set"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_set"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_set_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_set_output"
 ```
 
 `ColumnAggregateExpectation` computes a single aggregate value for the column, and so returns a `observed_value` to justify the Expectation result. It also includes additional information regarding observed values and counts, depending on the specific Expectation.
@@ -224,12 +224,12 @@ The summary `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg_output"
 ```
 
 
@@ -262,12 +262,12 @@ The complete `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_set"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_set"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_set_output
+```python name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_set_output
 ```
 
 `ColumnAggregateExpectation` computes a single aggregate value for the column, and so returns a `observed_value` to justify the Expectation result. It also includes additional information regarding observed values and counts, depending on the specific Expectation.
@@ -286,10 +286,10 @@ The complete `result` includes:
 
 For example:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg"
 ```
 
 Returns the following output:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg_output"
+```python name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg_output"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/batch_request.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/batch_request.md
@@ -42,10 +42,10 @@ You will rarely need to access an existing Batch Request.  Instead, you will oft
 
 You can create a Batch Request from a Data Asset by calling `build_batch_request`.  Here is an example of configuring a Pandas Filesystem Asset and creating a Batch Request:
 
- ```python name="version-0.18 docs/docusaurus/docs/snippets/batch_request batch_request"
+ ```python name="docs/docusaurus/docs/snippets/batch_request batch_request"
 ```
 
 The `options` one passes in to specify a batch will vary depending on how the specific Data Asset was configured.  To look at the keys for the options dictionary, you can do the following:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/batch_request options"
+```python name="docs/docusaurus/docs/snippets/batch_request options"
 ```

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/checkpoint.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/checkpoint.md
@@ -43,7 +43,7 @@ After you create a Checkpoint, you can use it to Validate data by running it aga
 
 In its most basic form, a Checkpoint accepts an `expectation_suite_name` identfying the test suite to run, and a `batch_request` identifying the data to test. Checkpoint can be directly directly in Python as follows:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request"
+```python name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request"
 ```
 
 For an in-depth guide on Checkpoint creation, see our [guide on how to create a new Checkpoint](/oss/guides/validation/checkpoints/how_to_create_a_new_checkpoint.md).
@@ -120,12 +120,12 @@ This configuration specifies full validation dictionaries - no nesting (defaults
 
 **YAML**:
 
-```yaml name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting just the yaml"
+```yaml name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting just the yaml"
 ```
 
 **runtime**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint"
 ```
 
 </TabItem>
@@ -134,17 +134,17 @@ This configuration specifies four top-level keys ("expectation_suite_name", "act
 
 **YAML**:
 
-```yaml name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults just the yaml"
+```yaml name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults just the yaml"
 ```
 
 **Runtime**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_2"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_2"
 ```
 
 **Results**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets"
 ```
 
 </TabItem>
@@ -153,17 +153,17 @@ This configuration omits the "validations" key from the YAML, which means a "val
 
 **YAML**:
 
-```yaml name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime just the yaml"
+```yaml name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime just the yaml"
 ```
 
 **Runtime**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_3"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_3"
 ```
 
 **Results**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_2"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_2"
 ```
 
 </TabItem>
@@ -172,17 +172,17 @@ This configuration references the Checkpoint detailed in the previous example ("
 
 **YAML**:
 
-```yaml name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template just the yaml"
+```yaml name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template just the yaml"
 ```
 
 **Runtime**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_4"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_4"
 ```
 
 **Results**:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_3"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_3"
 ```
 
 </TabItem>
@@ -200,7 +200,7 @@ Below is an example of a `CheckpointResult` object which itself contains `Valida
 
 ### Example CheckpointResult
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py results"
+```python name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py results"
 ```
 
 ## Example script

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/data_context.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/data_context.md
@@ -50,10 +50,10 @@ Because your Data Context contains the entirety of your GX project, GX Cloud can
 
 After you've created a Data Context, you'll likely start future work by instantiating a `DataContext` in Python. For example:
 
-```python title="Import GX" name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py import gx"
+```python title="Import GX" name="docs/docusaurus/docs/snippets/pandas_yaml_example.py import gx"
 ```
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py get_context"
+```python name="docs/docusaurus/docs/snippets/pandas_yaml_example.py get_context"
 ```
 
 Alternatively, you can use the `context_root_dir` parameter if you want to specify a specific directory
@@ -65,18 +65,18 @@ If you’re using GX Cloud, you set up the cloud environment variables before ca
 The code standards for GX strive for strongly typed inputs.  However, the Data Context's convenience functions are a noted exception to this standard.  For example, to get a Batch with typed input, you run the following code:
 
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py import BatchRequest"
+```python name="docs/docusaurus/docs/snippets/pandas_yaml_example.py import BatchRequest"
 ```
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with batch request"
+```python name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with batch request"
 ```
 
 If you prefer untyped inputs, you run code similar to the following examples:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters data_asset_name"
+```python name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters data_asset_name"
 ```
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters"
+```python name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters"
 ```
 
 In the example code, the `get_batch()` method is responsible for inferring your intended types, and passing it through to the correct internal methods.

--- a/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/datasource.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/reference/learn/terms/datasource.md
@@ -38,12 +38,12 @@ Data Sources do not modify your data during profiling or validation, but they ma
 
 Data Sources can be created and accessed using Python code, which can be executed from a script, a Python console, or a Jupyter Notebook. To access a Data Source all you need is a <TechnicalTag relative="../" tag="data_context" text="Data Context" /> and the name of the Data Source. The below snippet shows how to create a Pandas Data Source for local files:
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/connect_to_your_data_overview add_datasource"
+```python name="docs/docusaurus/docs/snippets/connect_to_your_data_overview add_datasource"
 ```
 
 This next snippet shows how to retrieve the Data Source from the Data Context.
 
-```python name="version-0.18 docs/docusaurus/docs/snippets/connect_to_your_data_overview config"
+```python name="docs/docusaurus/docs/snippets/connect_to_your_data_overview config"
 ```
 
 For detailed instructions on how to create Data Sources that are configured for various backends, see [our documentation on Connecting to Data Sources](/oss/guides/connecting_to_your_data/connect_to_data_lp.md).

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/actions.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/actions.py
@@ -41,21 +41,21 @@ class DocsAction(ValidationAction):
         expectation_suite_identifier=None,
         checkpoint_identifier=None,
     ):
-        # <snippet name="version-0.18 great_expectations/checkpoint/actions.py empty dict">
+        # <snippet name="great_expectations/checkpoint/actions.py empty dict">
         data_docs_validation_results: dict = {}
         # </snippet>
         if self._using_cloud_context:
             return data_docs_validation_results
 
         # get the URL for the validation result
-        # <snippet name="version-0.18 great_expectations/checkpoint/actions.py get_docs_sites_urls">
+        # <snippet name="great_expectations/checkpoint/actions.py get_docs_sites_urls">
         docs_site_urls_list = self.data_context.get_docs_sites_urls(
             resource_identifier=validation_result_suite_identifier,
             site_names=self._site_names,  # type: ignore[arg-type] # could be a `str`
         )
         # </snippet>
         # process payload
-        # <snippet name="version-0.18 great_expectations/checkpoint/actions.py iterate">
+        # <snippet name="great_expectations/checkpoint/actions.py iterate">
         for sites in docs_site_urls_list:
             data_docs_validation_results[sites["site_name"]] = sites["site_url"]
         # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/athena_python_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/athena_python_example.py
@@ -1,6 +1,6 @@
 import os
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py imports">
 import great_expectations as gx
 
 # </snippet>
@@ -21,17 +21,15 @@ if not ATHENA_STAGING_S3:
 connection_string = f"awsathena+rest://@athena.us-east-1.amazonaws.com/{ATHENA_DB_NAME}?s3_staging_dir={ATHENA_STAGING_S3}"
 
 # create datasource and add to DataContext
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py get_context">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py get_context">
 context = gx.get_context()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Connect and Build Batch Request">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py Connect and Build Batch Request">
 athena_source: SQLDatasource = context.sources.add_or_update_sql(
     "my_awsathena_datasource", connection_string=connection_string
 )
-athena_table = athena_source.add_table_asset(
-    "taxitable", table_name="version-0.18 taxitable"
-)
+athena_table = athena_source.add_table_asset("taxitable", table_name="taxitable")
 
 
 batch_request = athena_table.build_batch_request()
@@ -42,14 +40,14 @@ clean_athena_db(connection_string, ATHENA_DB_NAME, "taxitable")
 
 # Test 1 : temp_table is not created (default)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Create Expectation Suite">
-expectation_suite_name = "version-0.18 my_awsathena_expectation_suite"
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py Create Expectation Suite">
+expectation_suite_name = "my_awsathena_expectation_suite"
 suite = context.add_or_update_expectation_suite(
     expectation_suite_name=expectation_suite_name
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Test Datasource with Validator">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py Test Datasource with Validator">
 validator = context.get_validator(
     batch_request=batch_request,
     expectation_suite_name=expectation_suite_name,
@@ -58,9 +56,9 @@ validator.head(n_rows=5, fetch_all=False)
 # </snippet>
 assert validator
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Add Checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py Add Checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     validations=[
         {
             "batch_request": batch_request,
@@ -70,7 +68,7 @@ checkpoint = context.add_or_update_checkpoint(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/athena_python_example.py Run Checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/athena_python_example.py Run Checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_cloud_storage_pandas.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_cloud_storage_pandas.py
@@ -13,7 +13,7 @@ temp_dir = tempfile.TemporaryDirectory()
 full_path_to_project_directory = pathlib.Path(temp_dir.name).resolve()
 yaml: YAMLHandler = YAMLHandler()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py imports">
 import great_expectations as gx
 
 context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
@@ -41,7 +41,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
     "expectations_store_name"
 ]
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_expectations_store">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -59,7 +59,7 @@ assert actual_existing_expectations_store == yaml.load(
 
 # adding expectations store
 configured_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_expectations_store">
 stores:
   expectations_S3_store:
     class_name: ExpectationsStore
@@ -121,7 +121,7 @@ actual_existing_validations_store["validations_store_name"] = great_expectations
 ]
 
 expected_existing_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py existing_validations_store">
 stores:
   validations_store:
     class_name: ValidationsStore
@@ -139,7 +139,7 @@ assert actual_existing_validations_store == yaml.load(
 
 # adding validations store
 configured_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py new_validations_store">
 stores:
   validations_S3_store:
     class_name: ValidationsStore
@@ -149,7 +149,7 @@ stores:
       prefix: '<YOUR S3 VALIDATION PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py set_new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py set_new_validations_store">
 validations_store_name: validations_S3_store
 # </snippet>
 """
@@ -179,7 +179,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
 
 # adding data docs store
 data_docs_site_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_data_docs_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_data_docs_store">
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
@@ -214,25 +214,25 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_s3_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_s3_datasource">
 datasource = context.sources.add_or_update_pandas_s3(
-    name="version-0.18 s3_datasource", bucket="taxi-data-sample-test"
+    name="s3_datasource", bucket="taxi-data-sample-test"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_pandas_s3_asset">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_pandas_s3_asset">
 asset = datasource.add_csv_asset(
-    name="version-0.18 csv_taxi_s3_asset",
+    name="csv_taxi_s3_asset",
     batching_regex=r".*_(?P<year>\d{4})\.csv",
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_batch_request">
 request = asset.build_batch_request({"year": "2021"})
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_batch_list">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_batch_list">
 batches = asset.get_batch_list_from_batch_request(request)
 # </snippet>
 
@@ -240,33 +240,31 @@ config = context.fluent_datasources["s3_datasource"].yaml()
 assert "name: s3_datasource" in config
 assert "type: pandas_s3" in config
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_validator">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py get_validator">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=request, expectation_suite_name="test_suite"
 )
 
 print(validator.head())
 # </snippet>
 
 # add expectations to validator
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_expectations">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py add_expectations">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 validator.expect_column_values_to_be_between(
     column="congestion_surcharge", min_value=0, max_value=1000
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py save_expectations">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py save_expectations">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
 # build Checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py create_checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py create_checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     validations=[{"batch_request": request, "expectation_suite_name": "test_suite"}],
 )
 # </snippet>
@@ -276,7 +274,7 @@ checkpoint_result = checkpoint.run()
 assert not checkpoint_result.success
 
 # build datadocs
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py build_docs">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_pandas.py build_docs">
 context.build_data_docs()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_cloud_storage_spark.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_cloud_storage_spark.py
@@ -20,7 +20,7 @@ import boto3
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py imports">
 import great_expectations as gx
 
 context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
@@ -48,7 +48,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
     "expectations_store_name"
 ]
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py existing_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py existing_expectations_store">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -66,7 +66,7 @@ assert actual_existing_expectations_store == yaml.load(
 
 # adding expectations store
 configured_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py new_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py new_expectations_store">
 stores:
   expectations_S3_store:
     class_name: ExpectationsStore
@@ -128,7 +128,7 @@ actual_existing_validations_store["validations_store_name"] = great_expectations
 ]
 
 expected_existing_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py existing_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py existing_validations_store">
 stores:
   validations_store:
     class_name: ValidationsStore
@@ -146,7 +146,7 @@ assert actual_existing_validations_store == yaml.load(
 
 # adding validations store
 configured_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py new_validations_store">
 stores:
   validations_S3_store:
     class_name: ValidationsStore
@@ -156,7 +156,7 @@ stores:
       prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py set_new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py set_new_validations_store">
 validations_store_name: validations_S3_store
 # </snippet>
 """
@@ -186,7 +186,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
 
 # adding data docs store
 data_docs_site_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_data_docs_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_data_docs_store">
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
@@ -225,29 +225,29 @@ awscreds = {
     "aws_secret_access_key": AWS_SECRET_ACCESS_KEY,
 }
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_s3_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_s3_datasource">
 datasource = context.sources.add_or_update_spark_s3(
-    name="version-0.18 s3_datasource",
+    name="s3_datasource",
     bucket="taxi-data-sample-test",
     boto3_options=awscreds,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_spark_s3_asset">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_spark_s3_asset">
 asset = datasource.add_csv_asset(
-    name="version-0.18 csv_taxi_s3_asset",
+    name="csv_taxi_s3_asset",
     batching_regex=r".*_(?P<year>\d{4})\.csv",
     header=True,
     infer_schema=True,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_batch_request">
 request = asset.build_batch_request({"year": "2021"})
 # </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_batch_list">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_batch_list">
 batches = asset.get_batch_list_from_batch_request(request)
 # </snippet>
 
@@ -255,45 +255,43 @@ config = context.fluent_datasources["s3_datasource"].yaml()
 assert "name: s3_datasource" in config
 assert "type: spark_s3" in config
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_validator">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py get_validator">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=request, expectation_suite_name="test_suite"
 )
 
 print(validator.head())
 # </snippet>
 
 # add expectations to validator
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_expectations">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py add_expectations">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 validator.expect_column_values_to_be_between(
     column="congestion_surcharge", min_value=0, max_value=1000
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py save_expectations">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py save_expectations">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
 # build Checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py create_checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py create_checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     validations=[{"batch_request": request, "expectation_suite_name": "test_suite"}],
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py run checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 
 assert not checkpoint_result.success
 
 # build datadocs
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py build_docs">
+# <snippet name="docs/docusaurus/docs/snippets/aws_cloud_storage_spark.py build_docs">
 context.build_data_docs()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_redshift_deployment_patterns.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/aws_redshift_deployment_patterns.py
@@ -14,7 +14,7 @@ full_path_to_project_directory = pathlib.Path(temp_dir.name).resolve()
 yaml: YAMLHandler = YAMLHandler()
 CONNECTION_STRING = get_redshift_connection_url()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py imports">
 import great_expectations as gx
 
 context = gx.data_context.FileDataContext.create(full_path_to_project_directory)
@@ -42,7 +42,7 @@ actual_existing_expectations_store["expectations_store_name"] = great_expectatio
     "expectations_store_name"
 ]
 expected_existing_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py existing_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py existing_expectations_store">
 stores:
   expectations_store:
     class_name: ExpectationsStore
@@ -60,7 +60,7 @@ assert actual_existing_expectations_store == yaml.load(
 
 # adding expectations store
 configured_expectations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py new_expectations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py new_expectations_store">
 stores:
   expectations_S3_store:
     class_name: ExpectationsStore
@@ -122,7 +122,7 @@ actual_existing_validations_store["validations_store_name"] = great_expectations
 ]
 
 expected_existing_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py existing_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py existing_validations_store">
 stores:
   validations_store:
     class_name: ValidationsStore
@@ -140,7 +140,7 @@ assert actual_existing_validations_store == yaml.load(
 
 # adding validations store
 configured_validations_store_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py new_validations_store">
 stores:
   validations_S3_store:
     class_name: ValidationsStore
@@ -150,7 +150,7 @@ stores:
       prefix: '<YOUR S3 PREFIX NAME>'  # Bucket and prefix in combination must be unique across all stores
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py set_new_validations_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py set_new_validations_store">
 validations_store_name: validations_S3_store
 # </snippet>
 """
@@ -180,7 +180,7 @@ with open(great_expectations_yaml_file_path, "w") as f:
 
 # adding data docs store
 data_docs_site_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_data_docs_store">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_data_docs_store">
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
@@ -215,67 +215,63 @@ with open(great_expectations_yaml_file_path, "w") as f:
     yaml.dump(great_expectations_yaml, f)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py vars">
-datasource_name = "version-0.18 my_redshift_datasource"
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py vars">
+datasource_name = "my_redshift_datasource"
 connection_string = "redshift+psycopg2://<USER_NAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>?sslmode=<SSLMODE>"
 # </snippet>
 
 # For tests, we are replacing the `connection_string`
 connection_string = CONNECTION_STRING
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py datasource">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py datasource">
 datasource = context.sources.add_or_update_sql(
     name=datasource_name,
     connection_string=connection_string,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py table_asset">
-table_asset = datasource.add_table_asset(
-    name="my_table_asset", table_name="version-0.18 taxi_data"
-)
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py table_asset">
+table_asset = datasource.add_table_asset(name="my_table_asset", table_name="taxi_data")
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py query_asset">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py query_asset">
 query_asset = datasource.add_query_asset(
-    name="version-0.18 my_query_asset", query="SELECT * from taxi_data"
+    name="my_query_asset", query="SELECT * from taxi_data"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_suite_and_get_validator">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py add_suite_and_get_validator">
 request = table_asset.build_batch_request()
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 
 validator = context.get_validator(
-    batch_request=request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=request, expectation_suite_name="test_suite"
 )
 
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py validator_calls">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py validator_calls">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 validator.expect_column_values_to_be_between(
     column="congestion_surcharge", min_value=0, max_value=1000
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py save_expectations">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py save_expectations">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
 # build Checkpoint
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py create_checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py create_checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     validations=[{"batch_request": request, "expectation_suite_name": "test_suite"}],
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/aws_redshift_deployment_patterns.py run checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/batch_request.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/batch_request.py
@@ -14,19 +14,19 @@ data_directory = pathlib.Path(
     "taxi_yellow_tripdata_samples",
 ).resolve(strict=True)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/batch_request batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/batch_request batch_request">
 import great_expectations as gx
 
 context = gx.get_context()
 
 # data_directory is the full path to a directory containing csv files
 datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 my_pandas_datasource", base_directory=data_directory
+    name="my_pandas_datasource", base_directory=data_directory
 )
 
 # The batching_regex should max file names in the data_directory
 asset = datasource.add_csv_asset(
-    name="version-0.18 csv_asset",
+    name="csv_asset",
     batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
     order_by=["year", "month"],
 )
@@ -38,7 +38,7 @@ assert batch_request.datasource_name == "my_pandas_datasource"
 assert batch_request.data_asset_name == "csv_asset"
 assert batch_request.options == {"year": "2019", "month": "02"}
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/batch_request options">
+# <snippet name="docs/docusaurus/docs/snippets/batch_request options">
 options = asset.batch_request_options
 print(options)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/checkpoints.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/checkpoints.py
@@ -1,4 +1,4 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py setup">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints.py setup">
 import great_expectations as gx
 from great_expectations.datasource.fluent import DataAsset, Datasource
 
@@ -17,24 +17,24 @@ validator.expect_column_values_to_be_between(
 )
 
 taxi_suite = validator.get_expectation_suite()
-taxi_suite.expectation_suite_name = "version-0.18 taxi_suite"
+taxi_suite.expectation_suite_name = "taxi_suite"
 
 context.add_expectation_suite(expectation_suite=taxi_suite)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py create_and_run">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints.py create_and_run">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 taxi_checkpoint",
+    name="taxi_checkpoint",
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 taxi_suite",
+    expectation_suite_name="taxi_suite",
 )
 checkpoint.run()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py save">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints.py save">
 context.add_or_update_checkpoint(checkpoint=checkpoint)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints.py retrieve_and_run">
 checkpoint = context.get_checkpoint("taxi_checkpoint")
 checkpoint.run()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/checkpoints_and_actions.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/checkpoints_and_actions.py
@@ -32,7 +32,7 @@ context.add_or_update_expectation_suite("my_other_expectation_suite")
 
 # Add a Checkpoint
 context.add_or_update_checkpoint(
-    name="version-0.18 test_checkpoint",
+    name="test_checkpoint",
     run_name_template="%Y-%M-foo-bar-template",
     validations=[
         {
@@ -61,7 +61,7 @@ context.add_or_update_checkpoint(
 )
 assert context.list_checkpoints() == ["test_checkpoint"]
 
-results = context.run_checkpoint(checkpoint_name="version-0.18 test_checkpoint")
+results = context.run_checkpoint(checkpoint_name="test_checkpoint")
 assert results.success is True
 run_id_type = type(results.run_id)
 assert run_id_type == RunIdentifier
@@ -91,7 +91,7 @@ typed_results = {
     "success": True,
 }
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py results">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py results">
 results = {
     "run_id": RunIdentifier,
     "run_results": {
@@ -115,13 +115,13 @@ assert typed_results == results
 os.environ["VAR"] = "ge"
 
 batch_request = FluentBatchRequest(
-    datasource_name="version-0.18 taxi_datasource",
-    data_asset_name="version-0.18 taxi_asset",
+    datasource_name="taxi_datasource",
+    data_asset_name="taxi_asset",
     options={"year": "2019", "month": "01"},
 )
 validator = context.get_validator(
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 my_expectation_suite",
+    expectation_suite_name="my_expectation_suite",
 )
 validator.expect_table_row_count_to_be_between(
     min_value={"$PARAMETER": "GT_PARAM", "$PARAMETER.GT_PARAM": 0},
@@ -130,7 +130,7 @@ validator.expect_table_row_count_to_be_between(
 validator.save_expectation_suite(discard_failed_expectations=False)
 validator = context.get_validator(
     batch_request=batch_request,
-    expectation_suite_name="version-0.18 my_other_expectation_suite",
+    expectation_suite_name="my_other_expectation_suite",
 )
 validator.expect_table_row_count_to_be_between(
     min_value={"$PARAMETER": "GT_PARAM", "$PARAMETER.GT_PARAM": 0},
@@ -138,10 +138,10 @@ validator.expect_table_row_count_to_be_between(
 )
 validator.save_expectation_suite(discard_failed_expectations=False)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting">
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting just the yaml">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py no_nesting just the yaml">
 context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     run_name_template="%Y-%M-foo-bar-template-$VAR",
     validations=[
         {
@@ -175,8 +175,8 @@ context.add_or_update_checkpoint(
 # </snippet>
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint">
-results = context.run_checkpoint(checkpoint_name="version-0.18 my_checkpoint")
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint">
+results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 # </snippet>
 assert results.success is True
 assert (
@@ -192,10 +192,10 @@ assert (
     == 1000
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults">
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults just the yaml">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py nesting_with_defaults just the yaml">
 context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     run_name_template="%Y-%M-foo-bar-template-$VAR",
     validations=[
         {
@@ -213,7 +213,7 @@ context.add_or_update_checkpoint(
             },
         },
     ],
-    expectation_suite_name="version-0.18 my_expectation_suite",
+    expectation_suite_name="my_expectation_suite",
     action_list=[
         {
             "name": "<ACTION NAME FOR STORING VALIDATION RESULTS>",
@@ -236,12 +236,12 @@ context.add_or_update_checkpoint(
 # </snippet>
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_2">
-results = context.run_checkpoint(checkpoint_name="version-0.18 my_checkpoint")
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_2">
+results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 # </snippet>
 assert results.success is True
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets">
 first_validation_result = list(results.run_results.items())[0][1]["validation_result"]
 second_validation_result = list(results.run_results.items())[1][1]["validation_result"]
 
@@ -277,10 +277,10 @@ assert second_batch_identifiers == {
 }
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime">
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime just the yaml">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py keys_passed_at_runtime just the yaml">
 context.add_or_update_checkpoint(
-    name="version-0.18 my_base_checkpoint",
+    name="my_base_checkpoint",
     run_name_template="%Y-%M-foo-bar-template-$VAR",
     action_list=[
         {
@@ -304,9 +304,9 @@ context.add_or_update_checkpoint(
 # </snippet>
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_3">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_3">
 results = context.run_checkpoint(
-    checkpoint_name="version-0.18 my_base_checkpoint",
+    checkpoint_name="my_base_checkpoint",
     validations=[
         {
             "batch_request": {
@@ -328,7 +328,7 @@ results = context.run_checkpoint(
 )
 # </snippet>
 assert results.success is True
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_2">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_2">
 first_validation_result = list(results.run_results.items())[0][1]["validation_result"]
 second_validation_result = list(results.run_results.items())[1][1]["validation_result"]
 
@@ -367,11 +367,11 @@ assert second_batch_identifiers == {
 context.add_or_update_expectation_suite("my_expectation_suite")
 context.add_or_update_expectation_suite("my_other_expectation_suite")
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template">
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template just the yaml">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py using_template just the yaml">
 context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
-    template_name="version-0.18 my_base_checkpoint",
+    name="my_checkpoint",
+    template_name="my_base_checkpoint",
     validations=[
         {
             "batch_request": {
@@ -394,11 +394,11 @@ context.add_or_update_checkpoint(
 # </snippet>
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_4">
-results = context.run_checkpoint(checkpoint_name="version-0.18 my_checkpoint")
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py run_checkpoint_4">
+results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 # </snippet>
 assert results.success is True
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_3">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py validation_results_suites_data_assets_3">
 first_validation_result = list(results.run_results.items())[0][1]["validation_result"]
 second_validation_result = list(results.run_results.items())[1][1]["validation_result"]
 
@@ -435,7 +435,7 @@ assert second_batch_identifiers == {
 # </snippet>
 
 equivalent_using_checkpoint = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/checkpoints_and_actions.py checkpoint_example">
+# <snippet name="docs/docusaurus/docs/snippets/checkpoints_and_actions.py checkpoint_example">
 name: my_checkpoint
 config_version: 1
 class_name: Checkpoint
@@ -473,7 +473,7 @@ checkpoint_example = equivalent_using_checkpoint.replace(
 context.add_or_update_checkpoint(**yaml.load(equivalent_using_checkpoint))
 context.add_or_update_checkpoint(**yaml.load(checkpoint_example))
 
-results = context.run_checkpoint(checkpoint_name="version-0.18 my_checkpoint")
+results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 
 assert results.success is True
 validation_result = list(results.run_results.items())[0][1]["validation_result"]

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/connect_to_your_data_overview.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/connect_to_your_data_overview.py
@@ -1,16 +1,16 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/connect_to_your_data_overview add_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/connect_to_your_data_overview add_datasource">
 import great_expectations as gx
 
 context = gx.get_context()
 context.sources.add_pandas_filesystem(
-    name="version-0.18 my_pandas_datasource", base_directory="./data"
+    name="my_pandas_datasource", base_directory="./data"
 )
 # </snippet>
 
 assert "my_pandas_datasource" in context.datasources
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/connect_to_your_data_overview config">
+# <snippet name="docs/docusaurus/docs/snippets/connect_to_your_data_overview config">
 datasource = context.datasources["my_pandas_datasource"]
 print(datasource)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_dataframe_python_configs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_dataframe_python_configs.py
@@ -1,7 +1,7 @@
 # isort:skip_file
 import pathlib
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py imports">
 import great_expectations as gx
 from great_expectations.checkpoint import Checkpoint
 
@@ -11,19 +11,19 @@ from great_expectations.core.util import get_or_create_spark_application
 
 spark = get_or_create_spark_application()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py choose context_root_dir">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py choose context_root_dir">
 context_root_dir = "/dbfs/great_expectations/"
 # </snippet>
 
 context_root_dir = None
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py set up context">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py set up context">
 context = gx.get_context(context_root_dir=context_root_dir)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add datasource">
 dataframe_datasource = context.sources.add_or_update_spark(
-    name="version-0.18 my_spark_in_memory_datasource",
+    name="my_spark_in_memory_datasource",
 )
 csv_file_path = "/path/to/data/directory/yellow_tripdata_2020-08.csv"
 # </snippet>
@@ -36,20 +36,20 @@ csv_file_path = str(
     )
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add data asset">
 df = spark.read.csv(csv_file_path, header=True)
 dataframe_asset = dataframe_datasource.add_dataframe_asset(
-    name="version-0.18 yellow_tripdata",
+    name="yellow_tripdata",
     dataframe=df,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py build batch request">
 batch_request = dataframe_asset.build_batch_request()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator">
-expectation_suite_name = "version-0.18 insert_your_expectation_suite_name_here"
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py get validator">
+expectation_suite_name = "insert_your_expectation_suite_name_here"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 validator = context.get_validator(
     batch_request=batch_request,
@@ -59,7 +59,7 @@ validator = context.get_validator(
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add expectations">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 
 validator.expect_column_values_to_be_between(
@@ -67,11 +67,11 @@ validator.expect_column_values_to_be_between(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py save suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-my_checkpoint_name = "version-0.18 my_databricks_checkpoint"
+my_checkpoint_name = "my_databricks_checkpoint"
 
 checkpoint = Checkpoint(
     name=my_checkpoint_name,
@@ -88,10 +88,10 @@ checkpoint = Checkpoint(
     ],
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add checkpoint config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py add checkpoint config">
 context.add_or_update_checkpoint(checkpoint=checkpoint)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_python_configs.py run checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py
@@ -1,7 +1,7 @@
 # ruff: noqa: I001, PTH118, PTH109, PTH120
 import os
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py imports">
 import datetime
 import pandas as pd
 
@@ -29,14 +29,14 @@ spark = get_or_create_spark_application()
 
 # CODE vvvvv vvvvv
 # This root directory is for use in Databricks
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py root directory">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py root directory">
 root_directory = "/dbfs/great_expectations/"
 # </snippet>
 
 # For testing purposes only, we change the root_directory to an ephemeral location created by our test runner
 root_directory = os.path.join(os.getcwd(), "dbfs_temp_directory")
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py set up context">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py set up context">
 data_context_config = DataContextConfig(
     store_backend_defaults=FilesystemStoreBackendDefaults(
         root_directory=root_directory
@@ -58,7 +58,7 @@ assert os.listdir(uncommitted_directory) == ["validations"]
 # 3. Prepare your data
 
 # CODE vvvvv vvvvv
-filename = "version-0.18 yellow_tripdata_sample_2019-01.csv"
+filename = "yellow_tripdata_sample_2019-01.csv"
 data_dir = os.path.join(os.path.dirname(root_directory), "data")
 pandas_df = pd.read_csv(os.path.join(data_dir, filename))
 data_file_path = os.path.join(data_dir, filename)
@@ -74,7 +74,7 @@ assert len(pandas_df.columns) == len(df.columns) == 18
 # 4. Connect to your data
 
 # CODE vvvvv vvvvv
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py datasource config">
 my_spark_datasource_config = """
 name: insert_your_datasource_name_here
 class_name: Datasource
@@ -90,19 +90,19 @@ data_connectors:
 """
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test datasource config">
 context.test_yaml_config(my_spark_datasource_config)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add datasource config">
 context.add_datasource(**yaml.load(my_spark_datasource_config))
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py create batch request">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py create batch request">
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 insert_your_datasource_name_here",
-    data_connector_name="version-0.18 insert_your_data_connector_name_here",
-    data_asset_name="version-0.18 <YOUR_MEANGINGFUL_NAME>",  # This can be anything that identifies this data_asset for you
+    datasource_name="insert_your_datasource_name_here",
+    data_connector_name="insert_your_data_connector_name_here",
+    data_asset_name="<YOUR_MEANGINGFUL_NAME>",  # This can be anything that identifies this data_asset for you
     batch_identifiers={
         "some_key_maybe_pipeline_stage": "prod",
         "some_other_key_maybe_run_id": f"my_run_name_{datetime.date.today().strftime('%Y%m%d')}",
@@ -128,8 +128,8 @@ assert sorted(
 
 # 5. Create expectations
 # CODE vvvvv vvvvv
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py get validator">
-expectation_suite_name = "version-0.18 insert_your_expectation_suite_name_here"
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py get validator">
+expectation_suite_name = "insert_your_expectation_suite_name_here"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 validator = context.get_validator(
     batch_request=batch_request,
@@ -139,7 +139,7 @@ validator = context.get_validator(
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add expectations">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add expectations">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 
 validator.expect_column_values_to_be_between(
@@ -147,7 +147,7 @@ validator.expect_column_values_to_be_between(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py save suite">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py save suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 # CODE ^^^^^ ^^^^^
@@ -161,7 +161,7 @@ assert len(suite.expectations) == 2
 # 6. Validate your data (Dataframe)
 # CODE vvvvv vvvvv
 
-my_checkpoint_name = "version-0.18 insert_your_checkpoint_name_here"
+my_checkpoint_name = "insert_your_checkpoint_name_here"
 my_checkpoint_config = f"""
 name: {my_checkpoint_name}
 config_version: 1.0
@@ -169,15 +169,15 @@ class_name: Checkpoint
 run_name_template: "%Y%m%d-%H%M%S-my-run-name-template"
 """
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test checkpoint config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py test checkpoint config">
 my_checkpoint = context.test_yaml_config(my_checkpoint_config)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add checkpoint config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py add checkpoint config">
 context.add_or_update_checkpoint(**yaml.load(my_checkpoint_config))
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_dataframe_yaml_configs.py run checkpoint">
 checkpoint_result = context.run_checkpoint(
     checkpoint_name=my_checkpoint_name,
     validations=[

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_file_python_configs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/databricks_deployment_patterns_file_python_configs.py
@@ -2,23 +2,23 @@
 import pathlib
 from pyfakefs.fake_filesystem import FakeFilesystem
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py imports">
 import great_expectations as gx
 from great_expectations.checkpoint import Checkpoint
 
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose context_root_dir">
 context_root_dir = "/dbfs/great_expectations/"
 # </snippet>
 
 context_root_dir = None
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py set up context">
 context = gx.get_context(context_root_dir=context_root_dir)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose base directory">
 base_directory = "/dbfs/example_data/nyctaxi/tripdata/yellow/"
 # </snippet>
 
@@ -28,42 +28,42 @@ base_directory = pathlib.Path("/dbfs/data/")
 fs = FakeFilesystem()
 fs.add_real_directory(source_path=data_directory, target_path=base_directory)
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add datasource">
 dbfs_datasource = context.sources.add_or_update_spark_dbfs(
-    name="version-0.18 my_spark_dbfs_datasource",
+    name="my_spark_dbfs_datasource",
     base_directory=base_directory,
 )
 # </snippet>
 
 # unable to successfully mock dbfs, so using filesystem for tests
-context.delete_datasource(datasource_name="version-0.18 my_spark_dbfs_datasource")
+context.delete_datasource(datasource_name="my_spark_dbfs_datasource")
 dbfs_datasource = context.sources.add_or_update_spark_filesystem(
-    name="version-0.18 my_spark_dbfs_datasource",
+    name="my_spark_dbfs_datasource",
     base_directory=data_directory,
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py choose batching regex">
 batching_regex = r"yellow_tripdata_(?P<year>\d{4})-(?P<month>\d{2})\.csv\.gz"
 # </snippet>
 
 # For this test script, change batching_regex for location where test runner data is located
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add data asset">
 csv_asset = dbfs_datasource.add_csv_asset(
-    name="version-0.18 yellow_tripdata",
+    name="yellow_tripdata",
     batching_regex=batching_regex,
     header=True,
     infer_schema=True,
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py build batch request">
 batch_request = csv_asset.build_batch_request()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py get validator">
-expectation_suite_name = "version-0.18 insert_your_expectation_suite_name_here"
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py get validator">
+expectation_suite_name = "insert_your_expectation_suite_name_here"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 validator = context.get_validator(
     batch_request=batch_request,
@@ -73,16 +73,16 @@ validator = context.get_validator(
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add expectations">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add expectations">
 validator.expect_table_column_count_to_equal(value=18)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py save suite">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py save suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config">
-my_checkpoint_name = "version-0.18 my_databricks_checkpoint"
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py checkpoint config">
+my_checkpoint_name = "my_databricks_checkpoint"
 
 checkpoint = Checkpoint(
     name=my_checkpoint_name,
@@ -100,10 +100,10 @@ checkpoint = Checkpoint(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py add checkpoint config">
 context.add_or_update_checkpoint(checkpoint=checkpoint)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/databricks_deployment_patterns_file_python_configs.py run checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/expect_column_max_to_be_between_custom.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/expect_column_max_to_be_between_custom.py
@@ -39,23 +39,23 @@ from great_expectations.render.util import (
 )
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ColumnCustomMax class_def">
+# <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ColumnCustomMax class_def">
 class ColumnCustomMax(ColumnAggregateMetricProvider):
     # </snippet>
     """MetricProvider Class for Custom Aggregate Max MetricProvider"""
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_name">
-    metric_name = "version-0.18 column.custom_max"
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_name">
+    metric_name = "column.custom_max"
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _pandas">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _pandas">
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         """Pandas Max Implementation"""
         return column.max()
 
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_def">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_def">
     @metric_value(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(
         cls,
@@ -66,7 +66,7 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         runtime_configuration,
     ):
         # </snippet>
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_selectable">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_selectable">
         (
             selectable,
             compute_domain_kwargs,
@@ -78,7 +78,7 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         column_name = accessor_domain_kwargs["column"]
         column = sa.column(column_name)
         # </snippet>
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_query">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py sql_query">
         query = sa.select(sa.func.max(column)).select_from(selectable)
         result = execution_engine.execute_query(query).fetchone()
 
@@ -86,7 +86,7 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
 
     # </snippet>
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _spark">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _spark">
     @column_aggregate_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column, _table, _column_name, **kwargs):
         """Spark Max Implementation"""
@@ -96,15 +96,15 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
 #     </snippet>
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ExpectColumnMaxToBeBetween class_def">
+# <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py ExpectColumnMaxToBeBetween class_def">
 class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py docstring">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py docstring">
     """Expect column max to be between a given range."""
     # </snippet>
 
     # Defining test cases
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py examples">
     examples = [
         {
             "data": {"x": [1, 2, 3, 4, 5], "y": [0, -1, -2, 4, None]},
@@ -147,12 +147,12 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
     strict_max: bool = False
 
     # Setting necessary computation metric dependencies and defining kwargs, as well as assigning kwargs default values
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_dependencies">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py metric_dependencies">
     metric_dependencies = ("column.custom_max",)
     # </snippet>
     success_keys = ("min_value", "strict_min", "max_value", "strict_max")
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config">
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
@@ -171,7 +171,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
         configuration = configuration or self.configuration
         # </snippet>
 
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_params">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_params">
         min_value = configuration.kwargs["min_value"]
         max_value = configuration.kwargs["max_value"]
         strict_min = configuration.kwargs["strict_min"]
@@ -179,13 +179,13 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
         # </snippet>
 
         # Validating that min_val, max_val, strict_min, and strict_max are of the proper format and type
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_values">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_values">
         try:
             assert (
                 min_value is not None or max_value is not None
             ), "min_value and max_value cannot both be none"
             # </snippet>
-            # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_types">
+            # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_types">
             assert min_value is None or isinstance(
                 min_value, (float, int)
             ), "Provided min threshold must be a number"
@@ -193,13 +193,13 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
                 max_value, (float, int)
             ), "Provided max threshold must be a number"
             # </snippet>
-            # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_comparison">
+            # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_comparison">
             if min_value and max_value:
                 assert (
                     min_value <= max_value
                 ), "Provided min threshold must be less than or equal to max threshold"
             #     </snippet>
-            # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_none">
+            # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_none">
             assert strict_min is None or isinstance(
                 strict_min, bool
             ), "strict_min must be a boolean value"
@@ -207,13 +207,13 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
                 strict_max, bool
             ), "strict_max must be a boolean value"
         #     </snippet>
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_except">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py validate_config_except">
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 
     #     </snippet>
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _validate">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py _validate">
     def _validate(
         self,
         metrics: Dict,
@@ -326,7 +326,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
         ]
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py library_metadata">
     library_metadata = {
         "tags": ["flexible max comparisons"],
         "contributors": ["@joegargery"],
@@ -337,7 +337,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnAggregateExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_max_to_be_between_custom.py diagnostics">
     ExpectColumnMaxToBeBetweenCustom(
         column="x",
         min_value=0,

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/expect_column_values_to_equal_three.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/expect_column_values_to_equal_three.py
@@ -37,23 +37,23 @@ result_dict = {}
 
 # This class defines a Metric to support your Expectation.
 # For most ColumnMapExpectations, the main business logic for calculation will live in this class.
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ColumnValuesEqualThree class_def">
+# <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ColumnValuesEqualThree class_def">
 class ColumnValuesEqualThree(ColumnMapMetricProvider):
     # </snippet>
 
     # This is the id string that will be used to reference your metric.
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py metric_name">
-    condition_metric_name = "version-0.18 column_values.equal_three"
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py metric_name">
+    condition_metric_name = "column_values.equal_three"
     # </snippet>
 
     # This method implements the core logic for the PandasExecutionEngine
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py pandas">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py pandas">
     @column_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         return column == 3
         # </snippet>
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_definition">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_definition">
     @metric_partial(
         engine=SparkDFExecutionEngine,
         partial_fn_type=MetricPartialFunctionTypes.MAP_CONDITION_FN,
@@ -68,7 +68,7 @@ class ColumnValuesEqualThree(ColumnMapMetricProvider):
         runtime_configuration,
     ):
         # </snippet>
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_selectable">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_selectable">
         (
             selectable,
             compute_domain_kwargs,
@@ -80,13 +80,13 @@ class ColumnValuesEqualThree(ColumnMapMetricProvider):
         column_name = accessor_domain_kwargs["column"]
         column = F.col(column_name)
         # </snippet>
-        # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_query">
+        # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py spark_query">
         query = F.when(column == 3, F.lit(False)).otherwise(F.lit(True))
 
         return (query, compute_domain_kwargs, accessor_domain_kwargs)
         # </snippet>
 
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py sqlalchemy">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py sqlalchemy">
     @column_condition_partial(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(cls, column, **kwargs):
         return column.in_([3])
@@ -113,7 +113,7 @@ class ColumnValuesEqualThree(ColumnMapMetricProvider):
             k: v for k, v in metric.metric_domain_kwargs.items() if k != "column"
         }
         dependencies["table.column_types"] = MetricConfiguration(
-            metric_name="version-0.18 table.column_types",
+            metric_name="table.column_types",
             metric_domain_kwargs=table_domain_kwargs,
             metric_value_kwargs={
                 "include_nested": True,
@@ -124,16 +124,16 @@ class ColumnValuesEqualThree(ColumnMapMetricProvider):
 
 
 # This class defines the Expectation itself
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ExpectColumnValuesToEqualThree class_def">
+# <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py ExpectColumnValuesToEqualThree class_def">
 class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
     # </snippet>
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py docstring">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py docstring">
     """Expect values in this column to equal 3."""
 
     # </snippet>
     # These examples will be shown in the public gallery.
     # They will also be executed as unit tests for your Expectation.
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py examples">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py examples">
     examples = [
         {
             "data": {
@@ -166,7 +166,7 @@ class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
 
     # This is the id string of the Metric used by this Expectation.
     # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py map_metric">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py map_metric">
     map_metric = "column_values.equal_three"
     # </snippet>
 
@@ -377,7 +377,7 @@ class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
         return unexpected_table_content_block
 
     # This dictionary contains metadata for display in the public gallery
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py library_metadata">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py library_metadata">
     library_metadata = {
         "tags": ["extremely basic math"],
         "contributors": ["@joegargery"],
@@ -386,7 +386,7 @@ class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
 
 
 if __name__ == "__main__":
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py diagnostics">
+    # <snippet name="docs/docusaurus/docs/snippets/expect_column_values_to_equal_three.py diagnostics">
     ExpectColumnValuesToEqualThree().print_diagnostic_checklist()
 #     </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py
@@ -20,15 +20,15 @@ import great_expectations as gx
 context = gx.get_context()
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_datasource">
 # data_directory is the full path to a directory containing csv files
 my_datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 my_datasource", base_directory=data_directory
+    name="my_datasource", base_directory=data_directory
 )
 # </snippet>
 
 my_asset = my_datasource.add_csv_asset(
-    name="version-0.18 my_asset",
+    name="my_asset",
     batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
     order_by=["year", "month"],
 )
@@ -36,32 +36,28 @@ my_asset = my_datasource.add_csv_asset(
 import pandas as pd
 
 dataframe = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
-my_ephemeral_datasource = context.sources.add_pandas(
-    name="version-0.18 my_pandas_datasource"
-)
-my_asset = my_ephemeral_datasource.add_dataframe_asset(
-    name="version-0.18 my_ephemeral_asset"
-)
+my_ephemeral_datasource = context.sources.add_pandas(name="my_pandas_datasource")
+my_asset = my_ephemeral_datasource.add_dataframe_asset(name="my_ephemeral_asset")
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py build_batch_request_with_dataframe">
 my_batch_request = my_asset.build_batch_request(dataframe=dataframe)
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_asset">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_asset">
 my_asset = context.get_datasource("my_datasource").get_asset("my_asset")
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request_options">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request_options">
 print(my_asset.batch_request_options)
 # </snippet>
 
 assert my_asset.batch_request_options == ("year", "month", "path")
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_request">
 my_batch_request = my_asset.build_batch_request()
 # </snippet>
 
@@ -70,7 +66,7 @@ assert my_batch_request.data_asset_name == "my_asset"
 assert my_batch_request.options == {}
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_list">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py my_batch_list">
 batches = my_asset.get_batch_list_from_batch_request(my_batch_request)
 # </snippet>
 
@@ -83,7 +79,7 @@ for batch in batches:
     assert batch.data.dataframe.shape == (10000, 18)
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py print_batch_spec">
+# <snippet name="docs/docusaurus/docs/snippets/get_existing_data_asset_from_existing_datasource_pandas_filesystem_example.py print_batch_spec">
 for batch in batches:
     print(batch.batch_spec)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_pandas_datasource.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_pandas_datasource.py
@@ -82,7 +82,7 @@ def is_subset(subset, superset):
 
 
 def get_full_pandas_inferred_datasource_single_batch():
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_single_batch_full_snippet">
+    # <snippet name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_single_batch_full_snippet">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -114,7 +114,7 @@ def get_full_pandas_inferred_datasource_single_batch():
 
 
 def get_full_pandas_inferred_datasource_multi_batch():
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_multi_batch_full_snippet">
+    # <snippet name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_inferred_datasource_multi_batch_full_snippet">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -146,7 +146,7 @@ def get_full_pandas_inferred_datasource_multi_batch():
 
 
 def get_full_pandas_configured_datasource_single_batch():
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_single_batch_full_snippet">
+    # <snippet name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_single_batch_full_snippet">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -180,7 +180,7 @@ def get_full_pandas_configured_datasource_single_batch():
 
 
 def get_full_pandas_configured_datasource_multi_batch():
-    # <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_multi_batch_full_snippet">
+    # <snippet name="docs/docusaurus/docs/snippets/how_to_configure_a_pandas_datasource.py pandas_configured_datasource_multi_batch_full_snippet">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -214,7 +214,7 @@ def get_full_pandas_configured_datasource_multi_batch():
 
 
 def get_full_pandas_runtime_datasource():
-    # <snippet name="version-0.18 pandas_runtime_datasource_full_snippet">
+    # <snippet name="pandas_runtime_datasource_full_snippet">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -248,20 +248,20 @@ def validate_pandas_datasource_configuration_snippets():
 
     """
     # Snippet: create an empty dict for your configuration.
-    # <snippet name="version-0.18 datasource_configuration_empty_dictionary">
+    # <snippet name="datasource_configuration_empty_dictionary">
     datasource_config: dict = {}
     # </snippet>
 
     # Snippet: adding a name to your datasource
     datasource_config: dict = {
-        # <snippet name="version-0.18 datasource_configuration_name_key">
+        # <snippet name="datasource_configuration_name_key">
         "name": "my_datasource_name",  # Preferably name it something relevant
         # </snippet>
     }
     prev_snippet = datasource_config
 
     # Snippet: full config after adding a name to your Datasource.
-    # <snippet name="version-0.18 datasource_configuration_post_name_key">
+    # <snippet name="datasource_configuration_post_name_key">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
     }
@@ -271,7 +271,7 @@ def validate_pandas_datasource_configuration_snippets():
     # Snippet: Adding a class_name and module_name to your Datasource.
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
-        # <snippet name="version-0.18 datasource_configuration_class_and_module_keys">
+        # <snippet name="datasource_configuration_class_and_module_keys">
         "class_name": "Datasource",
         "module_name": "great_expectations.datasource"
         # </snippet>
@@ -280,7 +280,7 @@ def validate_pandas_datasource_configuration_snippets():
     prev_snippet = datasource_config
 
     # Snippet: Full configuration after adding class_name and module_name to your Datasource.
-    # <snippet name="version-0.18 datasource_configuration_post_class_and_module_keys">
+    # <snippet name="datasource_configuration_post_class_and_module_keys">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -294,7 +294,7 @@ def validate_pandas_datasource_configuration_snippets():
         "name": "my_datasource_name",
         "class_name": "Datasource",
         "module_name": "great_expectations.datasource",
-        # <snippet name="version-0.18 datasource_configuration_add_execution_engine">
+        # <snippet name="datasource_configuration_add_execution_engine">
         "execution_engine": {
             "class_name": "PandasExecutionEngine",
             "module_name": "great_expectations.execution_engine",
@@ -305,7 +305,7 @@ def validate_pandas_datasource_configuration_snippets():
     prev_snippet = datasource_config
 
     # Snippet: Full config after adding an Execution Engine to your Datasource.
-    # <snippet name="version-0.18 datasource_configuration_post_execution_engine">
+    # <snippet name="datasource_configuration_post_execution_engine">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -320,7 +320,7 @@ def validate_pandas_datasource_configuration_snippets():
     prev_snippet = datasource_config
 
     # Snippet: Add an empty dictionary for your data_connectors configuration.
-    # <snippet name="version-0.18 datasource_configuration_add_empty_data_connectors_key">
+    # <snippet name="datasource_configuration_add_empty_data_connectors_key">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -354,7 +354,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     full_inferred_multi_batch_config = get_full_pandas_inferred_datasource_multi_batch()
 
     # Snippet for adding the Data Connector configuration dictionary.
-    # <snippet name="version-0.18 datasource_config add empty inferred_data_connector">
+    # <snippet name="datasource_config add empty inferred_data_connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -373,7 +373,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 inferred data connector populate class_name">
+                # <snippet name="inferred data connector populate class_name">
                 "class_name": "InferredAssetFilesystemDataConnector",
                 # </snippet>
             }
@@ -386,7 +386,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 inferred data connector add base_directory">
+                # <snippet name="inferred data connector add base_directory">
                 "base_directory": "../data",
                 # </snippet>
             }
@@ -396,7 +396,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     is_subset(datasource_config, full_inferred_multi_batch_config)
 
     # Snippet for the final version of data_connectors class_name and module_name configuration.
-    # <snippet name="version-0.18 datasource_configuration_pandas_inferred_empty_regex">
+    # <snippet name="datasource_configuration_pandas_inferred_empty_regex">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -422,7 +422,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     datasource_config = {
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 datasource_configuration_glob_directive">
+                # <snippet name="datasource_configuration_glob_directive">
                 "glob_directive": "*.*"
                 # </snippet>
             }
@@ -430,7 +430,7 @@ def validate_pandas_datasource_configuration_inferred_snippets():
     }
     prev_config = datasource_config
     # Snippet: Full config after adding glob_directive.
-    # <snippet name="version-0.18 datasource_configuration_post_glob_directive">
+    # <snippet name="datasource_configuration_post_glob_directive">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -471,10 +471,10 @@ def validate_pandas_datasource_configuration_inferred_single_batch_snippets():
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
                 "default_regex": {
-                    # <snippet name="version-0.18 datasource_configuration_inferred_single_batch_regex_pattern">
+                    # <snippet name="datasource_configuration_inferred_single_batch_regex_pattern">
                     "pattern": "(.*)\\.csv",
                     # </snippet>
-                    # <snippet name="version-0.18 datasource_configuration_inferred_single_batch_group_names">
+                    # <snippet name="datasource_configuration_inferred_single_batch_group_names">
                     "group_names": ["data_asset_name"],
                     # </snippet>
                 }
@@ -486,7 +486,7 @@ def validate_pandas_datasource_configuration_inferred_single_batch_snippets():
     # Snippet: full inferred_data_connector with single batch default_regex
     datasource_config = {
         "data_connectors": {
-            # <snippet name="version-0.18 data_connector_configuration_post_single_batch_regex">
+            # <snippet name="data_connector_configuration_post_single_batch_regex">
             "name_of_my_inferred_data_connector": {
                 "class_name": "InferredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -501,7 +501,7 @@ def validate_pandas_datasource_configuration_inferred_single_batch_snippets():
     is_subset(datasource_config, full_inferred_single_batch_config)
 
     # Snippet: Full configuration for inferred Datasource with single batch default_regex.
-    # <snippet name="version-0.18 datasource_configuration_post_inferred_data_connector">
+    # <snippet name="datasource_configuration_post_inferred_data_connector">
     datasource_config = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -533,10 +533,10 @@ def validate_pandas_datasource_configuration_inferred_multi_batch_snippets():
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
                 "default_regex": {
-                    # <snippet name="version-0.18 datasource_configuration_inferred_multi_batch_regex_pattern">
+                    # <snippet name="datasource_configuration_inferred_multi_batch_regex_pattern">
                     "pattern": "(yellow_tripdata_sample_2020)-(\\d.*)\\.csv",
                     # </snippet>
-                    # <snippet name="version-0.18 group_names for inferred multi batch default_regex key">
+                    # <snippet name="group_names for inferred multi batch default_regex key">
                     "group_names": ["data_asset_name", "month"],
                     # </snippet>
                 }
@@ -548,7 +548,7 @@ def validate_pandas_datasource_configuration_inferred_multi_batch_snippets():
     # Snippet: full data connector config for inferred Data Connector multi batch
     datasource_config = {
         "data_connectors": {
-            # <snippet name="version-0.18 data connector config for inferred filesystem data connector multi batch">
+            # <snippet name="data connector config for inferred filesystem data connector multi batch">
             "name_of_my_inferred_data_connector": {
                 "class_name": "InferredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -563,7 +563,7 @@ def validate_pandas_datasource_configuration_inferred_multi_batch_snippets():
     is_subset(datasource_config, full_inferred_multi_batch_config)
 
     # Snippet: Full configuration for Pandas multibatch Inferred Datasource.
-    # <snippet name="version-0.18 datasource_configuration_post_multi_batch_inferred_data_connector">
+    # <snippet name="datasource_configuration_post_multi_batch_inferred_data_connector">
     datasource_config = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -597,7 +597,7 @@ def validate_pandas_datasource_configuration_configured_snippets():
     )
 
     # Snippet: Add a dictionary for your configured data_connector
-    # <snippet name="version-0.18 datasource_configuration_add_empty_configured_data_connector">
+    # <snippet name="datasource_configuration_add_empty_configured_data_connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -616,10 +616,10 @@ def validate_pandas_datasource_configuration_configured_snippets():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_configured_data_connector": {
-                # <snippet name="version-0.18 data_connector_configuration_configured_class_name">
+                # <snippet name="data_connector_configuration_configured_class_name">
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 # </snippet>
-                # <snippet name="version-0.18 data_connector_configuration_configured_base_directory">
+                # <snippet name="data_connector_configuration_configured_base_directory">
                 "base_directory": "../data",
                 # </snippet>
             }
@@ -629,7 +629,7 @@ def validate_pandas_datasource_configuration_configured_snippets():
     is_subset(datasource_config, full_configured_multi_batch_config)
 
     # Snippet: Full config for data connector, with empty assets dictionary
-    # <snippet name="version-0.18 datasource_config_configured_data_connector_empty_data_asset">
+    # <snippet name="datasource_config_configured_data_connector_empty_data_asset">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -663,7 +663,7 @@ def validate_pandas_datasource_configuration_configured_single_batch_snippets():
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 empty_data_asset_configuration_configured_single_batch">
+                    # <snippet name="empty_data_asset_configuration_configured_single_batch">
                     "yellow_tripdata_jan": {}
                     # </snippet>
                 }
@@ -679,10 +679,10 @@ def validate_pandas_datasource_configuration_configured_single_batch_snippets():
             "name_of_my_configured_data_connector": {
                 "assets": {
                     "yellow_tripdata_jan": {
-                        # <snippet name="version-0.18 pattern_for_single_batch_configured_data_asset_configuration">
+                        # <snippet name="pattern_for_single_batch_configured_data_asset_configuration">
                         "pattern": "yellow_tripdata_sample_2020-(01)\\.csv",
                         # </snippet>
-                        # <snippet name="version-0.18 group_names for single batch configured assets configuration">
+                        # <snippet name="group_names for single batch configured assets configuration">
                         "group_names": ["month"],
                         # </snippet>
                     }
@@ -697,7 +697,7 @@ def validate_pandas_datasource_configuration_configured_single_batch_snippets():
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 full_data_asset_for_single_batch_configured_data_connector">
+                    # <snippet name="full_data_asset_for_single_batch_configured_data_connector">
                     "yellow_tripdata_jan": {
                         "pattern": "yellow_tripdata_sample_2020-(01)\\.csv",
                         "group_names": ["month"],
@@ -712,7 +712,7 @@ def validate_pandas_datasource_configuration_configured_single_batch_snippets():
     # Snippet: Full configuration for a Configured Data Connector with a single-batch Data Asset.
     datasource_config = {
         "data_connectors": {
-            # <snippet name="version-0.18 full_single_batch_configured_data_connector_configuration">
+            # <snippet name="full_single_batch_configured_data_connector_configuration">
             "name_of_my_configured_data_connector": {
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -729,7 +729,7 @@ def validate_pandas_datasource_configuration_configured_single_batch_snippets():
     is_subset(datasource_config, full_configured_single_batch_config)
 
     # Snippet: Full configuration for a Datasource using a Configured Data Connector and single-batch Data Asset.
-    # <snippet name="version-0.18 full datasource_config for pandas execution engine, configured data connector; single batch asset">
+    # <snippet name="full datasource_config for pandas execution engine, configured data connector; single batch asset">
     datasource_config = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -766,7 +766,7 @@ def validate_pandas_datasource_configuration_configured_multi_batch_snippets():
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 empty data asset for configured, multi batch datasource">
+                    # <snippet name="empty data asset for configured, multi batch datasource">
                     "yellow_tripdata_2020": {}
                     # </snippet>
                 }
@@ -782,10 +782,10 @@ def validate_pandas_datasource_configuration_configured_multi_batch_snippets():
             "name_of_my_configured_data_connector": {
                 "assets": {
                     "yellow_tripdata_2020": {
-                        # <snippet name="version-0.18 pattern for asset in configured, multi-batch datasource">
+                        # <snippet name="pattern for asset in configured, multi-batch datasource">
                         "pattern": "yellow_tripdata_sample_2020-(.*)\\.csv",
                         # </snippet>
-                        # <snippet name="version-0.18 group_names for asset in configured, multi-batch datasource">
+                        # <snippet name="group_names for asset in configured, multi-batch datasource">
                         "group_names": ["month"],
                         # </snippet>
                     }
@@ -800,7 +800,7 @@ def validate_pandas_datasource_configuration_configured_multi_batch_snippets():
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 multi batch data asset for configured pandas datasource">
+                    # <snippet name="multi batch data asset for configured pandas datasource">
                     "yellow_tripdata_2020": {
                         "pattern": "yellow_tripdata_sample_2020-(.*)\\.csv",
                         "group_names": ["month"],
@@ -815,7 +815,7 @@ def validate_pandas_datasource_configuration_configured_multi_batch_snippets():
     # Snippet: Full configuration for a Configured Data Connector with a single-batch Data Asset.
     datasource_config = {
         "data_connectors": {
-            # <snippet name="version-0.18 data connector for configured, multi-batch, Pandas datasource">
+            # <snippet name="data connector for configured, multi-batch, Pandas datasource">
             "name_of_my_configured_data_connector": {
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -832,7 +832,7 @@ def validate_pandas_datasource_configuration_configured_multi_batch_snippets():
     is_subset(datasource_config, full_configured_multi_batch_config)
 
     # Snippet: Full configuration for a Datasource using a Configured Data Connector and single-batch Data Asset.
-    # <snippet name="version-0.18 full config for Pandas, configured, multi-batch Datasource">
+    # <snippet name="full config for Pandas, configured, multi-batch Datasource">
     datasource_config = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -862,7 +862,7 @@ def validate_pandas_datsource_configuration_runtime_snippets():
     full_runtime_config = get_full_pandas_runtime_datasource()
 
     # Snippet: Add empty dictionary for runtime data connector.
-    # <snippet name="version-0.18 add empty dictionary for runtime data connector">
+    # <snippet name="add empty dictionary for runtime data connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -880,7 +880,7 @@ def validate_pandas_datsource_configuration_runtime_snippets():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_runtime_data_connector": {
-                # <snippet name="version-0.18 class_name for pandas runtime data connector">
+                # <snippet name="class_name for pandas runtime data connector">
                 "class_name": "RuntimeDataConnector",
                 # </snippet>
             }
@@ -889,7 +889,7 @@ def validate_pandas_datsource_configuration_runtime_snippets():
     is_subset(datasource_config, full_runtime_config)
 
     # Snippet: Full datasource config for runtime data connector with blank batch_identifiers list.
-    # <snippet name="version-0.18 full config for pandas runtime Datasource with blank data asset identifiers">
+    # <snippet name="full config for pandas runtime Datasource with blank data asset identifiers">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -913,7 +913,7 @@ def validate_pandas_datsource_configuration_runtime_snippets():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_runtime_data_connector": {
-                # <snippet name="version-0.18 batch_identifiers for filesystem runtime data connector">
+                # <snippet name="batch_identifiers for filesystem runtime data connector">
                 "batch_identifiers": ["batch_timestamp"]
                 # </snippet>
             }
@@ -922,7 +922,7 @@ def validate_pandas_datsource_configuration_runtime_snippets():
     is_subset(datasource_config, full_runtime_config)
 
     # Snippet: Full Pandas Datasource configuration with Runtime data connector and timestamp batch identifier.
-    # <snippet name="version-0.18 full pandas runtime Datasource configuration">
+    # <snippet name="full pandas runtime Datasource configuration">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -961,7 +961,7 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 empty batch_spec_passthrough">
+                # <snippet name="empty batch_spec_passthrough">
                 "batch_spec_passthrough": {
                     "reader_method": "",
                     "reader_options": {},
@@ -977,10 +977,10 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
                 "batch_spec_passthrough": {
-                    # <snippet name="version-0.18 set reader_method to csv">
+                    # <snippet name="set reader_method to csv">
                     "reader_method": "csv",
                     # </snippet>
-                    # <snippet name="version-0.18 empty keys for reader_options">
+                    # <snippet name="empty keys for reader_options">
                     "reader_options": {
                         "header": "",
                         "inferSchema": "",
@@ -998,10 +998,10 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
             "name_of_my_inferred_data_connector": {
                 "batch_spec_passthrough": {
                     "reader_options": {
-                        # <snippet name="version-0.18 populate header for reader_options as True">
+                        # <snippet name="populate header for reader_options as True">
                         "header": True,
                         # </snippet>
-                        # <snippet name="version-0.18 populate inferSchema for reader_options as True">
+                        # <snippet name="populate inferSchema for reader_options as True">
                         "inferSchema": True,
                         # </snippet>
                     },
@@ -1015,7 +1015,7 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
     datasource_config: dict = {
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 fully populated batch_spec_passthrough configuration">
+                # <snippet name="fully populated batch_spec_passthrough configuration">
                 "batch_spec_passthrough": {
                     "reader_method": "csv",
                     "reader_options": {
@@ -1030,7 +1030,7 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
     for full_config in full_configs:
         is_subset(datasource_config, full_config)
 
-    # <snippet name="version-0.18 inferred datasource_config up to batch_spec_passthrough">
+    # <snippet name="inferred datasource_config up to batch_spec_passthrough">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -1058,7 +1058,7 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
     is_subset(datasource_config, get_full_pandas_inferred_datasource_multi_batch())
     is_subset(datasource_config, get_full_pandas_inferred_datasource_single_batch())
 
-    # <snippet name="version-0.18 configured datasource_config up to batch_spec_passthrough">
+    # <snippet name="configured datasource_config up to batch_spec_passthrough">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -1085,7 +1085,7 @@ def validate_pandas_batch_spec_passthrough_config_for_inferred():
     is_subset(datasource_config, get_full_pandas_configured_datasource_multi_batch())
     is_subset(datasource_config, get_full_pandas_configured_datasource_single_batch())
 
-    # <snippet name="version-0.18 runtime datasource_config up to batch_spec_passthrough">
+    # <snippet name="runtime datasource_config up to batch_spec_passthrough">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -1289,15 +1289,15 @@ def test_pandas_configured_runtime_full_configuration():
 def test_adding_your_datasource_to_the_datacontext():
     datasource_config = get_full_pandas_runtime_datasource()
 
-    # <snippet name="version-0.18 test your config with test_yaml_config">
+    # <snippet name="test your config with test_yaml_config">
     data_context.test_yaml_config(yaml.dump(datasource_config))
     # </snippet>
 
-    # <snippet name="version-0.18 add your datasource to your data_context">
+    # <snippet name="add your datasource to your data_context">
     data_context.add_datasource(**datasource_config)
     # </snippet>
 
-    # <snippet name="version-0.18 add your datasource to your data_context only if it does not already exit">
+    # <snippet name="add your datasource to your data_context only if it does not already exit">
     # add_datasource only if it doesn't already exist in your Data Context
     try:
         data_context.get_datasource(datasource_config["name"])

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_spark_datasource.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_spark_datasource.py
@@ -68,7 +68,7 @@ def validate_universal_config_elements():
 def section_5_add_the_spark_execution_engine_to_your_datasource_configuration():
     """Provides and tests the snippets for section 5 of the Spark Datasource configuration guide."""
 
-    # <snippet name="version-0.18 spark datasource_config up to definition of Spark execution engine">
+    # <snippet name="spark datasource_config up to definition of Spark execution engine">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -84,7 +84,7 @@ def section_5_add_the_spark_execution_engine_to_your_datasource_configuration():
         "name": "my_datasource_name",
         "class_name": "Datasource",
         "module_name": "great_expectations.datasource",
-        # <snippet name="version-0.18 define spark execution engine">
+        # <snippet name="define spark execution engine">
         "execution_engine": {
             "class_name": "SparkDFExecutionEngine",
             "module_name": "great_expectations.execution_engine",
@@ -111,7 +111,7 @@ def section_5_add_the_spark_execution_engine_to_your_datasource_configuration():
 def section_6_add_a_dictionary_as_the_value_of_the_data_connectors_key():
     """Provides and tests the snippets for section 6 of the Spark Datasource configuration guide."""
 
-    # <snippet name="version-0.18 spark datasource_config up to adding an empty data_connectors dictionary">
+    # <snippet name="spark datasource_config up to adding an empty data_connectors dictionary">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -143,7 +143,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
     Spark Datasource configuration guide.
 
     """
-    # <snippet name="version-0.18 spark Datasource configuration up to adding an empty inferred data connector">
+    # <snippet name="spark Datasource configuration up to adding an empty inferred data connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -162,7 +162,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
         datasource_config, get_full_config_spark_inferred_datasource_multi_batch()
     )
 
-    # <snippet name="version-0.18 inferred spark datasource_config up to adding empty default_regex and batch_spec_passthrough dictionaries">
+    # <snippet name="inferred spark datasource_config up to adding empty default_regex and batch_spec_passthrough dictionaries">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -173,7 +173,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
         },
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 inferred data connector define class_name as InferredAssetFilesystemDataConnector">
+                # <snippet name="inferred data connector define class_name as InferredAssetFilesystemDataConnector">
                 "class_name": "InferredAssetFilesystemDataConnector",
                 # </snippet>
                 "base_directory": "../data",
@@ -203,7 +203,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
             "name_of_my_inferred_data_connector": {
                 "class_name": "InferredAssetFilesystemDataConnector",
                 "base_directory": "../data",
-                # <snippet name="version-0.18 define glob_directive">
+                # <snippet name="define glob_directive">
                 "glob_directive": "*/*",
                 # </snippet>
                 "default_regex": {},
@@ -213,7 +213,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
     }
     is_subset(datasource_config, glob_directive)
 
-    # <snippet name="version-0.18 spark inferred datasource_config post glob_directive definition">
+    # <snippet name="spark inferred datasource_config post glob_directive definition">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -241,7 +241,7 @@ def section_7_configure_your_individual_data_connectors__configured():
     Spark Datasource configuration guide.
 
     """
-    # <snippet name="version-0.18 spark Datasource configuration up to adding an empty configured data connector">
+    # <snippet name="spark Datasource configuration up to adding an empty configured data connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -260,7 +260,7 @@ def section_7_configure_your_individual_data_connectors__configured():
         datasource_config, get_full_config_spark_configured_datasource_multi_batch()
     )
 
-    # <snippet name="version-0.18 configured spark datasource_config up to adding empty assets and batch_spec_passthrough dictionaries">
+    # <snippet name="configured spark datasource_config up to adding empty assets and batch_spec_passthrough dictionaries">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -271,7 +271,7 @@ def section_7_configure_your_individual_data_connectors__configured():
         },
         "data_connectors": {
             "name_of_my_configured_data_connector": {
-                # <snippet name="version-0.18 configured data connector define class_name as ConfiguredAssetFilesystemDataConnector">
+                # <snippet name="configured data connector define class_name as ConfiguredAssetFilesystemDataConnector">
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 # </snippet>
                 "base_directory": "../data",
@@ -295,7 +295,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
     Spark Datasource configuration guide.
 
     """
-    # <snippet name="version-0.18 spark Datasource configuration up to adding an empty runtime data connector">
+    # <snippet name="spark Datasource configuration up to adding an empty runtime data connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -309,7 +309,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
     # </snippet>
     is_subset(datasource_config, get_full_config_spark_runtime_datasource())
 
-    # <snippet name="version-0.18 runtime spark datasource_config up to adding empty batch_identifiers and batch_spec_passthrough dictionaries">
+    # <snippet name="runtime spark datasource_config up to adding empty batch_identifiers and batch_spec_passthrough dictionaries">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -320,7 +320,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
         },
         "data_connectors": {
             "name_of_my_runtime_data_connector": {
-                # <snippet name="version-0.18 runtime data connector define class_name as RuntimeDataConnector">
+                # <snippet name="runtime data connector define class_name as RuntimeDataConnector">
                 "class_name": "RuntimeDataConnector",
                 # </snippet>
                 "batch_spec_passthrough": {},
@@ -339,16 +339,16 @@ def section_8_configure_the_values_for_batch_spec_passthrough__universal():
 
     """
     empty_batch_spec_passthrough: dict = {
-        # <snippet name="version-0.18 populate batch_spec_passthrough with empty reader_method and reader_options">
+        # <snippet name="populate batch_spec_passthrough with empty reader_method and reader_options">
         "batch_spec_passthrough": {"reader_method": "", "reader_options": {}}
         # </snippet>
     }
     smaller_snippets: dict = {
         "batch_spec_passthrough": {
-            # <snippet name="version-0.18 populate reader_method with csv">
+            # <snippet name="populate reader_method with csv">
             "reader_method": "csv",
             # </snippet>
-            # <snippet name = "version-0.18 populate reader_options with empty header and inferSchema keys">
+            # <snippet name = "populate reader_options with empty header and inferSchema keys">
             "reader_options": {"header": "", "inferSchema": ""}
             # </snippet>
         }
@@ -357,10 +357,10 @@ def section_8_configure_the_values_for_batch_spec_passthrough__universal():
         "batch_spec_passthrough": {
             "reader_method": "csv",
             "reader_options": {
-                # <snippet name="version-0.18 define header as True for reader_options">
+                # <snippet name="define header as True for reader_options">
                 "header": True,
                 # </snippet>
-                # <snippet name="version-0.18 define inferSchema as True for reader_options">
+                # <snippet name="define inferSchema as True for reader_options">
                 "inferSchema": True
                 # </snippet>
             },
@@ -431,7 +431,7 @@ def section_8_configure_the_values_for_batch_spec_passthrough__universal():
 
 
 def section_8_configure_the_values_for_batch_spec_passthrough__inferred():
-    # <snippet name="version-0.18 inferred spark datasource_config post batch_spec_passthrough definition">
+    # <snippet name="inferred spark datasource_config post batch_spec_passthrough definition">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -465,7 +465,7 @@ def section_8_configure_the_values_for_batch_spec_passthrough__inferred():
 
 
 def section_8_configure_the_values_for_batch_spec_passthrough__configured():
-    # <snippet name="version-0.18 configured spark datasource_config post batch_spec_passthrough definition">
+    # <snippet name="configured spark datasource_config post batch_spec_passthrough definition">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -499,7 +499,7 @@ def section_8_configure_the_values_for_batch_spec_passthrough__configured():
 
 
 def section_8_configure_the_values_for_batch_spec_passthrough__runtime():
-    # <snippet name="version-0.18 runtime spark datasource_config post batch_spec_passthrough definition">
+    # <snippet name="runtime spark datasource_config post batch_spec_passthrough definition">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -531,10 +531,10 @@ def section_9_configure_your_data_connectors_data_assets__inferred__single_batch
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
                 "default_regex": {
-                    # <snippet name="version-0.18 inferred spark single batch pattern">
+                    # <snippet name="inferred spark single batch pattern">
                     "pattern": "(.*)\\.csv",
                     # </snippet>
-                    # <snippet name="version-0.18 inferred spark single batch group_names">
+                    # <snippet name="inferred spark single batch group_names">
                     "group_names": ["data_asset_name"]
                     # </snippet>
                 },
@@ -547,7 +547,7 @@ def section_9_configure_your_data_connectors_data_assets__inferred__single_batch
 
     data_connector_snippet: dict = {
         "data_connectors": {
-            # <snippet name="version-0.18 inferred spark single batch data connector config">
+            # <snippet name="inferred spark single batch data connector config">
             "name_of_my_inferred_data_connector": {
                 "class_name": "InferredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -564,7 +564,7 @@ def section_9_configure_your_data_connectors_data_assets__inferred__single_batch
         data_connector_snippet, get_full_config_spark_inferred_datasource_single_batch()
     )
 
-    # <snippet name="version-0.18 full datasource_config for inferred spark single batch datasource">
+    # <snippet name="full datasource_config for inferred spark single batch datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -598,7 +598,7 @@ def section_9_configure_your_data_connectors_data_assets__inferred__single_batch
 
 
 def section_9_configure_your_data_connectors_data_assets__inferred__multi_batch():
-    # <snippet name="version-0.18 full datasource_config for inferred spark multi batch datasource">
+    # <snippet name="full datasource_config for inferred spark multi batch datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -608,7 +608,7 @@ def section_9_configure_your_data_connectors_data_assets__inferred__multi_batch(
             "module_name": "great_expectations.execution_engine",
         },
         "data_connectors": {
-            # <snippet name="version-0.18 inferred spark multi batch data connector config">
+            # <snippet name="inferred spark multi batch data connector config">
             "name_of_my_inferred_data_connector": {
                 "class_name": "InferredAssetFilesystemDataConnector",
                 "base_directory": "../data",
@@ -638,7 +638,7 @@ def section_9_configure_your_data_connectors_data_assets__configured__single_bat
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 empty asset for configured spark single batch datasource">
+                    # <snippet name="empty asset for configured spark single batch datasource">
                     "yellow_tripdata_jan": {}
                     # </snippet>
                 }
@@ -649,7 +649,7 @@ def section_9_configure_your_data_connectors_data_assets__configured__single_bat
         datasource_config, get_full_config_spark_configured_datasource_single_batch()
     )
 
-    # <snippet name="version-0.18 full datasource_config for configured spark single batch datasource">
+    # <snippet name="full datasource_config for configured spark single batch datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -659,17 +659,17 @@ def section_9_configure_your_data_connectors_data_assets__configured__single_bat
             "module_name": "great_expectations.execution_engine",
         },
         "data_connectors": {
-            # <snippet name="version-0.18 configured spark single batch data connector config">
+            # <snippet name="configured spark single batch data connector config">
             "name_of_my_configured_data_connector": {
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 "base_directory": "../data",
                 "assets": {
-                    # <snippet name="version-0.18 configured spark single batch asset">
+                    # <snippet name="configured spark single batch asset">
                     "yellow_tripdata_jan": {
-                        # <snippet name="version-0.18 configured spark single batch pattern">
+                        # <snippet name="configured spark single batch pattern">
                         "pattern": "yellow_tripdata_sample_2020-(01)\\.csv",
                         # </snippet>
-                        # <snippet name="version-0.18 configured spark single batch group_names">
+                        # <snippet name="configured spark single batch group_names">
                         "group_names": ["month"],
                         # </snippet>
                     },
@@ -697,7 +697,7 @@ def section_9_configure_your_data_connectors_data_assets__configured__multi_batc
         "data_connectors": {
             "name_of_my_configured_data_connector": {
                 "assets": {
-                    # <snippet name="version-0.18 empty asset for configured spark multi batch datasource">
+                    # <snippet name="empty asset for configured spark multi batch datasource">
                     "yellow_tripdata_2020": {}
                     # </snippet>
                 }
@@ -708,7 +708,7 @@ def section_9_configure_your_data_connectors_data_assets__configured__multi_batc
         datasource_config, get_full_config_spark_configured_datasource_multi_batch()
     )
 
-    # <snippet name="version-0.18 full datasource_config for configured spark multi batch datasource">
+    # <snippet name="full datasource_config for configured spark multi batch datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -718,17 +718,17 @@ def section_9_configure_your_data_connectors_data_assets__configured__multi_batc
             "module_name": "great_expectations.execution_engine",
         },
         "data_connectors": {
-            # <snippet name="version-0.18 configured spark multi batch data connector config">
+            # <snippet name="configured spark multi batch data connector config">
             "name_of_my_configured_data_connector": {
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 "base_directory": "../data",
                 "assets": {
-                    # <snippet name="version-0.18 configured spark multi batch asset">
+                    # <snippet name="configured spark multi batch asset">
                     "yellow_tripdata_2020": {
-                        # <snippet name="version-0.18 configured spark multi batch pattern">
+                        # <snippet name="configured spark multi batch pattern">
                         "pattern": "yellow_tripdata_sample_2020-(.*)\\.csv",
                         # </snippet>
-                        # <snippet name="version-0.18 configured spark multi batch group_names">
+                        # <snippet name="configured spark multi batch group_names">
                         "group_names": ["month"],
                         # </snippet>
                     },
@@ -752,7 +752,7 @@ def section_9_configure_your_data_connectors_data_assets__configured__multi_batc
 
 
 def section_9_configure_your_data_connectors_data_assets__runtime():
-    # <snippet name="version-0.18 full datasource_config for runtime spark datasource">
+    # <snippet name="full datasource_config for runtime spark datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",  # Preferably name it something relevant
         "class_name": "Datasource",
@@ -771,7 +771,7 @@ def section_9_configure_your_data_connectors_data_assets__runtime():
                         "inferSchema": True,
                     },
                 },
-                # <snippet name="version-0.18 runtime spark batch_identifiers">
+                # <snippet name="runtime spark batch_identifiers">
                 "batch_identifiers": ["batch_timestamp"],
                 # </snippet>
             }
@@ -843,15 +843,15 @@ def section_12_add_your_new_datasource_to_your_datacontext():
             "name_of_my_configured_data_connector",
         ),
     ):
-        # <snippet name="version-0.18 test your spark datasource config with test_yaml_config">
+        # <snippet name="test your spark datasource config with test_yaml_config">
         data_context.test_yaml_config(yaml.dump(datasource_config))
         # </snippet>
 
-        # <snippet name="version-0.18 add your spark datasource to your data_context">
+        # <snippet name="add your spark datasource to your data_context">
         data_context.add_datasource(**datasource_config)
         # </snippet>
 
-        # <snippet name="version-0.18 add your spark datasource to your data_context only if it does not already exit">
+        # <snippet name="add your spark datasource to your data_context only if it does not already exit">
         # add_datasource only if it doesn't already exist in your Data Context
         try:
             data_context.get_datasource(datasource_config["name"])
@@ -867,9 +867,7 @@ def section_12_add_your_new_datasource_to_your_datacontext():
             datasource_name
             in data_context.list_datasources()[0]["data_connectors"].keys()
         ), f"{datasource_name} not in {data_context.list_datasources()}"
-        data_context.delete_datasource(
-            datasource_name="version-0.18 my_datasource_name"
-        )
+        data_context.delete_datasource(datasource_name="my_datasource_name")
 
 
 validate_universal_config_elements()

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_sql_datasource.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_configure_a_sql_datasource.py
@@ -57,7 +57,7 @@ def validate_universal_config_elements():
 
 def section_5_add_the_sqlalchemy_execution_engine_to_your_datasource_configuration():
     datasource_config: dict = {
-        # <snippet name="version-0.18 sql datasource define execution_engine class_name and module_name">
+        # <snippet name="sql datasource define execution_engine class_name and module_name">
         "execution_engine": {
             "class_name": "SqlAlchemyExecutionEngine",
             "module_name": "great_expectations.execution_engine",
@@ -72,7 +72,7 @@ def section_5_add_the_sqlalchemy_execution_engine_to_your_datasource_configurati
     ):
         is_subset(datasource_config, full_config)
 
-    # <snippet name="version-0.18 sql datasource configuration post execution engine defined">
+    # <snippet name="sql datasource configuration post execution engine defined">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -80,7 +80,7 @@ def section_5_add_the_sqlalchemy_execution_engine_to_your_datasource_configurati
         "execution_engine": {
             "class_name": "SqlAlchemyExecutionEngine",
             "module_name": "great_expectations.execution_engine",
-            # <snippet name="version-0.18 sql datasource define CONNECTION_STRING">
+            # <snippet name="sql datasource define CONNECTION_STRING">
             "connection_string": CONNECTION_STRING,
             # </snippet>
         },
@@ -96,7 +96,7 @@ def section_5_add_the_sqlalchemy_execution_engine_to_your_datasource_configurati
 
 
 def section_6_add_a_dictionary_as_the_value_of_the_data_connectors_key():
-    # <snippet name="version-0.18 sql datasource configuration post execution engine defined with empty data_connectors">
+    # <snippet name="sql datasource configuration post execution engine defined with empty data_connectors">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -119,7 +119,7 @@ def section_6_add_a_dictionary_as_the_value_of_the_data_connectors_key():
 
 
 def section_7_configure_your_individual_data_connectors__inferred():
-    # <snippet name="version-0.18 sql datasource configuration with empty inferred sql data_connector">
+    # <snippet name="sql datasource configuration with empty inferred sql data_connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -138,7 +138,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
         datasource_config, get_full_config_sql_inferred_datasource__single_batch_only()
     )
 
-    # <snippet name="version-0.18 inferred sql datasource configuration with data_connector class_name defined">
+    # <snippet name="inferred sql datasource configuration with data_connector class_name defined">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -150,7 +150,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
         },
         "data_connectors": {
             "name_of_my_inferred_data_connector": {
-                # <snippet name="version-0.18 define data_connector class_name for inferred sql datasource">
+                # <snippet name="define data_connector class_name for inferred sql datasource">
                 "class_name": "InferredAssetSqlDataConnector",
                 # </snippet>
             },
@@ -163,7 +163,7 @@ def section_7_configure_your_individual_data_connectors__inferred():
 
 
 def section_7_configure_your_individual_data_connectors__configured():
-    # <snippet name="version-0.18 sql datasource configuration with empty configured sql data_connector">
+    # <snippet name="sql datasource configuration with empty configured sql data_connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -180,7 +180,7 @@ def section_7_configure_your_individual_data_connectors__configured():
     # </snippet>
     is_subset(datasource_config, get_full_config_sql_configured_datasource())
 
-    # <snippet name="version-0.18 configured sql datasource configuration with data_connector class_name defined">
+    # <snippet name="configured sql datasource configuration with data_connector class_name defined">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -192,7 +192,7 @@ def section_7_configure_your_individual_data_connectors__configured():
         },
         "data_connectors": {
             "name_of_my_configured_data_connector": {
-                # <snippet name="version-0.18 define data_connector class_name for configured sql datasource">
+                # <snippet name="define data_connector class_name for configured sql datasource">
                 "class_name": "ConfiguredAssetSqlDataConnector",
                 # </snippet>
                 "assets": {},
@@ -204,7 +204,7 @@ def section_7_configure_your_individual_data_connectors__configured():
 
 
 def section_7_configure_your_individual_data_connectors__runtime():
-    # <snippet name="version-0.18 sql datasource configuration with empty runtime sql data_connector">
+    # <snippet name="sql datasource configuration with empty runtime sql data_connector">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -221,7 +221,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
     # </snippet>
     is_subset(datasource_config, get_full_config_sql_runtime_datasource())
 
-    # <snippet name="version-0.18 runtime sql datasource configuration with data_connector class_name defined">
+    # <snippet name="runtime sql datasource configuration with data_connector class_name defined">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -233,7 +233,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
         },
         "data_connectors": {
             "name_of_my_runtime_data_connector": {
-                # <snippet name="version-0.18 define data_connector class_name for runtime sql datasource">
+                # <snippet name="define data_connector class_name for runtime sql datasource">
                 "class_name": "RuntimeDataConnector",
                 # </snippet>
                 "batch_identifiers": {},
@@ -245,7 +245,7 @@ def section_7_configure_your_individual_data_connectors__runtime():
 
 
 def section_8_configure_your_data_connectors_data_assets__inferred():
-    # <snippet name="version-0.18 full configuration for sql inferred Datasource">
+    # <snippet name="full configuration for sql inferred Datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -256,12 +256,12 @@ def section_8_configure_your_data_connectors_data_assets__inferred():
             "connection_string": CONNECTION_STRING,
         },
         "data_connectors": {
-            # <snippet name="version-0.18 inferred sql data asset single batch">
+            # <snippet name="inferred sql data asset single batch">
             "inferred_data_connector_single_batch_asset": {
                 "class_name": "InferredAssetSqlDataConnector",
             },
             # </snippet>
-            # <snippet name="version-0.18 inferred sql data asset multi batch">
+            # <snippet name="inferred sql data asset multi batch">
             "inferred_data_connector_multi_batch_asset_split_on_date_time": {
                 "class_name": "InferredAssetSqlDataConnector",
                 "splitter_method": "split_on_year_and_month",
@@ -280,7 +280,7 @@ def section_8_configure_your_data_connectors_data_assets__inferred():
 
 
 def section_8_configure_your_data_connectors_data_assets__configured():
-    # <snippet name="version-0.18 full configuration for sql configured Datasource">
+    # <snippet name="full configuration for sql configured Datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -294,13 +294,13 @@ def section_8_configure_your_data_connectors_data_assets__configured():
             "name_of_my_configured_data_connector": {
                 "class_name": "ConfiguredAssetSqlDataConnector",
                 "assets": {
-                    # <snippet name="version-0.18 configured sql data asset single batch">
+                    # <snippet name="configured sql data asset single batch">
                     "yellow_tripdata_sample_2020_full": {
                         "table_name": "yellow_tripdata_sample_2020",
                         "schema_name": "main",
                     },
                     # </snippet>
-                    # <snippet name="version-0.18 configured sql data asset multi batch">
+                    # <snippet name="configured sql data asset multi batch">
                     "yellow_tripdata_sample_2020_by_year_and_month": {
                         "table_name": "yellow_tripdata_sample_2020",
                         "schema_name": "main",
@@ -322,7 +322,7 @@ def section_8_configure_your_data_connectors_data_assets__configured():
 
 
 def section_8_configure_your_data_connectors_data_assets__runtime():
-    # <snippet name="version-0.18 full configuration for sql runtime Datasource">
+    # <snippet name="full configuration for sql runtime Datasource">
     datasource_config: dict = {
         "name": "my_datasource_name",
         "class_name": "Datasource",
@@ -335,7 +335,7 @@ def section_8_configure_your_data_connectors_data_assets__runtime():
         "data_connectors": {
             "name_of_my_runtime_data_connector": {
                 "class_name": "RuntimeDataConnector",
-                # <snippet name="version-0.18 runtime sql data asset define batch_identifiers">
+                # <snippet name="runtime sql data asset define batch_identifiers">
                 "batch_identifiers": ["batch_timestamp"],
                 # </snippet>
             },
@@ -349,7 +349,7 @@ def section_8_configure_your_data_connectors_data_assets__runtime():
 
 
 def configure_your_data_connectors_data_assets__runtime__yaml():
-    # <snippet name="version-0.18 full configuration for sql runtime Datasource YAML">
+    # <snippet name="full configuration for sql runtime Datasource YAML">
     datasource_config = f"""
     name: my_datasource_name
     class_name: Datasource
@@ -363,7 +363,7 @@ def configure_your_data_connectors_data_assets__runtime__yaml():
           - batch_timestamp
     """
     # </snippet>
-    connector_name = "version-0.18 name_of_my_runtime_data_connector"
+    connector_name = "name_of_my_runtime_data_connector"
     asset_count = 0
 
     test_result = data_context.test_yaml_config(datasource_config)
@@ -422,11 +422,11 @@ def section_9_test_your_configuration__inferred_and_configured():
 def section_9_test_your_configuration__runtime():
     # Testing the runtime data connector (there will be no data assets, those are passed in by the RuntimeBatchRequest.)
     datasource_config = get_full_config_sql_runtime_datasource()
-    connector_name = "version-0.18 name_of_my_runtime_data_connector"
+    connector_name = "name_of_my_runtime_data_connector"
     asset_count = 0
 
     test_result = (
-        # <snippet name="version-0.18 test your sql datasource_config with test_yaml_config">
+        # <snippet name="test your sql datasource_config with test_yaml_config">
         data_context.test_yaml_config(yaml.dump(datasource_config))
         # </snippet>
     )

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_connect_to_a_sql_table.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_connect_to_a_sql_table.py
@@ -24,7 +24,7 @@ sqlite_database_path = str(
 )
 
 
-my_table_name = "version-0.18 yellow_tripdata_sample_2019_01"
+my_table_name = "yellow_tripdata_sample_2019_01"
 
 context = gx.get_context()
 
@@ -33,19 +33,17 @@ connection_string = f"sqlite:///{sqlite_database_path}"
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=GxDatasourceWarning)
     datasource = context.sources.add_sql(
-        name="version-0.18 my_datasource", connection_string=connection_string
+        name="my_datasource", connection_string=connection_string
     )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py datasource">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py datasource">
 datasource = context.get_datasource("my_datasource")
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource">
-table_asset = datasource.add_table_asset(
-    name="version-0.18 my_asset", table_name=my_table_name
-)
+# <snippet name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py create_datasource">
+table_asset = datasource.add_table_asset(name="my_asset", table_name=my_table_name)
 # </snippet>
 
 assert datasource.get_asset_names() == {"my_asset"}
@@ -77,11 +75,11 @@ assert set(batches[0].columns()) == {
     "congestion_surcharge",
 }
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py add_vendor_id_splitter">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py add_vendor_id_splitter">
 table_asset.add_splitter_column_value("vendor_id")
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py build_vendor_id_batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_connect_to_a_sql_table.py build_vendor_id_batch_request">
 my_batch_request = my_asset.build_batch_request({"vendor_id": 1})
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_create_a_new_checkpoint.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_create_a_new_checkpoint.py
@@ -14,7 +14,7 @@ data_directory = pathlib.Path(
 
 
 datasource = context.sources.add_pandas_filesystem(
-    name="version-0.18 demo_pandas", base_directory=data_directory
+    name="demo_pandas", base_directory=data_directory
 )
 
 asset = datasource.add_csv_asset(
@@ -26,7 +26,7 @@ asset = datasource.add_csv_asset(
 batch_request = asset.build_batch_request({"year": "2020", "month": "04"})
 validator = context.get_validator(
     batch_request=batch_request,
-    create_expectation_suite_with_name="version-0.18 my_expectation_suite",
+    create_expectation_suite_with_name="my_expectation_suite",
 )
 
 
@@ -34,9 +34,9 @@ validator.expect_table_row_count_to_be_between(min_value=5000, max_value=20000)
 validator.save_expectation_suite(discard_failed_expectations=False)
 
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py create checkpoint batch_request">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     validations=[
         {
             "batch_request": batch_request,
@@ -48,18 +48,18 @@ checkpoint = context.add_or_update_checkpoint(
 
 assert context.list_checkpoints() == ["my_checkpoint"]
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py run checkpoint batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py run checkpoint batch_request">
 checkpoint_result = checkpoint.run()
 # </snippet>
 
 assert checkpoint_result.success
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py build data docs">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py build data docs">
 context.build_data_docs()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py get checkpoint">
-retrieved_checkpoint = context.get_checkpoint(name="version-0.18 my_checkpoint")
+# <snippet name="docs/docusaurus/docs/snippets/how_to_create_a_new_checkpoint.py get checkpoint">
+retrieved_checkpoint = context.get_checkpoint(name="my_checkpoint")
 # </snippet>
 
 assert retrieved_checkpoint

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py
@@ -13,7 +13,7 @@ from great_expectations.data_context.data_context.file_data_context import (
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_data_context_config_with_in_memory_store_backend">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_data_context_config_with_in_memory_store_backend">
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
@@ -22,20 +22,20 @@ from great_expectations.data_context.types.base import (
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_ephemeral_data_context">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py import_ephemeral_data_context">
 from great_expectations.data_context import EphemeralDataContext
 
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_data_context_config_with_in_memory_store_backend">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_data_context_config_with_in_memory_store_backend">
 project_config = DataContextConfig(
     store_backend_defaults=InMemoryStoreBackendDefaults()
 )
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_ephemeral_data_context">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py instantiate_ephemeral_data_context">
 context = EphemeralDataContext(project_config=project_config)
 # </snippet>
 
@@ -44,7 +44,7 @@ assert context
 assert not context.root_directory
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py check_data_context_is_ephemeral">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py check_data_context_is_ephemeral">
 from great_expectations.data_context import EphemeralDataContext
 
 # ...
@@ -54,7 +54,7 @@ if isinstance(context, EphemeralDataContext):
 # </snippet>
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context">
+# <snippet name="docs/docusaurus/docs/snippets/how_to_explicitly_instantiate_an_ephemeral_data_context.py convert_ephemeral_data_context_filesystem_data_context">
 context = context.convert_to_file_context()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_python_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_python_example.py
@@ -7,7 +7,7 @@ from great_expectations.core.yaml_handler import YAMLHandler
 yaml = YAMLHandler()
 context = gx.get_context()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py datasource_config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py datasource_config">
 datasource_config = {
     "name": "my_s3_datasource",
     "class_name": "Datasource",
@@ -39,19 +39,19 @@ datasource_config["data_connectors"]["default_inferred_data_connector_name"][
     "prefix"
 ] = "data/taxi_yellow_tripdata_samples/"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py test_yaml_config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py test_yaml_config">
 context.test_yaml_config(yaml.dump(datasource_config))
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py add_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_python_example.py add_datasource">
 context.add_datasource(**datasource_config)
 # </snippet>
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="<YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
     runtime_parameters={"path": "<PATH_TO_YOUR_DATA_HERE>"},  # Add your S3 path here.
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
@@ -62,11 +62,9 @@ batch_request.runtime_parameters[
     "path"
 ] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 
@@ -81,9 +79,9 @@ assert batch.data.dataframe.shape[0] == 10000
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_DATA_ASSET_NAME>",
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="<YOUR_DATA_ASSET_NAME>",
 )
 
 # Please note this override is only to provide good UX for docs and tests.
@@ -92,11 +90,9 @@ batch_request.data_asset_name = (
     "data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01"
 )
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_yaml_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_yaml_example.py
@@ -8,7 +8,7 @@ yaml = YAMLHandler()
 
 context = gx.get_context()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py datasource_yaml">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py datasource_yaml">
 datasource_yaml = r"""
 name: my_s3_datasource
 class_name: Datasource
@@ -39,20 +39,20 @@ datasource_yaml = datasource_yaml.replace(
     "<BUCKET_PATH_TO_DATA>", "data/taxi_yellow_tripdata_samples/"
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py test_yaml_config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py test_yaml_config">
 context.test_yaml_config(datasource_yaml)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py add_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py add_datasource">
 context.add_datasource(**yaml.load(datasource_yaml))
 # </snippet>
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py path batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py path batch_request">
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="<YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
     runtime_parameters={"path": "<PATH_TO_YOUR_DATA_HERE>"},  # Add your S3 path here.
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
@@ -64,12 +64,10 @@ batch_request.runtime_parameters[
     "path"
 ] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator 1">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator 1">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>
@@ -84,11 +82,11 @@ batch: Batch = batch_list[0]
 assert batch.data.dataframe.shape[0] == 10000
 
 # Here is a BatchRequest naming a data_asset
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py batch_request">
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_DATA_ASSET_NAME>",
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="<YOUR_DATA_ASSET_NAME>",
 )
 # </snippet>
 
@@ -98,12 +96,10 @@ batch_request.data_asset_name = (
     "data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01"
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example.py get_validator">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_yaml_example_spark_s3.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/inferred_and_runtime_yaml_example_spark_s3.py
@@ -1,6 +1,6 @@
 from typing import List
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py imports for spark data context">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py imports for spark data context">
 import great_expectations as gx
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -25,7 +25,7 @@ data_context_config = DataContextConfig(
 context = get_context(project_config=data_context_config)
 
 datasource_yaml = r"""
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py datasource config">
 name: my_s3_datasource
 class_name: Datasource
 execution_engine:
@@ -55,20 +55,20 @@ datasource_yaml = datasource_yaml.replace(
     "<BUCKET_PATH_TO_DATA>", "data/taxi_yellow_tripdata_samples/"
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py test datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py test datasource config">
 context.test_yaml_config(datasource_yaml)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py add datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py add datasource config">
 context.add_datasource(**yaml.load(datasource_yaml))
 # </snippet>
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 1">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 1">
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="<YOUR_MEANGINGFUL_NAME>",  # this can be anything that identifies this data_asset for you
     runtime_parameters={"path": "<PATH_TO_YOUR_DATA_HERE>"},  # Add your S3 path here.
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
@@ -80,12 +80,10 @@ batch_request.runtime_parameters[
     "path"
 ] = "s3a://superconductive-docs-test/data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 1">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 1">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>
@@ -94,11 +92,11 @@ print(validator.head())
 assert isinstance(validator, gx.validator.validator.Validator)
 
 # Here is a BatchRequest naming a data_asset
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 2">
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py batch request 2">
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_s3_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_DATA_ASSET_NAME>",
+    datasource_name="my_s3_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="<YOUR_DATA_ASSET_NAME>",
     batch_spec_passthrough={"reader_method": "csv", "reader_options": {"header": True}},
 )
 # </snippet>
@@ -109,12 +107,10 @@ batch_request.data_asset_name = (
     "data/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01"
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 2">
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+# <snippet name="docs/docusaurus/docs/snippets/inferred_and_runtime_yaml_example_spark_s3.py get validator 2">
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/legacy_docs/ge_checkpoint_bigquery.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/legacy_docs/ge_checkpoint_bigquery.py
@@ -1,6 +1,6 @@
 # a v17 doc requires this legacy snippet path:
 
-# <snippet name="version-0.18 tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py full">
+# <snippet name="tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py full">
 from datetime import timedelta
 
 import airflow

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/legacy_docs/ge_checkpoint_gcs.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/legacy_docs/ge_checkpoint_gcs.py
@@ -3,7 +3,7 @@
 # The reference fails, and was being silently resolved here, which broke when we
 # moved snippets out of tests. This can be deleted once we remove support for 0.15/0/16 docs.
 
-# <snippet name="version-0.18 tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py full">
+# <snippet name="tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py full">
 from datetime import timedelta
 
 import airflow

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/organize_batches_in_sqlite_datasource.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/organize_batches_in_sqlite_datasource.py
@@ -22,25 +22,25 @@ context = gx.get_context()
 
 sql_connection_string = f"sqlite:///{yellow_tripdata_db_file}"
 my_datasource = context.sources.add_sqlite(
-    name="version-0.18 my_datasource", connection_string=sql_connection_string
+    name="my_datasource", connection_string=sql_connection_string
 )
 
 my_datasource.add_table_asset(
     name="my_table_asset",
-    table_name="version-0.18 yellow_tripdata_sample_2020",
+    table_name="yellow_tripdata_sample_2020",
     schema_name=None,
 )
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_datasource">
 my_datasource = context.get_datasource("my_datasource")
-my_table_asset = my_datasource.get_asset(asset_name="version-0.18 my_table_asset")
+my_table_asset = my_datasource.get_asset(asset_name="my_table_asset")
 # </snippet>
 
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month">
-my_table_asset.add_splitter_year_and_month(column_name="version-0.18 pickup_datetime")
+# <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_splitter_year_and_month">
+my_table_asset.add_splitter_year_and_month(column_name="pickup_datetime")
 # </snippet>
 
 my_batch_request = my_table_asset.build_batch_request()
@@ -49,14 +49,14 @@ batches = my_table_asset.get_batch_list_from_batch_request(my_batch_request)
 assert len(batches) == 12
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters">
+# <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py add_sorters">
 my_asset = my_table_asset.add_sorters(["+year", "-month"])
 # </snippet>
 
 assert my_asset.batch_request_options == ("year", "month")
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list">
+# <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py my_batch_list">
 my_batch_request = my_table_asset.build_batch_request()
 batches = my_table_asset.get_batch_list_from_batch_request(my_batch_request)
 # </snippet>
@@ -68,7 +68,7 @@ assert my_batch_request.options == {}
 assert len(batches) == 12
 
 # Python
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec">
+# <snippet name="docs/docusaurus/docs/snippets/organize_batches_in_sqlite_datasource.py print_batch_spec">
 for batch in batches:
     print(batch.batch_spec)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/pandas_yaml_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/pandas_yaml_example.py
@@ -2,16 +2,16 @@ from great_expectations.core.yaml_handler import YAMLHandler
 
 yaml = YAMLHandler()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py import gx">
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py import gx">
 import great_expectations as gx
 
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py import BatchRequest">
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py import BatchRequest">
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
 
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py get_context">
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py get_context">
 context = gx.get_context()
 # </snippet>
 
@@ -46,9 +46,9 @@ context.add_datasource(**yaml.load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 taxi_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_MEANINGFUL_NAME>",  # This can be anything that identifies this data_asset for you
+    datasource_name="taxi_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="<YOUR_MEANINGFUL_NAME>",  # This can be anything that identifies this data_asset for you
     runtime_parameters={"path": "<PATH_TO_YOUR_DATA_HERE>"},  # Add your path here.
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
@@ -57,11 +57,9 @@ batch_request = RuntimeBatchRequest(
 # In normal usage you'd set your path directly in the BatchRequest above.
 batch_request.runtime_parameters["path"] = "./data/yellow_tripdata_sample_2019-01.csv"
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 
@@ -69,42 +67,40 @@ print(validator.head())
 assert isinstance(validator, gx.validator.validator.Validator)
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(
-    datasource_name="version-0.18 taxi_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 <YOUR_DATA_ASSET_NAME>",
+    datasource_name="taxi_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="<YOUR_DATA_ASSET_NAME>",
 )
 
 # Please note this override is only to provide good UX for docs and tests.
 # In normal usage you'd set your data asset name directly in the BatchRequest above.
-batch_request.data_asset_name = "version-0.18 yellow_tripdata_sample_2019-01.csv"
+batch_request.data_asset_name = "yellow_tripdata_sample_2019-01.csv"
 
 # Example using batch request to get a batch:
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with batch request">
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with batch request">
 batch = context.get_batch_list(batch_request=batch_request)[0]
 # </snippet>
 
 # Example using parameters to get a batch:
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters data_asset_name">
-data_asset_name = "version-0.18 <YOUR_DATA_ASSET_NAME>"
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters data_asset_name">
+data_asset_name = "<YOUR_DATA_ASSET_NAME>"
 # </snippet>
 
 # Please note this override is only to provide good UX for docs and tests.
 # In normal usage you'd set your data asset name directly in the get_batch call below
-data_asset_name = "version-0.18 yellow_tripdata_sample_2019-01.csv"
+data_asset_name = "yellow_tripdata_sample_2019-01.csv"
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters">
+# <snippet name="docs/docusaurus/docs/snippets/pandas_yaml_example.py context.get_batch with parameters">
 context.get_batch_list(
-    datasource_name="version-0.18 taxi_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
+    datasource_name="taxi_datasource",
+    data_connector_name="default_inferred_data_connector_name",
     data_asset_name=data_asset_name,
 )
 # </snippet>
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/postgres_deployment_patterns.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/postgres_deployment_patterns.py
@@ -1,10 +1,10 @@
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py imports">
 import great_expectations as gx
 from great_expectations.checkpoint import Checkpoint
 
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py set up context">
 context = gx.get_context()
 # </snippet>
 
@@ -15,27 +15,27 @@ from tests.test_utils import load_data_into_test_database
 PG_CONNECTION_STRING = "postgresql+psycopg2://postgres:@localhost/test_ci"
 
 load_data_into_test_database(
-    table_name="version-0.18 postgres_taxi_data",
+    table_name="postgres_taxi_data",
     csv_path="./data/yellow_tripdata_sample_2019-01.csv",
     connection_string=PG_CONNECTION_STRING,
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_datasource">
 pg_datasource = context.sources.add_postgres(
-    name="version-0.18 pg_datasource", connection_string=PG_CONNECTION_STRING
+    name="pg_datasource", connection_string=PG_CONNECTION_STRING
 )
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add_asset">
 pg_datasource.add_table_asset(
-    name="postgres_taxi_data", table_name="version-0.18 postgres_taxi_data"
+    name="postgres_taxi_data", table_name="postgres_taxi_data"
 )
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py pg_batch_request">
 batch_request = pg_datasource.get_asset("postgres_taxi_data").build_batch_request()
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator">
-expectation_suite_name = "version-0.18 insert_your_expectation_suite_name_here"
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py get validator">
+expectation_suite_name = "insert_your_expectation_suite_name_here"
 context.add_or_update_expectation_suite(expectation_suite_name=expectation_suite_name)
 validator = context.get_validator(
     batch_request=batch_request,
@@ -45,7 +45,7 @@ validator = context.get_validator(
 print(validator.head())
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add expectations">
 validator.expect_column_values_to_not_be_null(column="passenger_count")
 
 validator.expect_column_values_to_be_between(
@@ -53,12 +53,12 @@ validator.expect_column_values_to_be_between(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py save suite">
 validator.save_expectation_suite(discard_failed_expectations=False)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config">
-my_checkpoint_name = "version-0.18 my_sql_checkpoint"
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py checkpoint config">
+my_checkpoint_name = "my_sql_checkpoint"
 
 checkpoint = Checkpoint(
     name=my_checkpoint_name,
@@ -76,11 +76,11 @@ checkpoint = Checkpoint(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py add checkpoint config">
 context.add_or_update_checkpoint(checkpoint=checkpoint)
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint">
+# <snippet name="docs/docusaurus/docs/snippets/postgres_deployment_patterns.py run checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/quickstart.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/quickstart.py
@@ -1,22 +1,22 @@
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py import_gx">
+# <snippet name="tutorials/quickstart/quickstart.py import_gx">
 import great_expectations as gx
 
 # </snippet>
 
 # Set up
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py get_context">
+# <snippet name="tutorials/quickstart/quickstart.py get_context">
 context = gx.get_context()
 # </snippet>
 
 # Connect to data
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py connect_to_data">
+# <snippet name="tutorials/quickstart/quickstart.py connect_to_data">
 validator = context.sources.pandas_default.read_csv(
     "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
 )
 # </snippet>
 
 # Create Expectations
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py create_expectation">
+# <snippet name="tutorials/quickstart/quickstart.py create_expectation">
 validator.expect_column_values_to_not_be_null("pickup_datetime")
 validator.expect_column_values_to_be_between(
     "passenger_count", min_value=1, max_value=6
@@ -25,18 +25,18 @@ validator.save_expectation_suite()
 # </snippet>
 
 # Validate data
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py create_checkpoint">
+# <snippet name="tutorials/quickstart/quickstart.py create_checkpoint">
 checkpoint = context.add_or_update_checkpoint(
-    name="version-0.18 my_quickstart_checkpoint",
+    name="my_quickstart_checkpoint",
     validator=validator,
 )
 # </snippet>
 
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py run_checkpoint">
+# <snippet name="tutorials/quickstart/quickstart.py run_checkpoint">
 checkpoint_result = checkpoint.run()
 # </snippet>
 
 # View results
-# <snippet name="version-0.18 tutorials/quickstart/quickstart.py view_results">
+# <snippet name="tutorials/quickstart/quickstart.py view_results">
 context.view_validation_result(checkpoint_result)
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/redshift_python_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/redshift_python_example.py
@@ -19,14 +19,14 @@ CONNECTION_STRING = f"postgresql+psycopg2://{redshift_username}:{redshift_passwo
 from util import load_data_into_test_database
 
 load_data_into_test_database(
-    table_name="version-0.18 taxi_data",
+    table_name="taxi_data",
     csv_path="./data/yellow_tripdata_sample_2019-01.csv",
     connection_string=CONNECTION_STRING,
 )
 
 context = gx.get_context()
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_python_example.py datasource config">
 datasource_config = {
     "name": "my_redshift_datasource",
     "class_name": "Datasource",
@@ -51,7 +51,7 @@ datasource_config = {
 # In normal usage you'd set your path directly in the yaml above.
 datasource_config["execution_engine"]["connection_string"] = CONNECTION_STRING
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py test datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_python_example.py test datasource config">
 context.test_yaml_config(yaml.dump(datasource_config))
 # </snippet>
 
@@ -59,18 +59,16 @@ context.add_datasource(**datasource_config)
 
 # First test for RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_redshift_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 default_name",  # this can be anything that identifies this data
+    datasource_name="my_redshift_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="default_name",  # this can be anything that identifies this data
     runtime_parameters={"query": "SELECT * from taxi_data LIMIT 10"},
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 
@@ -78,17 +76,15 @@ print(validator.head())
 assert isinstance(validator, gx.validator.validator.Validator)
 
 # Second test for BatchRequest naming a table
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_python_example.py load data with table name">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_python_example.py load data with table name">
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_redshift_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 taxi_data",  # this is the name of the table you want to retrieve
+    datasource_name="my_redshift_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="taxi_data",  # this is the name of the table you want to retrieve
 )
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/redshift_yaml_example.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/redshift_yaml_example.py
@@ -19,7 +19,7 @@ CONNECTION_STRING = f"postgresql+psycopg2://{redshift_username}:{redshift_passwo
 from tests.test_utils import load_data_into_test_database
 
 load_data_into_test_database(
-    table_name="version-0.18 taxi_data",
+    table_name="taxi_data",
     csv_path="./data/yellow_tripdata_sample_2019-01.csv",
     connection_string=CONNECTION_STRING,
 )
@@ -27,7 +27,7 @@ load_data_into_test_database(
 context = gx.get_context()
 
 datasource_yaml = """
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_yaml_example.py datasource config">
 name: my_redshift_datasource
 class_name: Datasource
 execution_engine:
@@ -51,27 +51,25 @@ datasource_yaml = datasource_yaml.replace(
     CONNECTION_STRING,
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py test datasource config">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_yaml_example.py test datasource config">
 context.test_yaml_config(datasource_yaml)
 # </snippet>
 
 context.add_datasource(**yaml.load(datasource_yaml))
 
 # First test for RuntimeBatchRequest using a query
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/redshift_yaml_example.py load data with query">
+# <snippet name="docs/docusaurus/docs/snippets/redshift_yaml_example.py load data with query">
 batch_request = RuntimeBatchRequest(
-    datasource_name="version-0.18 my_redshift_datasource",
-    data_connector_name="version-0.18 default_runtime_data_connector_name",
-    data_asset_name="version-0.18 default_name",  # this can be anything that identifies this data
+    datasource_name="my_redshift_datasource",
+    data_connector_name="default_runtime_data_connector_name",
+    data_asset_name="default_name",  # this can be anything that identifies this data
     runtime_parameters={"query": "SELECT * from taxi_data LIMIT 10"},
     batch_identifiers={"default_identifier_name": "default_identifier"},
 )
 
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 # </snippet>
@@ -81,15 +79,13 @@ assert isinstance(validator, gx.validator.validator.Validator)
 
 # Second test for BatchRequest naming a table
 batch_request = BatchRequest(
-    datasource_name="version-0.18 my_redshift_datasource",
-    data_connector_name="version-0.18 default_inferred_data_connector_name",
-    data_asset_name="version-0.18 taxi_data",  # this is the name of the table you want to retrieve
+    datasource_name="my_redshift_datasource",
+    data_connector_name="default_inferred_data_connector_name",
+    data_asset_name="taxi_data",  # this is the name of the table you want to retrieve
 )
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
 validator = context.get_validator(
-    batch_request=batch_request, expectation_suite_name="version-0.18 test_suite"
+    batch_request=batch_request, expectation_suite_name="test_suite"
 )
 print(validator.head())
 

--- a/docs/docusaurus/versioned_docs/version-0.18/snippets/result_format.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/snippets/result_format.py
@@ -13,7 +13,7 @@ from great_expectations.expectations.expectation_configuration import (
 )
 
 # Snippet: example data frame for result_format
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format pandas_df_for_result_format">
+# <snippet name="docs/docusaurus/docs/snippets/result_format pandas_df_for_result_format">
 dataframe = pd.DataFrame(
     {
         "pk_column": ["zero", "one", "two", "three", "four", "five", "six", "seven"],
@@ -26,18 +26,18 @@ dataframe = pd.DataFrame(
 
 # NOTE: The following code is only for testing and can be ignored by users.
 context = gx.get_context()
-datasource = context.sources.add_pandas(name="version-0.18 my_pandas_datasource")
-data_asset = datasource.add_dataframe_asset(name="version-0.18 my_df")
+datasource = context.sources.add_pandas(name="my_pandas_datasource")
+data_asset = datasource.add_dataframe_asset(name="my_df")
 my_batch_request = data_asset.build_batch_request(dataframe=dataframe)
 context.add_or_update_expectation_suite("my_expectation_suite")
 my_validator = context.get_validator(
     batch_request=my_batch_request,
-    expectation_suite_name="version-0.18 my_expectation_suite",
+    expectation_suite_name="my_expectation_suite",
 )
 
 # Expectation-level Configuration
 # Snippet: result_format BOOLEAN example
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_boolean_example">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_boolean_example">
 validation_result = my_validator.expect_column_values_to_be_in_set(
     column="my_var",
     value_set=["A", "B"],
@@ -45,19 +45,19 @@ validation_result = my_validator.expect_column_values_to_be_in_set(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_boolean_example_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_boolean_example_output">
 assert validation_result.success is False
 assert validation_result.result == {}
 # </snippet>
 
 
 # Snippet: result_format BASIC example with set
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_set">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_set">
 validation_result = my_validator.expect_column_values_to_be_in_set(
     column="my_var", value_set=["A", "B"], result_format={"result_format": "BASIC"}
 )
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_set_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_set_output">
 assert validation_result.success is False
 assert validation_result.result == {
     "element_count": 8,
@@ -72,19 +72,19 @@ assert validation_result.result == {
 # </snippet>
 
 # Snippet: result_format BASIC example with aggregate
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg">
 validation_result = my_validator.expect_column_mean_to_be_between(
     column="my_numbers", min_value=0.0, max_value=10.0, result_format="BASIC"
 )
 # </snippet>
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_basic_example_agg_output">
 assert validation_result.success is True
 assert validation_result.result == {"observed_value": 2.75}
 # </snippet>
 
 
 # Snippet: result_format SUMMARY example with set
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_set">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_set">
 validation_result = my_validator.expect_column_values_to_be_in_set(
     column="my_var",
     value_set=["A", "B"],
@@ -96,7 +96,7 @@ validation_result = my_validator.expect_column_values_to_be_in_set(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_set_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_set_output">
 assert validation_result.success is False
 assert validation_result.result == {
     "element_count": 8,
@@ -123,19 +123,19 @@ assert validation_result.result == {
 # </snippet>
 
 # Snippet: result_format SUMMARY example with agg
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg">
 validation_result = my_validator.expect_column_mean_to_be_between(
     column="my_numbers", min_value=0.0, max_value=10.0, result_format="SUMMARY"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_summary_example_agg_output">
 assert validation_result.success is True
 assert validation_result.result == {"observed_value": 2.75}
 # </snippet>
 
 # Snippet: result_format COMPLETE example with set
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_set">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_set">
 validation_result = my_validator.expect_column_values_to_be_in_set(
     column="my_var",
     value_set=["A", "B"],
@@ -147,7 +147,7 @@ validation_result = my_validator.expect_column_values_to_be_in_set(
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_set_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_set_output">
 assert validation_result.success is False
 assert validation_result.result == {
     "element_count": 8,
@@ -184,13 +184,13 @@ assert validation_result.result == {
 # </snippet>
 
 # Snippet: result_format COMPLETE example with agg
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg">
 validation_result = my_validator.expect_column_mean_to_be_between(
     column="my_numbers", min_value=0.0, max_value=10.0, result_format="COMPLETE"
 )
 # </snippet>
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg_output">
+# <snippet name="docs/docusaurus/docs/snippets/result_format result_format_complete_example_agg_output">
 assert validation_result.success is True
 assert validation_result.result == {"observed_value": 2.75}
 # </snippet>
@@ -198,12 +198,8 @@ assert validation_result.result == {"observed_value": 2.75}
 
 # Checkpoint
 # NOTE: The following code is only for testing and can be ignored by users.
-context.add_or_update_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
-test_suite = context.get_expectation_suite(
-    expectation_suite_name="version-0.18 test_suite"
-)
+context.add_or_update_expectation_suite(expectation_suite_name="test_suite")
+test_suite = context.get_expectation_suite(expectation_suite_name="test_suite")
 
 expectation_config = ExpectationConfiguration(
     expectation_type="expect_column_values_to_be_in_set",
@@ -214,18 +210,18 @@ expectation_config = ExpectationConfiguration(
 )
 test_suite.add_expectation_configuration(expectation_configuration=expectation_config)
 
-test_suite.expectation_suite_name = "version-0.18 test_suite"
+test_suite.expectation_suite_name = "test_suite"
 context.add_or_update_expectation_suite(
     expectation_suite=test_suite,
 )
 
-# <snippet name="version-0.18 docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example">
+# <snippet name="docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example">
 checkpoint: Checkpoint = Checkpoint(
-    name="version-0.18 my_checkpoint",
+    name="my_checkpoint",
     run_name_template="%Y%m%d-%H%M%S-my-run-name-template",
     data_context=context,
     batch_request=my_batch_request,
-    expectation_suite_name="version-0.18 test_suite",
+    expectation_suite_name="test_suite",
     action_list=[
         {
             "name": "store_validation_result",


### PR DESCRIPTION
Version prefixes are no longer needed in snippets, so this removes them. This also reverts some changes *within* snippets where names were given prefixes due to some over-eager regex.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
