### PR TITLE
[MAINTENANCE] Ignore pandas `DeprecationWarning` for legacy `CustomPandasDataset`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,6 +450,9 @@ filterwarnings = [
     # Example Actual Warning: DeprecationWarning: Passing a BlockManager to PandasDataset is deprecated and will raise in a future version. Use public APIs instead.
     # This is a legacy pattern that will be removed from GX
     'ignore: Passing a BlockManager to PandasDataset is deprecated and will raise in a future version. Use public APIs instead.:DeprecationWarning',
+    # Example Actual Warning: DeprecationWarning: Passing a BlockManager to CustomPandasDataset is deprecated and will raise in a future version. Use public APIs instead.
+    # This is a legacy pattern that will be removed from GX
+    'ignore: Passing a BlockManager to CustomPandasDataset is deprecated and will raise in a future version. Use public APIs instead.:DeprecationWarning',
 
     # numpy
     # Example Actual Warning: RuntimeWarning: Mean of empty slice.


### PR DESCRIPTION
Ignore pandas `DeprecationWarning` for legacy `CustomPandasDataset`

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated
