### PR TITLE
[DOCS] Fix regex when checking for snippet names

### DIFF
--- a/docs/docusaurus/scripts/remark-named-snippets/index.js
+++ b/docs/docusaurus/scripts/remark-named-snippets/index.js
@@ -48,7 +48,7 @@ function codeImport () {
         continue
       }
 
-      const nameMeta = /^name=(?<snippetName>.+?)$/.exec(
+      const nameMeta = /\bname=(?<snippetName>["'].+["'])$/.exec(
         meta
       )
       if (!nameMeta) {

--- a/docs/docusaurus/scripts/remark-named-snippets/index.js
+++ b/docs/docusaurus/scripts/remark-named-snippets/index.js
@@ -48,7 +48,7 @@ function codeImport () {
         continue
       }
 
-      const nameMeta = /\bname=(?<snippetName>["'].+["'])$/.exec(
+      const nameMeta = /\bname=(?<snippetName>["'].+["'])/.exec(
         meta
       )
       if (!nameMeta) {


### PR DESCRIPTION
Fixes missing snippets. The issue was that our parsing expected a node's `meta` to only include a name. This feel apart when we included `title`. This PR updates the regex used for this to be more permissable.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
