### PR TITLE
[BUGFIX] Fix incorrect python version in Snowflake reqs

### DIFF
--- a/reqs/requirements-dev-snowflake.txt
+++ b/reqs/requirements-dev-snowflake.txt
@@ -1,4 +1,4 @@
-pandas<2.2.0; python_version < "3.9"
+pandas<2.2.0; python_version >= "3.9"
 snowflake-connector-python>=2.5.0; python_version < "3.11"
 snowflake-connector-python>2.9.0; python_version >= "3.11" # earlier versions fail to build on 3.11
 snowflake-sqlalchemy>=1.2.3


### PR DESCRIPTION
Fix incorrect python version in Snowflake reqs

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated