### PR TITLE
[MAINTENANCE] Sample getting a file passing mdx check

### DIFF
--- a/docs/docusaurus/docs/core/expectation_suites/manage_expectation_suites.md
+++ b/docs/docusaurus/docs/core/expectation_suites/manage_expectation_suites.md
@@ -42,13 +42,14 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
 
 :::
 
-<details><summary>Full example code</summary>
-<p>
+<details>
+  <summary>Full example code</summary>
+  <p>
 
-```python title="Python code" name="core/expectation_suites/_examples/create_an_expectation_suite.py full example code"
-```
+  ```python title="Python code" name="core/expectation_suites/_examples/create_an_expectation_suite.py full example code"
+  ```
 
-</p>
+  </p>
 </details>
 
 ## Get an existing Expectation Suite
@@ -68,7 +69,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   ```python title="Python code" name="core/expectation_suites/_examples/get_an_expectation_suite.py create Expectation Suite"
   ```
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/get_an_expectation_suite.py full example code"
@@ -99,7 +101,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   ```python title="Python code" name="core/expectation_suites/_examples/delete_an_expectation_suite.py delete Expectation Suite"
   ```
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/delete_an_expectation_suite.py full example code"
@@ -146,7 +149,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   
   :::
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/add_expectations_to_an_expectation_suite.py full example code"
@@ -177,7 +181,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   ```python title="Python code" name="core/expectation_suites/_examples/get_a_specific_expectation_from_an_expectation_suite.py retrieve expectation"
   ```
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/get_a_specific_expectation_from_an_expectation_suite.py full example code"
@@ -219,7 +224,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   You can [test changes to an Expectation](/core/expectations/manage_expectations.md#test-an-expectation) without running `expectation.save()`, but those changes will not persist in the Expectation Suite until `expectation.save()` is run.
   :::
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/edit_a_single_expectation.py full example code"
@@ -252,7 +258,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   ```python title="Python code" name="core/expectation_suites/_examples/edit_all_expectations_in_an_expectation_suite.py save Expectation Suite"
   ```
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/edit_all_expectations_in_an_expectation_suite.py full example code"
@@ -288,7 +295,8 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
   ```python title="Python code" name="core/expectation_suites/_examples/delete_an_expectation_in_an_expectation_suite.py delete the Expectation"
   ```
 
-<details><summary>Full example code</summary>
+<details>
+<summary>Full example code</summary>
 <p>
 
 ```python title="Python code" name="core/expectation_suites/_examples/delete_an_expectation_in_an_expectation_suite.py full example code"

--- a/docs/docusaurus/docs/core/expectation_suites/manage_expectation_suites.md
+++ b/docs/docusaurus/docs/core/expectation_suites/manage_expectation_suites.md
@@ -43,13 +43,13 @@ You can add an Expectation Suite to your Data Context at the same time as you cr
 :::
 
 <details>
-  <summary>Full example code</summary>
-  <p>
+<summary>Full example code</summary>
+<p>
 
-  ```python title="Python code" name="core/expectation_suites/_examples/create_an_expectation_suite.py full example code"
-  ```
+```python title="Python code" name="core/expectation_suites/_examples/create_an_expectation_suite.py full example code"
+```
 
-  </p>
+</p>
 </details>
 
 ## Get an existing Expectation Suite


### PR DESCRIPTION
Looks like the mdx checker is happy as long as `<summary>` isn't on the same line as `<details>`. I don't understand why ATM.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
