### PR TITLE
[DOCS] Pin sphinx extensions

### DIFF
--- a/docs/sphinx_api_docs_source/requirements-dev-api-docs.txt
+++ b/docs/sphinx_api_docs_source/requirements-dev-api-docs.txt
@@ -2,3 +2,9 @@ docstring-parser==0.15
 myst-parser
 pydata-sphinx-theme==0.11.0  # Pinned to keep the css styling consistent.
 sphinx~=4.5.0
+# Need to pin some sphinx extensions to avoid breaking changes. (https://stackoverflow.com/questions/77848565/sphinxcontrib-applehelp-breaking-sphinx-builds-with-sphinx-version-less-than-5-0)
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
We've been seeing some folks run into an issue where some transitive deps require sphinx 5.0, but we pin to 4.5. This should fix that issue.

I think a fresh run of `pip install -r /Users/hoffmant/Repositories/great_expectations/docs/sphinx_api_docs_source/requirements-dev-api-docs.txt` should get things up to date.

See the accepted (with one upvote!) answer here: https://stackoverflow.com/questions/77848565/sphinxcontrib-applehelp-breaking-sphinx-builds-with-sphinx-version-less-than-5-0

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
