### PR TITLE
[MAINTENANCE] Revert Add batch_configs to context schema

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1518,12 +1518,6 @@ class GXCloudConfig(DictDot):
 
 
 class DataContextConfigSchema(Schema):
-    batch_configs = fields.Dict(
-        keys=fields.Str(),
-        required=False,
-        allow_none=True,
-        load_only=True,
-    )
     config_version = fields.Number(
         validate=lambda x: 0 < x < 100,  # noqa: PLR2004
         error_messages={"invalid": "config version must " "be a number."},
@@ -2276,7 +2270,6 @@ class DataContextConfig(BaseYamlConfig):
         - https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file/
 
     Args:
-        batch_configs: (Optional[Dict]): a dictionary of batch_config dicts.
         config_version (Optional[float]): config version of this DataContext.
         datasources (Optional[Union[Dict[str, DatasourceConfig], Dict[str, Dict[str, Union[Dict[str, str], str, dict]]]]):
             DatasourceConfig or Dict containing configurations for Datasources associated with DataContext.
@@ -2308,7 +2301,6 @@ class DataContextConfig(BaseYamlConfig):
 
     def __init__(  # noqa: C901, PLR0912, PLR0913
         self,
-        batch_configs: Optional[Dict] = None,
         config_version: Optional[float] = None,
         datasources: Optional[
             Union[
@@ -2361,7 +2353,6 @@ class DataContextConfig(BaseYamlConfig):
         self._config_version = config_version
         if datasources is None:
             datasources = {}
-        self.batch_configs = batch_configs or {}
         self.datasources = datasources
         self.fluent_datasources = fluent_datasources or {}
         self.expectations_store_name = expectations_store_name
@@ -2906,8 +2897,10 @@ class CheckpointConfig(BaseYamlConfig):
                 validation_dict=substituted_validation_dict,
                 batch_request_required=False,
             )
-            validation_batch_request: BatchRequestBase = substituted_validation_dict.get(  # type: ignore[assignment]
-                "batch_request"
+            validation_batch_request: BatchRequestBase = (
+                substituted_validation_dict.get(  # type: ignore[assignment]
+                    "batch_request"
+                )
             )
             validation_dict["batch_request"] = validation_batch_request
             validation_expectation_suite_name: str = substituted_validation_dict.get(  # type: ignore[assignment]
@@ -2916,8 +2909,10 @@ class CheckpointConfig(BaseYamlConfig):
             validation_dict[
                 "expectation_suite_name"
             ] = validation_expectation_suite_name
-            validation_expectation_suite_ge_cloud_id: str = substituted_validation_dict.get(  # type: ignore[assignment]
-                "expectation_suite_ge_cloud_id"
+            validation_expectation_suite_ge_cloud_id: str = (
+                substituted_validation_dict.get(  # type: ignore[assignment]
+                    "expectation_suite_ge_cloud_id"
+                )
             )
             validation_dict[
                 "expectation_suite_ge_cloud_id"

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1347,7 +1347,6 @@ def test_InlineStoreBackend(empty_data_context) -> None:
     )
     assert sorted(inline_store_backend.list_keys()) == [
         ("anonymous_usage_statistics",),
-        ("batch_configs",),
         ("checkpoint_store_name",),
         ("concurrency",),
         ("config_variables_file_path",),

--- a/tests/data_context/test_data_context_config_ui.py
+++ b/tests/data_context/test_data_context_config_ui.py
@@ -1574,7 +1574,6 @@ def test_data_context_config_defaults():
             "explicit_url": False,
             "usage_statistics_url": "https://stats.greatexpectations.io/great_expectations/v1/usage_statistics",
         },
-        "batch_configs": {},
         "checkpoint_store_name": None,
         "concurrency": None,
         "config_variables_file_path": None,

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -225,7 +225,6 @@ def test_get_config(empty_data_context):
     print(context.get_config(mode=ConfigOutputModes.DICT).keys())
 
     assert set(context.get_config(mode=ConfigOutputModes.DICT).keys()) == {
-        "batch_configs",
         "config_version",
         "datasources",
         "config_variables_file_path",


### PR DESCRIPTION
This reverts commit a43cdca906a1c52e889bcc23dcc607c683b9e97e.

This appears to be leftover from an abandoned approach.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
