### PR TITLE
[DOCS] Remove Beta from GX Cloud Account References

### DIFF
--- a/docs/docusaurus/docs/cloud/connect/connect_airflow.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_airflow.md
@@ -11,7 +11,7 @@ Apache Airflow is an orchestration tool that allows you to schedule and monitor 
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - You have installed Apache Airflow and initialized the database (__airflow db init__).
 

--- a/docs/docusaurus/docs/cloud/connect/connect_postgresql.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_postgresql.md
@@ -13,7 +13,7 @@ New to GX Cloud and not sure that it's the right solution for your organization?
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
 
 - You have a PostgreSQL database, schema, and table.
 

--- a/docs/docusaurus/docs/cloud/connect/connect_python.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_python.md
@@ -14,7 +14,7 @@ In this quickstart, you'll learn how to use GX Cloud from a Python script or int
 ## Prerequisites
 
 - You have internet access and download permissions.
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 ## Prepare your environment
 

--- a/docs/docusaurus/docs/cloud/connect/connect_snowflake.md
+++ b/docs/docusaurus/docs/cloud/connect/connect_snowflake.md
@@ -13,7 +13,7 @@ New to GX Cloud and not sure that it's the right solution for your organization?
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
 
 - You have a Snowflake database, schema, and table.
 

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -31,7 +31,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 ### Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - The GX Agent is running. See [Try GX Cloud](../try_gx_cloud.md) or [Connect GX Cloud](../connect/connect_lp.md).
 
@@ -98,7 +98,7 @@ Define the data you want GX Cloud to access within PostgreSQL.
 
 ### Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - The GX Agent is running. See [Try GX Cloud](../try_gx_cloud.md) or [Connect GX Cloud](../connect/connect_lp.md).
 

--- a/docs/docusaurus/docs/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/try_gx_cloud.md
@@ -16,7 +16,7 @@ If you've tested GX Cloud features and functionality and discovered it's a great
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - You have a [Docker instance](https://docs.docker.com/get-docker/).
 

--- a/docs/docusaurus/docs/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/try_gx_cloud.md
@@ -24,7 +24,7 @@ If you've tested GX Cloud features and functionality and discovered it's a great
 
 ## Self-hosted deployment
 
-To try GX Cloud, you use a [self-hosted deployment](./about_gx#self-hosted-deployment-pattern) to run the GX Agent with Docker, connect the GX Agent to your target Data Sources, and use the GX Cloud web UI to define your Data Assets, create Expectations, and run Validations. A self-hosted deployment is recommended when you want to test GX cloud features and functionality and it differs from the recommended [org-hosted deployment](./about_gx.md#org-hosted-deployment-pattern), in which the GX Agent runs in your organization's deployment environment.
+To try GX Cloud, you use a [self-hosted deployment](./about_gx#self-hosted-deployment-pattern) to run the GX Agent with Docker, connect the GX Agent to your target Data Sources, and use the GX Cloud web UI to define your Data Assets, create Expectations, and run Validations. A self-hosted deployment is recommended when you want to test GX Cloud features and functionality and it differs from the recommended [org-hosted deployment](./about_gx.md#org-hosted-deployment-pattern), in which the GX Agent runs in your organization's deployment environment.
 
 ## Get your user access token and copy your organization ID
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_airflow.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_airflow.md
@@ -11,7 +11,7 @@ Apache Airflow is an orchestration tool that allows you to schedule and monitor 
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - You have installed Apache Airflow and initialized the database (__airflow db init__).
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_postgresql.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_postgresql.md
@@ -13,7 +13,7 @@ New to GX Cloud and not sure that it's the right solution for your organization?
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
 
 - You have a PostgreSQL database, schema, and table.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_python.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_python.md
@@ -14,7 +14,7 @@ In this quickstart, you'll learn how to use GX Cloud from a Python script or int
 ## Prerequisites
 
 - You have internet access and download permissions.
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 ## Prepare your environment
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_snowflake.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/connect/connect_snowflake.md
@@ -13,7 +13,7 @@ New to GX Cloud and not sure that it's the right solution for your organization?
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud) with [Admin or Editor permissions](../about_gx.md#roles-and-responsibilities).
 
 - You have a Snowflake database, schema, and table.
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
@@ -31,7 +31,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 ### Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - The GX Agent is running. See [Try GX Cloud](../try_gx_cloud.md) or [Connect GX Cloud](../connect/connect_lp.md).
 
@@ -98,7 +98,7 @@ Define the data you want GX Cloud to access within PostgreSQL.
 
 ### Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - The GX Agent is running. See [Try GX Cloud](../try_gx_cloud.md) or [Connect GX Cloud](../connect/connect_lp.md).
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
@@ -16,7 +16,7 @@ If you've tested GX Cloud features and functionality and discovered it's a great
 
 ## Prerequisites
 
-- You have a [GX Cloud Beta account](https://greatexpectations.io/cloud).
+- You have a [GX Cloud account](https://greatexpectations.io/cloud).
 
 - You have a [Docker instance](https://docs.docker.com/get-docker/).
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
@@ -24,7 +24,7 @@ If you've tested GX Cloud features and functionality and discovered it's a great
 
 ## Self-hosted deployment
 
-To try GX Cloud, you use a [self-hosted deployment](./about_gx#self-hosted-deployment-pattern) to run the GX Agent with Docker, connect the GX Agent to your target Data Sources, and use the GX Cloud web UI to define your Data Assets, create Expectations, and run Validations. A self-hosted deployment is recommended when you want to test GX cloud features and functionality and it differs from the recommended [org-hosted deployment](./about_gx.md#org-hosted-deployment-pattern), in which the GX Agent runs in your organization's deployment environment.
+To try GX Cloud, you use a [self-hosted deployment](./about_gx#self-hosted-deployment-pattern) to run the GX Agent with Docker, connect the GX Agent to your target Data Sources, and use the GX Cloud web UI to define your Data Assets, create Expectations, and run Validations. A self-hosted deployment is recommended when you want to test GX Cloud features and functionality and it differs from the recommended [org-hosted deployment](./about_gx.md#org-hosted-deployment-pattern), in which the GX Agent runs in your organization's deployment environment.
 
 ## Get your user access token and copy your organization ID
 


### PR DESCRIPTION
With public preview, using _Beta_ when referencing GX Cloud accounts is no longer relevant. This change was confirmed and approved by @Erin-GX. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated
