### PR TITLE
[MAINTENANCE] Update CI trigger to recognize pre-release candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ on:
   workflow_dispatch:  # allows manual triggering with branch picker
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      # Semantic versioning syntax defined by PyPI: https://pythonpackaging.info/07-Package-Release.html#Versioning-your-code
+      - '[0-9]+.[0-9]+.[0-9]+((a|b|rc)[0-9]+)?'
 
 concurrency:
   # Only run one instance of this workflow in PRs, but allow multiple instances in develop.


### PR DESCRIPTION
Allow for {a|b|rc}N syntax per PyPI docs

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
