### PR TITLE
[MAINTENANCE] Remove manual validation around evaluation parameters in core expecta…

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_missing_threshold.py
+++ b/docs/sphinx_api_docs_source/public_api_missing_threshold.py
@@ -59,8 +59,6 @@ ITEMS_IGNORED_FROM_PUBLIC_API = [
     "File: great_expectations/datasource/fluent/sql_datasource.py Name: get_batch_list_from_batch_request",
     "File: great_expectations/datasource/new_datasource.py Name: get_batch_list_from_batch_request",
     "File: great_expectations/exceptions/exceptions.py Name: InvalidExpectationConfigurationError",
-    "File: great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py Name: validate_configuration",
-    "File: great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py Name: validate_configuration",
     "File: great_expectations/expectations/expectation.py Name: validate_configuration",
     "File: great_expectations/expectations/expectation_configuration.py Name: to_domain_obj",
     "File: great_expectations/expectations/metrics/map_metric_provider/column_pair_condition_partial.py Name: column_pair_condition_partial",

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -159,20 +159,11 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
                     isinstance(configuration.kwargs["min_value"], dict)
                     or float(configuration.kwargs.get("min_value")).is_integer()
                 ), "min_value and max_value must be integers"
-                if isinstance(configuration.kwargs.get("min_value"), dict):
-                    assert "$PARAMETER" in configuration.kwargs.get(
-                        "min_value"
-                    ), 'Evaluation Parameter dict for min_value kwarg must have "$PARAMETER" key.'
-
             if configuration.kwargs.get("max_value"):
                 assert (
                     isinstance(configuration.kwargs["max_value"], dict)
                     or float(configuration.kwargs.get("max_value")).is_integer()
                 ), "min_value and max_value must be integers"
-                if isinstance(configuration.kwargs.get("max_value"), dict):
-                    assert "$PARAMETER" in configuration.kwargs.get(
-                        "max_value"
-                    ), 'Evaluation Parameter dict for max_value kwarg must have "$PARAMETER" key.'
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from great_expectations._docs_decorators import public_api
+from great_expectations.compatibility.pydantic import (
+    root_validator,
+)
 from great_expectations.core.evaluation_parameters import (
     EvaluationParameterDict,  # noqa: TCH001
 )
-from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
     render_evaluation_parameter_string,
@@ -124,48 +125,13 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
         "max_value",
     )
 
-    @public_api
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """Validates the configuration of an Expectation.
-
-        For `expect_column_value_lengths_to_be_between` it is required that the `configuration.kwargs` contain
-        `min_value` and/or `max_value`; both cannot be None.  Both `min_value` and `max_value` may be either an integer
-        or a `dict`; if a `dict`, it must include `$PARAMETER` as a key.
-
-         The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
-         superclass hierarchy.
-
-        Args:
-            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
-                from the configuration attribute of the Expectation instance.
-
-        Raises:
-            InvalidExpectationConfigurationError: The configuration does not contain the values required by the
-                Expectation.
-        """
-        super().validate_configuration(configuration)
-
-        configuration = configuration or self.configuration
-
-        try:
-            assert (
-                configuration.kwargs.get("min_value") is not None
-                or configuration.kwargs.get("max_value") is not None
-            ), "min_value and max_value cannot both be None"
-            if configuration.kwargs.get("min_value"):
-                assert (
-                    isinstance(configuration.kwargs["min_value"], dict)
-                    or float(configuration.kwargs.get("min_value")).is_integer()
-                ), "min_value and max_value must be integers"
-            if configuration.kwargs.get("max_value"):
-                assert (
-                    isinstance(configuration.kwargs["max_value"], dict)
-                    or float(configuration.kwargs.get("max_value")).is_integer()
-                ), "min_value and max_value must be integers"
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
+    @root_validator
+    def _validate_min_or_max_set(cls, values):
+        min_value = values.get("min_value")
+        max_value = values.get("max_value")
+        if min_value is None and max_value is None:
+            raise ValueError("min_value and max_value cannot both be None")
+        return values
 
     @classmethod
     def _prescriptive_template(  # noqa: PLR0912

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -8,7 +8,6 @@ from great_expectations.core.evaluation_parameters import (
 )
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
-    InvalidExpectationConfigurationError,
 )
 from great_expectations.render.components import (
     LegacyRendererType,
@@ -104,36 +103,6 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
         "column",
         "like_pattern_list",
     )
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """Validates the configuration for the Expectation.
-
-        For `expect_column_values_to_match_like_pattern`
-        we require that the `configuraton.kwargs` contain a `like_pattern_list` key that is either a `list` or `dict`.
-
-        Args:
-            configuration: The ExpectationConfiguration to be validated.
-
-        Raises:
-            InvalidExpectationConfigurationError: The configuraton does not contain the values required by the Expectation
-        """
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-        try:
-            assert (
-                "like_pattern_list" in configuration.kwargs
-            ), "Must provide like_pattern_list"
-            assert isinstance(
-                configuration.kwargs.get("like_pattern_list"), (list, dict)
-            ), "like_pattern_list must be a list"
-            assert isinstance(configuration.kwargs.get("like_pattern_list"), dict) or (
-                len(configuration.kwargs.get("like_pattern_list")) > 0
-            ), "At least one like_pattern must be supplied in the like_pattern_list."
-
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -131,10 +131,6 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
             assert isinstance(configuration.kwargs.get("like_pattern_list"), dict) or (
                 len(configuration.kwargs.get("like_pattern_list")) > 0
             ), "At least one like_pattern must be supplied in the like_pattern_list."
-            if isinstance(configuration.kwargs.get("like_pattern_list"), dict):
-                assert "$PARAMETER" in configuration.kwargs.get(
-                    "like_pattern_list"
-                ), 'Evaluation Parameter dict for like_pattern_list kwarg must have "$PARAMETER" key.'
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -8,7 +8,6 @@ from great_expectations.core.evaluation_parameters import (
 )
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
-    InvalidExpectationConfigurationError,
 )
 from great_expectations.render.components import (
     LegacyRendererType,
@@ -102,41 +101,6 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
         "column",
         "like_pattern_list",
     )
-
-    def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration] = None
-    ) -> None:
-        """
-        Validates the configuration of an Expectation.
-
-        For `expect_column_values_to_not_match_like_pattern_list` it is required that:
-            - 'like_pattern_list' is present in configuration's kwarg
-            - assert 'like_pattern_list' is of type list or dict
-            - if 'like_pattern_list' is list, assert non-empty
-
-        Args:
-            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
-                                  from the configuration attribute of the Expectation instance.
-
-        Raises:
-            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
-                                  Expectation."
-        """
-        super().validate_configuration(configuration)
-        configuration = configuration or self.configuration
-        try:
-            assert (
-                "like_pattern_list" in configuration.kwargs
-            ), "Must provide like_pattern_list"
-            assert isinstance(
-                configuration.kwargs.get("like_pattern_list"), (list, dict)
-            ), "like_pattern_list must be a list or dict"
-            assert isinstance(configuration.kwargs.get("like_pattern_list"), dict) or (
-                len(configuration.kwargs.get("like_pattern_list")) > 0
-            ), "At least one like_pattern must be supplied in the like_pattern_list."
-
-        except AssertionError as e:
-            raise InvalidExpectationConfigurationError(str(e))
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -113,7 +113,6 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
             - 'like_pattern_list' is present in configuration's kwarg
             - assert 'like_pattern_list' is of type list or dict
             - if 'like_pattern_list' is list, assert non-empty
-            - if 'like_pattern_list' is dict, assert a key "$PARAMETER" is present
 
         Args:
             configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
@@ -135,10 +134,6 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
             assert isinstance(configuration.kwargs.get("like_pattern_list"), dict) or (
                 len(configuration.kwargs.get("like_pattern_list")) > 0
             ), "At least one like_pattern must be supplied in the like_pattern_list."
-            if isinstance(configuration.kwargs.get("like_pattern_list"), dict):
-                assert "$PARAMETER" in configuration.kwargs.get(
-                    "like_pattern_list"
-                ), 'Evaluation Parameter dict for like_pattern_list kwarg must have "$PARAMETER" key.'
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))


### PR DESCRIPTION
…tions

Pydantic does the heavy lifting for us. This PR removes some remaining manual checking around evaluation parameters.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
