### PR TITLE
[DOCS] Update alert colors to be on brand

### DIFF
--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -104,7 +104,7 @@ h3 {
 }
 
 
-.alert {
+.theme-doc-version-banner {
     --ifm-color-warning-dark: #223f99;
     --ifm-alert-background-color: #f4f4f7;
 }

--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -103,6 +103,12 @@ h3 {
     color: #404041;
 }
 
+
+.alert {
+    --ifm-color-warning-dark: #223f99;
+    --ifm-alert-background-color: #f4f4f7;
+}
+
 /* pagination overrides */
 .pagination-nav__item {
     flex: inherit;


### PR DESCRIPTION
The purpose here is to make the version banner (for both past and prerelease) on brand. I didn't see other warnings in the docs, but if they exist, they will be recolored as well.

![Screenshot 2024-02-14 at 11 45 22 AM](https://github.com/great-expectations/great_expectations/assets/5400974/4da989c6-32de-4bb8-836d-2a522453657f)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
