### PR TITLE
[DOCS] Update styles for autogenerated index pages

### DIFF
--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -468,7 +468,7 @@ module.exports = {
       { type: 'doc', id: 'oss/changelog' },
       ],
   gx_apis: [
-      {
+    {
       type: 'category',
       label: 'GX API',
       link: {

--- a/docs/docusaurus/src/css/overview_pages.scss
+++ b/docs/docusaurus/src/css/overview_pages.scss
@@ -38,14 +38,24 @@
   max-width: 40rem;
 }
 
-.generated-index-page header {
-  @include overview-card-container;
-
-  h1 {
-    @include overview-card-title;
+.generated-index-page {
+  .theme-doc-breadcrumbs {
+    display: none;
   }
 
-  p {
-    @include overview-card-description;
+  & > div {
+    max-width: unset !important;
+  }
+
+  header {
+    @include overview-card-container;
+
+    h1 {
+      @include overview-card-title;
+    }
+
+    p {
+      @include overview-card-description;
+    }
   }
 }

--- a/docs/docusaurus/src/css/pagination.scss
+++ b/docs/docusaurus/src/css/pagination.scss
@@ -25,6 +25,10 @@
   max-width: 14rem;
   text-align: center;
   width: 100%;
+
+  &--next {
+    margin-left: auto;
+  }
 }
 
 a.pagination-nav__link:hover {


### PR DESCRIPTION
# Description
- Hide breadcrumb from API page
- Force autogenerated index pages to have full width
- Fix alignment of next button when there's no previous button

# Screenshot
![screencapture-localhost-3000-docs-reference-api-2024-02-16-01_16_12](https://github.com/great-expectations/great_expectations/assets/7197057/a40e0a9e-90e3-4498-b84d-62a225fe1d3a)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
