### PR TITLE
[MAINTENANCE] Fix pandas usage due to `DeprecationWarning`

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_decreasing.py
@@ -54,7 +54,7 @@ class ColumnValuesDecreasing(ColumnMapMetricProvider):
         # The first element is null, so it gets a bye and is always treated as True
         if parse_strings_as_datetimes:
             series_diff[series_diff.isnull()] = datetime.timedelta(seconds=-1)
-            series_diff = pd.to_timedelta(series_diff, unit="S")
+            series_diff = pd.to_timedelta(series_diff, unit="s")
         else:
             series_diff[series_diff.isnull()] = -1
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_increasing.py
@@ -54,7 +54,7 @@ class ColumnValuesIncreasing(ColumnMapMetricProvider):
         # The first element is null, so it gets a bye and is always treated as True
         if parse_strings_as_datetimes:
             series_diff[series_diff.isnull()] = datetime.timedelta(seconds=1)
-            series_diff = pd.to_timedelta(series_diff, unit="S")
+            series_diff = pd.to_timedelta(series_diff, unit="s")
         else:
             series_diff[series_diff.isnull()] = 1
 


### PR DESCRIPTION
Fix pandas usage due to `DeprecationWarning`. Pandas now requires the unit to be `s` not `S`.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated