### PR TITLE
[DOCS] Fix links style

### DIFF
--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -99,8 +99,14 @@
       --link-hover-color: #A03E0A;
 }
 
+.markdown a,
 p > a {
+    color: var(--ifm-color-primary);
     text-decoration: underline;
+
+  &:hover {
+    color: var(--link-hover-color);
+  }
 }
 
 h3 {


### PR DESCRIPTION
## Screenshots
![image](https://github.com/great-expectations/great_expectations/assets/7197057/282cc5c1-4a26-4300-ba39-7d33599a8fd8)

### On hover
![image](https://github.com/great-expectations/great_expectations/assets/7197057/84eda339-f0db-473d-bc65-cb79d829b0a2)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
