### PR TITLE
[MAINTENANCE] Run docs tests on merge queue.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
     # run on non-draft PRs with docs changes
     if: |
       (github.event.pull_request.draft == false && github.base_ref == 'develop') ||
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/1.'))
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/1.')) ||
+      github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -226,7 +227,8 @@ jobs:
     # run on non-draft PRs
     if: |
       (github.event.pull_request.draft == false && github.base_ref == 'develop') ||
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/1.'))
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/1.')) ||
+      github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This turns on doc snippet tests and doc building in the merge queue. Note, we only use python 3.8 for this at this time. Doc building is fine, but we should likely run the snippet tests on 3.11 also. That change will happen in a different PR.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
