### PR TITLE
[BUGFIX] Fix test setup to get ephemeral context

### DIFF
--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -618,7 +618,7 @@ class TestEvaluationParameterOptions:
 
     @pytest.fixture
     def expectation_suite(self) -> ExpectationSuite:
-        get_context()
+        get_context(mode="ephemeral")
         return ExpectationSuite("test-suite")
 
     @pytest.fixture


### PR DESCRIPTION
Fixes the failure seen here: https://github.com/great-expectations/great_expectations/actions/runs/7988746346/job/21814183950#step:5:233. I suspect there are other underlying issues with sharing context between tests, but following the error from CI makes it look like in this case, just forcing an ephemeral context does the trick.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
