### PR TITLE
[MAINTENANCE] Release without `docs-snippets` tests for `0.18.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,6 @@ jobs:
       ci-is-on-main-repo,
       doc-checks,
       static-analysis,
-      docs-snippets,
       unit-tests,
       cloud-tests,
       marker-tests,


### PR DESCRIPTION
Release without `docs-snippets` tests for `0.18.x`

The tests passed, but release didn't happen.

Before:
![image](https://github.com/great-expectations/great_expectations/assets/19361723/d89afbe9-e296-4e9a-8187-a2defdf69d09)

After:
![image](https://github.com/great-expectations/great_expectations/assets/19361723/ec94c9ce-87a1-47d8-8471-1c32833c0b45)


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated
