### PR TITLE
[MAINTENANCE] Remove hashed column partitioner

### DIFF
--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -67,9 +67,6 @@
                     "$ref": "#/definitions/SqlPartitionerDatetimePart"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerHashedColumn"
-                },
-                {
                     "$ref": "#/definitions/PartitionerConvertedDateTime"
                 }
             ]
@@ -541,34 +538,6 @@
             "required": [
                 "column_name",
                 "datetime_parts"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerHashedColumn": {
-            "title": "PartitionerHashedColumn",
-            "description": "Partition on hash value of a column.\n\nArgs:\n    hash_digits: The number of digits to truncate the hash to.\n    method_name: Literal[\"partition_on_hashed_column\"]",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_hashed_column",
-                    "enum": [
-                        "partition_on_hashed_column"
-                    ],
-                    "type": "string"
-                },
-                "hash_digits": {
-                    "title": "Hash Digits",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "hash_digits"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -67,9 +67,6 @@
                     "$ref": "#/definitions/SqlPartitionerDatetimePart"
                 },
                 {
-                    "$ref": "#/definitions/PartitionerHashedColumn"
-                },
-                {
                     "$ref": "#/definitions/PartitionerConvertedDateTime"
                 }
             ]
@@ -546,34 +543,6 @@
             "required": [
                 "column_name",
                 "datetime_parts"
-            ],
-            "additionalProperties": false
-        },
-        "PartitionerHashedColumn": {
-            "title": "PartitionerHashedColumn",
-            "description": "Partition on hash value of a column.\n\nArgs:\n    hash_digits: The number of digits to truncate the hash to.\n    method_name: Literal[\"partition_on_hashed_column\"]",
-            "type": "object",
-            "properties": {
-                "column_name": {
-                    "title": "Column Name",
-                    "type": "string"
-                },
-                "method_name": {
-                    "title": "Method Name",
-                    "default": "partition_on_hashed_column",
-                    "enum": [
-                        "partition_on_hashed_column"
-                    ],
-                    "type": "string"
-                },
-                "hash_digits": {
-                    "title": "Hash Digits",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "column_name",
-                "hash_digits"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/datasource/fluent/sqlite_datasource.py
+++ b/great_expectations/datasource/fluent/sqlite_datasource.py
@@ -48,39 +48,6 @@ if TYPE_CHECKING:
 # See SqliteDatasource, SqliteTableAsset, and SqliteQueryAsset below.
 
 
-class PartitionerHashedColumn(_PartitionerOneColumnOneParam):
-    """Partition on hash value of a column.
-
-    Args:
-        hash_digits: The number of digits to truncate the hash to.
-        method_name: Literal["partition_on_hashed_column"]
-    """
-
-    # hash digits is the length of the hash. The md5 of the column is truncated to this length.
-    hash_digits: int
-    column_name: str
-    method_name: Literal["partition_on_hashed_column"] = "partition_on_hashed_column"
-
-    @property
-    @override
-    def param_names(self) -> List[str]:
-        return ["hash"]
-
-    @override
-    def partitioner_method_kwargs(self) -> Dict[str, Any]:
-        return {"column_name": self.column_name, "hash_digits": self.hash_digits}
-
-    @override
-    def batch_request_options_to_batch_spec_kwarg_identifiers(
-        self, options: BatchRequestOptions
-    ) -> Dict[str, Any]:
-        if "hash" not in options:
-            raise ValueError(
-                "'hash' must be specified in the batch request options to create a batch identifier"
-            )
-        return {self.column_name: options["hash"]}
-
-
 class PartitionerConvertedDateTime(_PartitionerOneColumnOneParam):
     """A partitioner than can be used for sql engines that represents datetimes as strings.
 
@@ -133,31 +100,10 @@ class SqliteDsn(pydantic.AnyUrl):
     host_required = False
 
 
-SqlitePartitioner = Union[
-    SqlPartitioner, PartitionerHashedColumn, PartitionerConvertedDateTime
-]
+SqlitePartitioner = Union[SqlPartitioner, PartitionerConvertedDateTime]
 
 
 class _SQLiteAssetMixin:
-    @public_api
-    def add_partitioner_hashed_column(
-        self: Self, column_name: str, hash_digits: int
-    ) -> Self:
-        """Associates a hashed column partitioner with this sqlite data asset.
-        Args:
-            column_name: The column name of the date column where year and month will be parsed out.
-            hash_digits: Number of digits to truncate output of hashing function (to limit length of hashed result).
-        Returns:
-            This sql asset so we can use this method fluently.
-        """
-        return self._add_partitioner(  # type: ignore[attr-defined]  # This is a mixin for a _SQLAsset
-            PartitionerHashedColumn(
-                method_name="partition_on_hashed_column",
-                column_name=column_name,
-                hash_digits=hash_digits,
-            )
-        )
-
     @public_api
     def add_partitioner_converted_datetime(
         self: Self, column_name: str, date_format_string: str

--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -329,18 +329,6 @@ def test_filesystem_data_asset_batching_regex(
         pytest.param(
             "yellow_tripdata.db",
             "yellow_tripdata_sample_2019_02",
-            "add_partitioner_hashed_column",
-            {"column_name": "passenger_count", "hash_digits": 3},
-            ["hash"],
-            7,
-            {"hash": "af3"},
-            1,
-            {"hash": "af3"},
-            id="hash",
-        ),
-        pytest.param(
-            "yellow_tripdata.db",
-            "yellow_tripdata_sample_2019_02",
             "add_partitioner_converted_datetime",
             {"column_name": "pickup_datetime", "date_format_string": "%Y-%m-%d"},
             ["datetime"],

--- a/tests/datasource/fluent/test_sqlite_datasource.py
+++ b/tests/datasource/fluent/test_sqlite_datasource.py
@@ -133,17 +133,6 @@ def create_sqlite_source() -> (
     ],
     [
         pytest.param(
-            "add_partitioner_hashed_column",
-            {"column_name": "passenger_count", "hash_digits": 3},
-            [("abc",), ("bcd",), ("xyz",)],
-            ["hash"],
-            3,
-            {"hash": "abc"},
-            1,
-            {"hash": "abc"},
-            id="hash",
-        ),
-        pytest.param(
             "add_partitioner_converted_datetime",
             {"column_name": "pickup_datetime", "date_format_string": "%Y-%m-%d"},
             [("2019-02-01",), ("2019-02-23",)],


### PR DESCRIPTION
We're standardizing partitioners so that they can be used consistently across backends. This partitioner is specific to sqlite, and there are no plans to implement it across other backends, so we're removing it.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
