### PR TITLE
[DOCS] Add Result Format Content to the GX Cloud Docs

### DIFF
--- a/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
@@ -112,6 +112,17 @@ To learn more about Checkpoints, see [Checkpoint](/reference/learn/terms/checkpo
     checkpoint = context.add_or_update_checkpoint(**checkpoint_config) 
     ```
 
+## Configure the Checkpoint result format parameter 
+
+You can use the `result_format` parameter to define the level of detail you want returned with your Validation Results. For example, you can return a success or failure message, a summary of observed values, a list of failing values, or you can add a query or a filter function that returns all failing rows. For more information, see [Result format](../../reference/learn/expectations/result_format.md).
+
+Run the following code to apply `result_format` to every Expectation in a Suite:
+
+```python name="docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example"
+```
+
+Replace `my_checkpoint` and `test_suite` with your own values. You define your Checkpoint configuration below the `runtime_configuration` key. The results are stored in the Validation Result after you run the Checkpoint.
+
 ## Delete a Checkpoint
 
 1. In GX Cloud, click **Checkpoints**.

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -199,6 +199,11 @@ module.exports = {
               href: '/docs/cloud/checkpoints/manage_checkpoints#edit-a-checkpoint-configuration',
             },
             {
+              "type": "link",
+              "label": "Configure the Checkpoint result format parameter",
+              "href": "/docs/cloud/checkpoints/manage_checkpoints#configure_the_checkpoint_result_format_parameter"
+            },
+            {
               type: 'link',
               label: 'Delete a Checkpoint',
               href: '/docs/cloud/checkpoints/manage_checkpoints#delete-a-checkpoint',

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -201,7 +201,7 @@ module.exports = {
             {
               "type": "link",
               "label": "Configure the Checkpoint result format parameter",
-              "href": "/docs/cloud/checkpoints/manage_checkpoints#configure_the_checkpoint_result_format_parameter"
+          "href": "/docs/cloud/checkpoints/manage_checkpoints#configure-the-checkpoint-result-format-parameter"
             },
             {
               type: 'link',

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/checkpoints/manage_checkpoints.md
@@ -112,6 +112,17 @@ To learn more about Checkpoints, see [Checkpoint](/reference/learn/terms/checkpo
     checkpoint = context.add_or_update_checkpoint(**checkpoint_config) 
     ```
 
+## Configure the Checkpoint result format parameter 
+
+You can use the `result_format` parameter to define the level of detail you want returned with your Validation Results. For example, you can return a success or failure message, a summary of observed values, a list of failing values, or you can add a query or a filter function that returns all failing rows. For more information, see [Result format](../../reference/learn/expectations/result_format.md).
+
+Run the following code to apply `result_format` to every Expectation in a Suite:
+
+```python name="docs/docusaurus/docs/snippets/result_format.py result_format_checkpoint_example"
+```
+
+Replace `my_checkpoint` and `test_suite` with your own values. You define your Checkpoint configuration below the `runtime_configuration` key. The results are stored in the Validation Result after you run the Checkpoint.
+
 ## Delete a Checkpoint
 
 1. In GX Cloud, click **Checkpoints**.

--- a/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
@@ -228,7 +228,7 @@
         {
           "type": "link",
           "label": "Configure the Checkpoint result format parameter",
-          "href": "/docs/cloud/checkpoints/manage_checkpoints#configure_the_checkpoint_result_format_parameter"
+          "href": "/docs/cloud/checkpoints/manage_checkpoints#configure-the-checkpoint-result-format-parameter"
         },
         {
           "type": "link",

--- a/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-0.18-sidebars.json
@@ -227,6 +227,11 @@
         },
         {
           "type": "link",
+          "label": "Configure the Checkpoint result format parameter",
+          "href": "/docs/cloud/checkpoints/manage_checkpoints#configure_the_checkpoint_result_format_parameter"
+        },
+        {
+          "type": "link",
           "label": "Delete a Checkpoint",
           "href": "/docs/cloud/checkpoints/manage_checkpoints#delete-a-checkpoint"
         }


### PR DESCRIPTION
[DOC-670](https://greatexpectations.atlassian.net/browse/DOC-670) requests the addition of content describing how to configure the `results_format` parameter to the GX Cloud documentation. This PR implements this request.

This is a temporary solution and the content will be removed or revised when Checkpoint functionality is added to the GX Cloud UI. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated


[DOC-670]: https://greatexpectations.atlassian.net/browse/DOC-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ