### PR TITLE
[MAINTENANCE] Remove `expectation_suite_name` param from `ExpectationSuite`

### DIFF
--- a/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
+++ b/docs/docusaurus/docs/cloud/checkpoints/manage_checkpoints.md
@@ -42,7 +42,7 @@ To learn more about Checkpoints, see [Checkpoint](/reference/learn/terms/checkpo
     checkpoint_config = {
         "name": checkpoint_name,
         "validations": [{
-            "expectation_suite_name": expectation_suite.expectation_suite_name,
+            "expectation_suite_name": expectation_suite.name,
             "expectation_suite_id": expectation_suite.id,
             "batch_request": {
                 "datasource_name": "<data_source_name>",

--- a/docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py
+++ b/docs/docusaurus/docs/oss/guides/setup/configuring_data_docs/data_docs.py
@@ -15,7 +15,7 @@ validator.expect_column_values_to_be_between(
 )
 
 taxi_suite = validator.get_expectation_suite()
-taxi_suite.expectation_suite_name = "taxi_suite"
+taxi_suite.name = "taxi_suite"
 
 context.add_expectation_suite(expectation_suite=taxi_suite)
 

--- a/docs/docusaurus/docs/snippets/checkpoints.py
+++ b/docs/docusaurus/docs/snippets/checkpoints.py
@@ -17,7 +17,7 @@ validator.expect_column_values_to_be_between(
 )
 
 taxi_suite = validator.get_expectation_suite()
-taxi_suite.expectation_suite_name = "taxi_suite"
+taxi_suite.name = "taxi_suite"
 
 context.add_expectation_suite(expectation_suite=taxi_suite)
 

--- a/docs/docusaurus/docs/snippets/result_format.py
+++ b/docs/docusaurus/docs/snippets/result_format.py
@@ -210,7 +210,7 @@ expectation_config = ExpectationConfiguration(
 )
 test_suite.add_expectation_configuration(expectation_configuration=expectation_config)
 
-test_suite.expectation_suite_name = "test_suite"
+test_suite.name = "test_suite"
 context.add_or_update_expectation_suite(
     expectation_suite=test_suite,
 )

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -74,7 +74,6 @@ class ExpectationSuite(SerializableDictDot):
 
     Args:
         name: Name of the Expectation Suite
-        expectation_suite_name (deprecated): Name of the Expectation Suite.
         expectations: Expectation Configurations to associate with this Expectation Suite.
         evaluation_parameters: Evaluation parameters to be substituted when evaluating Expectations.
         data_asset_type: Type of data asset to associate with this suite.
@@ -85,7 +84,7 @@ class ExpectationSuite(SerializableDictDot):
 
     def __init__(  # noqa: PLR0913
         self,
-        name: Optional[str] = None,
+        name: str,
         expectations: Optional[
             Sequence[Union[dict, ExpectationConfiguration, Expectation]]
         ] = None,
@@ -95,16 +94,8 @@ class ExpectationSuite(SerializableDictDot):
         meta: Optional[dict] = None,
         notes: str | list[str] | None = None,
         id: Optional[str] = None,
-        expectation_suite_name: Optional[
-            str
-        ] = None,  # for backwards compatibility - remove
     ) -> None:
-        if name:
-            assert isinstance(name, str), "Name is a required field."
-            self.name = name
-        else:
-            assert isinstance(expectation_suite_name, str), "Name is a required field."
-            self.name = expectation_suite_name
+        self.name = name
         self.id = id
 
         self.expectations = [
@@ -131,14 +122,6 @@ class ExpectationSuite(SerializableDictDot):
         from great_expectations import project_manager
 
         self._store = project_manager.get_expectations_store()
-
-    @property
-    def expectation_suite_name(self) -> str:
-        return self.name
-
-    @expectation_suite_name.setter
-    def expectation_suite_name(self, value) -> None:
-        self.name = value
 
     @property
     def evaluation_parameter_options(self) -> tuple[str, ...]:
@@ -361,7 +344,7 @@ class ExpectationSuite(SerializableDictDot):
         """
         ExpectationSuite equivalence relies only on expectations and evaluation parameters. It does not include:
         - data_asset_name
-        - expectation_suite_name
+        - name
         - meta
         - data_asset_type
         """
@@ -399,7 +382,7 @@ class ExpectationSuite(SerializableDictDot):
             return NotImplemented
         return all(
             (
-                self.expectation_suite_name == other.expectation_suite_name,
+                self.name == other.name,
                 self.expectations == other.expectations,
                 self.evaluation_parameters == other.evaluation_parameters,
                 self.data_asset_type == other.data_asset_type,
@@ -1134,7 +1117,7 @@ class ExpectationSuite(SerializableDictDot):
 
 
 class ExpectationSuiteSchema(Schema):
-    expectation_suite_name = fields.Str()
+    name = fields.Str()
     id = fields.UUID(required=False, allow_none=True)
     expectations = fields.List(fields.Nested("ExpectationConfigurationSchema"))
     evaluation_parameters = fields.Dict(allow_none=True)

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -350,7 +350,7 @@ class DataAsset:
             if expectation_suite_name is None:
                 expectation_suite_name = "default"
             self._expectation_suite = ExpectationSuite(
-                expectation_suite_name=expectation_suite_name,
+                name=expectation_suite_name,
             )
 
         self._expectation_suite.data_asset_type = self._data_asset_type

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -320,7 +320,7 @@ class DataAsset:
                 key value `data_asset_name` as `data_asset_name`.
 
             expectation_suite_name (string): \
-                The name to assign to the `expectation_suite.expectation_suite_name`
+                The name to assign to the `expectation_suite.name`
 
         Returns:
             None
@@ -337,17 +337,14 @@ class DataAsset:
             self._expectation_suite = expectation_suite
 
             if expectation_suite_name is not None:
-                if (
-                    self._expectation_suite.expectation_suite_name
-                    != expectation_suite_name
-                ):
+                if self._expectation_suite.name != expectation_suite_name:
                     logger.warning(
                         "Overriding existing expectation_suite_name {n1} with new name {n2}".format(
-                            n1=self._expectation_suite.expectation_suite_name,
+                            n1=self._expectation_suite.name,
                             n2=expectation_suite_name,
                         )
                     )
-                self._expectation_suite.expectation_suite_name = expectation_suite_name
+                self._expectation_suite.name = expectation_suite_name
 
         else:
             if expectation_suite_name is None:
@@ -844,7 +841,7 @@ class DataAsset:
                         abbrev_results.append(exp)
                 results = abbrev_results
 
-            expectation_suite_name = expectation_suite.expectation_suite_name
+            expectation_suite_name = expectation_suite.name
 
             expectation_meta = copy.deepcopy(expectation_suite.meta)
 
@@ -931,12 +928,12 @@ class DataAsset:
     @property
     def expectation_suite_name(self):
         """Gets the current expectation_suite name of this data_asset as stored in the expectations configuration."""
-        return self._expectation_suite.expectation_suite_name
+        return self._expectation_suite.name
 
     @expectation_suite_name.setter
     def expectation_suite_name(self, expectation_suite_name) -> None:
         """Sets the expectation_suite name of this data_asset as stored in the expectations configuration."""
-        self._expectation_suite.expectation_suite_name = expectation_suite_name
+        self._expectation_suite.name = expectation_suite_name
 
     ###
     #

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -454,10 +454,10 @@ class AbstractDataContext(ConfigPeer, ABC):
     ) -> None:
         if expectation_suite_name is None:
             key = ExpectationSuiteIdentifier(
-                expectation_suite_name=expectation_suite.expectation_suite_name
+                expectation_suite_name=expectation_suite.name
             )
         else:
-            expectation_suite.expectation_suite_name = expectation_suite_name
+            expectation_suite.name = expectation_suite_name
             key = ExpectationSuiteIdentifier(
                 expectation_suite_name=expectation_suite_name
             )
@@ -2256,7 +2256,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             ), "expectation_suite_name must be specified."
 
             expectation_suite = ExpectationSuite(
-                expectation_suite_name=expectation_suite_name,
+                name=expectation_suite_name,
                 id=id,
                 expectations=expectations,
                 evaluation_parameters=evaluation_parameters,
@@ -2277,9 +2277,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         overwrite_existing: bool,
         **kwargs,
     ) -> ExpectationSuite:
-        key = ExpectationSuiteIdentifier(
-            expectation_suite_name=expectation_suite.expectation_suite_name
-        )
+        key = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite.name)
 
         persistence_fn: Callable
         if overwrite_existing:
@@ -2313,7 +2311,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         """
         Like `update_expectation_suite` but without the usage statistics logging.
         """
-        name = expectation_suite.expectation_suite_name
+        name = expectation_suite.name
         id = expectation_suite.id
         key = self._determine_key_for_suite_update(name=name, id=id)
         self.expectations_store.update(key=key, value=expectation_suite)
@@ -2401,7 +2399,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             ), "expectation_suite_name must be specified."
 
             expectation_suite = ExpectationSuite(
-                expectation_suite_name=expectation_suite_name,
+                name=expectation_suite_name,
                 id=id,
                 expectations=expectations,
                 evaluation_parameters=evaluation_parameters,

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -570,9 +570,7 @@ class CloudDataContext(SerializableDataContext):
         if not isinstance(overwrite_existing, bool):
             raise ValueError("overwrite_existing must be of type bool.")
 
-        expectation_suite = ExpectationSuite(
-            expectation_suite_name=expectation_suite_name
-        )
+        expectation_suite = ExpectationSuite(name=expectation_suite_name)
 
         existing_suite_names = self.list_expectation_suite_names()
         cloud_id: Optional[str] = None

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -715,7 +715,7 @@ class CloudDataContext(SerializableDataContext):
         key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             id=id,
-            resource_name=expectation_suite.expectation_suite_name,
+            resource_name=expectation_suite.name,
         )
 
         if not overwrite_existing:
@@ -889,7 +889,7 @@ class CloudDataContext(SerializableDataContext):
 
         key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
-            resource_name=expectation_suite.expectation_suite_name,
+            resource_name=expectation_suite.name,
             id=cloud_id,
         )
 

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -71,7 +71,7 @@ class ExpectationsStore(Store):
                     "table_name", "ge_expectations_store"
                 )
                 store_backend["key_columns"] = store_backend.get(
-                    "key_columns", ["expectation_suite_name"]
+                    "key_columns", ["name"]
                 )
 
         super().__init__(
@@ -99,13 +99,13 @@ class ExpectationsStore(Store):
         deserialization into a GX object
         """
         suite_data: Dict
-        # if only the expectation_suite_name is passed, a list will be returned
+        # if only the name is passed, a list will be returned
         if isinstance(response_json["data"], list):
             if len(response_json["data"]) == 1:
                 suite_data = response_json["data"][0]
             else:
                 raise ValueError(
-                    "More than one Expectation Suite was found with the expectation_suite_name."
+                    "More than one Expectation Suite was found with the name."
                 )
         else:
             suite_data = response_json["data"]
@@ -228,7 +228,7 @@ class ExpectationsStore(Store):
             return result
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.ExpectationSuiteError(
-                f"An ExpectationSuite named {value.expectation_suite_name} already exists."
+                f"An ExpectationSuite named {value.name} already exists."
             )
 
     def _update(self, key, value, **kwargs):
@@ -254,7 +254,7 @@ class ExpectationsStore(Store):
         except gx_exceptions.StoreBackendError as exc:
             # todo: this generic error clobbers more informative errors coming from the store
             raise gx_exceptions.ExpectationSuiteError(
-                f"Could not find an existing ExpectationSuite named {value.expectation_suite_name}."
+                f"Could not find an existing ExpectationSuite named {value.name}."
             ) from exc
 
     def _add_ids_on_create(self, suite: ExpectationSuite) -> ExpectationSuite:

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -236,7 +236,7 @@ class UserConfigurableProfiler:
             # Only `Validator`` has `get_expectation_suite()`
             # noinspection PyProtectedMember
             suite_name: str = (
-                self.profile_dataset._expectation_suite.expectation_suite_name  # type: ignore[union-attr]
+                self.profile_dataset._expectation_suite.name  # type: ignore[union-attr]
             )
             self.profile_dataset._expectation_suite = ExpectationSuite(  # type: ignore[union-attr]
                 expectation_suite_name=suite_name

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -239,7 +239,7 @@ class UserConfigurableProfiler:
                 self.profile_dataset._expectation_suite.name  # type: ignore[union-attr]
             )
             self.profile_dataset._expectation_suite = ExpectationSuite(  # type: ignore[union-attr]
-                expectation_suite_name=suite_name
+                name=suite_name
             )
 
         if self.semantic_types_dict:

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -1059,7 +1059,7 @@ def get_or_create_expectation_suite(
                 logger.info(f'Created ExpectationSuite "{expectation_suite.name}".')
         else:
             expectation_suite = ExpectationSuite(
-                expectation_suite_name=expectation_suite_name,
+                name=expectation_suite_name,
             )
 
     return expectation_suite

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -1025,7 +1025,7 @@ def get_or_create_expectation_suite(
     create_expectation_suite: bool
 
     if expectation_suite is not None and expectation_suite_name is not None:
-        if expectation_suite.expectation_suite_name != expectation_suite_name:
+        if expectation_suite.name != expectation_suite_name:
             raise ValueError(
                 'Mutually inconsistent "expectation_suite" and "expectation_suite_name" were specified.'
             )
@@ -1056,9 +1056,7 @@ def get_or_create_expectation_suite(
                 expectation_suite = data_context.add_expectation_suite(
                     expectation_suite_name=expectation_suite_name
                 )
-                logger.info(
-                    f'Created ExpectationSuite "{expectation_suite.expectation_suite_name}".'
-                )
+                logger.info(f'Created ExpectationSuite "{expectation_suite.name}".')
         else:
             expectation_suite = ExpectationSuite(
                 expectation_suite_name=expectation_suite_name,

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -375,7 +375,7 @@ class ActionListValidationOperator(ValidationOperator):
                 )
             else:
                 expectation_suite_identifier = ExpectationSuiteIdentifier(
-                    expectation_suite_name=batch._expectation_suite.expectation_suite_name
+                    expectation_suite_name=batch._expectation_suite.name
                 )
                 validation_result_id = ValidationResultIdentifier(
                     batch_identifier=batch_identifier,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -302,12 +302,12 @@ class Validator:
     @property
     def expectation_suite_name(self) -> str:
         """Gets the current expectation_suite name of this data_asset as stored in the expectations configuration."""
-        return self._expectation_suite.expectation_suite_name
+        return self._expectation_suite.name
 
     @expectation_suite_name.setter
     def expectation_suite_name(self, expectation_suite_name: str) -> None:
         """Sets the expectation_suite name of this data_asset as stored in the expectations configuration."""
-        self._expectation_suite.expectation_suite_name = expectation_suite_name
+        self._expectation_suite.name = expectation_suite_name
 
     def load_batch_list(self, batch_list: Sequence[Batch | FluentBatch]) -> None:
         self._execution_engine.batch_manager.load_batch_list(batch_list=batch_list)
@@ -1479,7 +1479,7 @@ class Validator:
                         abbrev_results.append(exp)
                 results = abbrev_results
 
-            expectation_suite_name = expectation_suite.expectation_suite_name
+            expectation_suite_name = expectation_suite.name
 
             result = ExpectationSuiteValidationResult(
                 results=results,
@@ -1638,7 +1638,7 @@ class Validator:
                 key value `data_asset_name` as `data_asset_name`.
 
             expectation_suite_name (string): \
-                The name to assign to the `expectation_suite.expectation_suite_name`
+                The name to assign to the `expectation_suite.name`
 
         Returns:
             None
@@ -1662,24 +1662,19 @@ class Validator:
             self._expectation_suite: ExpectationSuite = expectation_suite
 
             if expectation_suite_name is not None:
-                if (
-                    self._expectation_suite.expectation_suite_name
-                    != expectation_suite_name
-                ):
+                if self._expectation_suite.name != expectation_suite_name:
                     logger.warning(
                         "Overriding existing expectation_suite_name {n1} with new name {n2}".format(
-                            n1=self._expectation_suite.expectation_suite_name,
+                            n1=self._expectation_suite.name,
                             n2=expectation_suite_name,
                         )
                     )
-                self._expectation_suite.expectation_suite_name = expectation_suite_name
+                self._expectation_suite.name = expectation_suite_name
 
         else:
             if expectation_suite_name is None:
                 expectation_suite_name = "default"
-            self._expectation_suite = ExpectationSuite(
-                expectation_suite_name=expectation_suite_name
-            )
+            self._expectation_suite = ExpectationSuite(name=expectation_suite_name)
 
         self._expectation_suite.execution_engine_type = type(self._execution_engine)
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -296,7 +296,7 @@ class Validator:
     def expectation_suite(self, value: ExpectationSuite) -> None:
         self._initialize_expectations(
             expectation_suite=value,
-            expectation_suite_name=value.expectation_suite_name,
+            expectation_suite_name=value.name,
         )
 
     @property

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -123,7 +123,7 @@ def test_run_validation_operator_raises_error_if_no_matching_validation_operator
 def test_validation_operator_evaluation_parameters(
     validation_operators_data_context, parameterized_expectation_suite
 ):
-    parameterized_expectation_suite.expectation_suite_name = "param_suite"
+    parameterized_expectation_suite.name = "param_suite"
     validation_operators_data_context.add_expectation_suite(
         expectation_suite=parameterized_expectation_suite
     )
@@ -144,7 +144,7 @@ def test_validation_operator_evaluation_parameters(
     )
     assert res["success"] is True
 
-    parameterized_expectation_suite.expectation_suite_name = "param_suite.failure"
+    parameterized_expectation_suite.name = "param_suite.failure"
     validation_operators_data_context.add_expectation_suite(
         expectation_suite=parameterized_expectation_suite
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -645,7 +645,7 @@ def spark_session_v012(test_backends):
 @pytest.fixture
 def basic_expectation_suite():
     expectation_suite = ExpectationSuite(
-        expectation_suite_name="default",
+        name="default",
         meta={},
         expectations=[
             ExpectationConfiguration(
@@ -2528,7 +2528,7 @@ def titanic_sqlite_db_connection_string(sa):
 def titanic_expectation_suite(empty_data_context_stats_enabled):
     data_context = empty_data_context_stats_enabled
     return ExpectationSuite(
-        expectation_suite_name="Titanic.warning",
+        name="Titanic.warning",
         meta={},
         data_asset_type="Dataset",
         expectations=[
@@ -3998,9 +3998,7 @@ def alice_columnar_table_single_batch():
     )
 
     expectation_suite_name: str = "alice_columnar_table_single_batch"
-    expected_expectation_suite = ExpectationSuite(
-        expectation_suite_name=expectation_suite_name
-    )
+    expected_expectation_suite = ExpectationSuite(name=expectation_suite_name)
     expectation_configuration: ExpectationConfiguration
     for expectation_configuration in expectation_configurations:
         # NOTE Will 20211208 add_expectation() method, although being called by an ExpectationSuite instance, is being
@@ -5341,7 +5339,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
         "bobby_columnar_table_multi_batch_quantiles_estimator"
     )
     expected_expectation_suite_quantiles_estimator: ExpectationSuite = ExpectationSuite(
-        expectation_suite_name=expectation_suite_name_quantiles_estimator,
+        name=expectation_suite_name_quantiles_estimator,
     )
     expectation_configuration: ExpectationConfiguration
     for expectation_configuration in expectation_configurations:

--- a/tests/core/factory/test_suite_factory.py
+++ b/tests/core/factory/test_suite_factory.py
@@ -157,7 +157,7 @@ def test_suite_factory_add_success_filesystem(empty_data_context):
     _test_suite_factory_add_success(empty_data_context)
 
 
-@pytest.mark.filesystem
+@pytest.mark.cloud
 def test_suite_factory_add_success_cloud(empty_cloud_context_fluent):
     _test_suite_factory_add_success(empty_cloud_context_fluent)
 

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -67,7 +67,7 @@ def expect_column_values_to_be_in_set_col_a_with_meta_dict() -> dict:
 @pytest.fixture
 def empty_suite_with_meta(fake_expectation_suite_name: str) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name=fake_expectation_suite_name,
+        name=fake_expectation_suite_name,
         meta={"notes": "This is an expectation suite."},
     )
 
@@ -88,11 +88,11 @@ class TestInit:
 
     @pytest.mark.unit
     def test_expectation_suite_init_defaults(self, fake_expectation_suite_name: str):
-        suite = ExpectationSuite(expectation_suite_name=fake_expectation_suite_name)
+        suite = ExpectationSuite(name=fake_expectation_suite_name)
 
         default_meta = {"great_expectations_version": ge_version}
 
-        assert suite.expectation_suite_name == fake_expectation_suite_name
+        assert suite.name == fake_expectation_suite_name
         assert suite.expectations == []
         assert suite.evaluation_parameters == {}
         assert suite.data_asset_type is None
@@ -118,7 +118,7 @@ class TestInit:
         test_id = "test_id"
 
         suite = ExpectationSuite(
-            expectation_suite_name=fake_expectation_suite_name,
+            name=fake_expectation_suite_name,
             expectations=[expect_column_values_to_be_in_set_col_a_with_meta],
             evaluation_parameters=test_evaluation_parameters,
             data_asset_type=test_data_asset_type,
@@ -126,7 +126,7 @@ class TestInit:
             meta=test_meta,
             id=test_id,
         )
-        assert suite.expectation_suite_name == fake_expectation_suite_name
+        assert suite.name == fake_expectation_suite_name
         assert suite.expectation_configurations == [
             expect_column_values_to_be_in_set_col_a_with_meta
         ]
@@ -154,10 +154,10 @@ class TestInit:
         ]
 
         suite = ExpectationSuite(
-            expectation_suite_name=fake_expectation_suite_name,
+            name=fake_expectation_suite_name,
             expectations=test_expectations_input,  # type: ignore[arg-type]
         )
-        assert suite.expectation_suite_name == fake_expectation_suite_name
+        assert suite.name == fake_expectation_suite_name
 
         test_expected_expectations = [
             ExpectationConfiguration(
@@ -186,7 +186,7 @@ class TestInit:
 
         with pytest.raises(InvalidExpectationConfigurationError) as e:
             ExpectationSuite(
-                expectation_suite_name=fake_expectation_suite_name,
+                name=fake_expectation_suite_name,
                 meta=test_meta,  # type: ignore[arg-type]
             )
         assert "is of type NotSerializable which cannot be serialized to json" in str(
@@ -241,7 +241,7 @@ class TestCRUDMethods:
     def test_add_success_with_saved_suite(self, expectation):
         context = Mock(spec=AbstractDataContext)
         set_context(project=context)
-        suite = ExpectationSuite(expectation_suite_name=self.expectation_suite_name)
+        suite = ExpectationSuite(name=self.expectation_suite_name)
 
         with mock.patch.object(ExpectationSuite, "_submit_expectation_created_event"):
             created_expectation = suite.add_expectation(expectation=expectation)
@@ -259,7 +259,7 @@ class TestCRUDMethods:
         context = Mock(spec=AbstractDataContext)
         context.expectations_store.has_key.return_value = False
         set_context(project=context)
-        suite = ExpectationSuite(expectation_suite_name=self.expectation_suite_name)
+        suite = ExpectationSuite(name=self.expectation_suite_name)
 
         created_expectation = suite.add_expectation(expectation=expectation)
 
@@ -276,7 +276,7 @@ class TestCRUDMethods:
         context.expectations_store.has_key.return_value = True
         set_context(project=context)
         suite = ExpectationSuite(
-            expectation_suite_name=self.expectation_suite_name,
+            name=self.expectation_suite_name,
             expectations=[expectation.configuration],
         )
 
@@ -294,7 +294,7 @@ class TestCRUDMethods:
         context.expectations_store.has_key.return_value = True
         set_context(project=context)
         suite = ExpectationSuite(
-            expectation_suite_name="test-suite",
+            name="test-suite",
         )
 
         with pytest.raises(ConnectionError):  # exception type isn't important
@@ -308,7 +308,7 @@ class TestCRUDMethods:
         set_context(project=context)
         context.expectations_store.has_key.return_value = True
         suite = ExpectationSuite(
-            expectation_suite_name=self.expectation_suite_name,
+            name=self.expectation_suite_name,
             expectations=[expectation.configuration],
         )
 
@@ -328,7 +328,7 @@ class TestCRUDMethods:
         set_context(project=context)
         context.expectations_store.has_key.return_value = False
         suite = ExpectationSuite(
-            expectation_suite_name=self.expectation_suite_name,
+            name=self.expectation_suite_name,
             expectations=[expectation.configuration],
         )
 
@@ -345,7 +345,7 @@ class TestCRUDMethods:
         context = Mock(spec=AbstractDataContext)
         set_context(project=context)
         suite = ExpectationSuite(
-            expectation_suite_name="test-suite",
+            name="test-suite",
         )
 
         with pytest.raises(KeyError, match="No matching expectation was found."):
@@ -362,7 +362,7 @@ class TestCRUDMethods:
         )  # arbitrary exception
         set_context(project=context)
         suite = ExpectationSuite(
-            expectation_suite_name="test-suite",
+            name="test-suite",
             expectations=[
                 expectation.configuration,
             ],
@@ -379,7 +379,7 @@ class TestCRUDMethods:
         context.expectations_store.has_key.return_value = True
         set_context(project=context)
         suite = ExpectationSuite(
-            expectation_suite_name=self.expectation_suite_name,
+            name=self.expectation_suite_name,
         )
         store_key = context.expectations_store.get_key.return_value
 
@@ -914,7 +914,7 @@ class TestIsEquivalentTo:
     ):
         """Only expectation equivalence is considered for suite equivalence. Marked as integration since this uses the ExpectationConfiguration.isEquivalentTo() under the hood."""
         different_but_equivalent_suite = deepcopy(suite_with_single_expectation)
-        different_but_equivalent_suite.expectation_suite_name = "different_name"
+        different_but_equivalent_suite.name = "different_name"
         different_but_equivalent_suite.meta = {"notes": "Different meta."}
         different_but_equivalent_suite.data_asset_type = "different_data_asset_type"
         different_but_equivalent_suite.id = "different_id"
@@ -996,7 +996,7 @@ class TestEqDunder:
     @pytest.mark.parametrize(
         "attribute,new_value",
         [
-            pytest.param("expectation_suite_name", "different_name"),
+            pytest.param("name", "different_name"),
             pytest.param(
                 "data_context",
                 MagicMock(),
@@ -1123,7 +1123,7 @@ def table_exp3() -> ExpectationConfiguration:
 @pytest.fixture
 def empty_suite() -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[],
         meta={"notes": "This is an expectation suite."},
     )
@@ -1141,7 +1141,7 @@ def suite_with_table_and_column_expectations(
     table_exp3,
 ) -> ExpectationSuite:
     suite = ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[
             expect_column_values_to_be_in_set_col_a_with_meta,
             exp2,
@@ -1162,7 +1162,7 @@ def baseline_suite(
     expect_column_values_to_be_in_set_col_a_with_meta, exp2
 ) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[expect_column_values_to_be_in_set_col_a_with_meta, exp2],
         meta={"notes": "This is an expectation suite."},
     )

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -15,7 +15,7 @@ from great_expectations.expectations.expectation_configuration import (
 @pytest.fixture
 def empty_suite() -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[],
         meta={"notes": "This is an expectation suite."},
     )
@@ -24,7 +24,7 @@ def empty_suite() -> ExpectationSuite:
 @pytest.fixture
 def baseline_suite(exp1, exp2) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1, exp2],
         meta={"notes": "This is an expectation suite."},
     )
@@ -141,7 +141,7 @@ def column_pair_expectation() -> ExpectationConfiguration:
 @pytest.fixture
 def single_expectation_suite(exp1) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1],
         meta={"notes": "This is an expectation suite."},
     )
@@ -153,7 +153,7 @@ def single_expectation_suite_with_expectation_ge_cloud_id(exp1) -> ExpectationSu
     exp1_with_ge_cloud_id.id = "0faf94a9-f53a-41fb-8e94-32f218d4a774"
 
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1_with_ge_cloud_id],
         meta={"notes": "This is an expectation suite."},
     )
@@ -162,7 +162,7 @@ def single_expectation_suite_with_expectation_ge_cloud_id(exp1) -> ExpectationSu
 @pytest.fixture
 def different_suite(exp1, exp4) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1, exp4],
         meta={"notes": "This is an expectation suite."},
     )
@@ -171,7 +171,7 @@ def different_suite(exp1, exp4) -> ExpectationSuite:
 @pytest.fixture
 def domain_success_runtime_suite(exp1, exp2, exp3, exp4, exp5) -> ExpectationSuite:
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1, exp2, exp3, exp4, exp5],
         meta={"notes": "This is an expectation suite."},
     )
@@ -189,7 +189,7 @@ def suite_with_table_and_column_expectations(
     table_exp3,
 ) -> ExpectationSuite:
     suite = ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[
             exp1,
             exp2,
@@ -213,7 +213,7 @@ def suite_with_column_pair_and_table_expectations(
     column_pair_expectation,
 ) -> ExpectationSuite:
     suite = ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[
             column_pair_expectation,
             table_exp1,
@@ -236,7 +236,7 @@ def ge_cloud_suite(ge_cloud_id, exp1, exp2, exp3) -> ExpectationSuite:
     for exp in (exp1, exp2, exp3):
         exp.id = ge_cloud_id
     return ExpectationSuite(
-        expectation_suite_name="warning",
+        name="warning",
         expectations=[exp1, exp2, exp3],
         meta={"notes": "This is an expectation suite."},
         id=ge_cloud_id,

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -57,7 +57,7 @@ def data_context_simple_expectation_suite_with_custom_pandas_dataset(tmp_path_fa
 def test_data_asset_expectation_suite():
     asset = DataAsset()
     default_suite = ExpectationSuite(
-        expectation_suite_name="default",
+        name="default",
         data_asset_type="DataAsset",
         meta={"great_expectations_version": ge_version},
         expectations=[],

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -25,21 +25,21 @@ def test_expectations_store():
     ns_1 = ExpectationSuiteIdentifier.from_tuple(tuple("a.b.c.warning"))
     my_store.set(
         ns_1,
-        ExpectationSuite(expectation_suite_name="a.b.c.warning"),
+        ExpectationSuite(name="a.b.c.warning"),
     )
 
     ns_1_dict: dict = my_store.get(ns_1)
     ns_1_suite = ExpectationSuite(**ns_1_dict)
-    assert ns_1_suite == ExpectationSuite(expectation_suite_name="a.b.c.warning")
+    assert ns_1_suite == ExpectationSuite(name="a.b.c.warning")
 
     ns_2 = ExpectationSuiteIdentifier.from_tuple(tuple("a.b.c.failure"))
     my_store.set(
         ns_2,
-        ExpectationSuite(expectation_suite_name="a.b.c.failure"),
+        ExpectationSuite(name="a.b.c.failure"),
     )
     ns_2_dict: dict = my_store.get(ns_2)
     ns_2_suite = ExpectationSuite(**ns_2_dict)
-    assert ns_2_suite == ExpectationSuite(expectation_suite_name="a.b.c.failure")
+    assert ns_2_suite == ExpectationSuite(name="a.b.c.failure")
 
     assert set(my_store.list_keys()) == {
         ns_1,
@@ -64,7 +64,7 @@ def test_ExpectationsStore_with_DatabaseStoreBackend(sa):
 
     # first suite to add to db
     default_suite = ExpectationSuite(
-        expectation_suite_name="a.b.c.warning",
+        name="a.b.c.warning",
         meta={"test_meta_key": "test_meta_value"},
         expectations=[],
     )
@@ -75,14 +75,14 @@ def test_ExpectationsStore_with_DatabaseStoreBackend(sa):
     ns_1_dict: dict = my_store.get(ns_1)
     ns_1_suite = ExpectationSuite(**ns_1_dict)
     assert ns_1_suite == ExpectationSuite(
-        expectation_suite_name="a.b.c.warning",
+        name="a.b.c.warning",
         meta={"test_meta_key": "test_meta_value"},
         expectations=[],
     )
 
     # update suite and check if new value exists
     updated_suite = ExpectationSuite(
-        expectation_suite_name="a.b.c.warning",
+        name="a.b.c.warning",
         meta={"test_meta_key": "test_new_meta_value"},
         expectations=[],
     )
@@ -90,7 +90,7 @@ def test_ExpectationsStore_with_DatabaseStoreBackend(sa):
     ns_1_dict: dict = my_store.get(ns_1)
     ns_1_suite = ExpectationSuite(**ns_1_dict)
     assert ns_1_suite == ExpectationSuite(
-        expectation_suite_name="a.b.c.warning",
+        name="a.b.c.warning",
         meta={"test_meta_key": "test_new_meta_value"},
         expectations=[],
     )
@@ -98,12 +98,12 @@ def test_ExpectationsStore_with_DatabaseStoreBackend(sa):
     ns_2 = ExpectationSuiteIdentifier.from_tuple(tuple("a.b.c.failure"))
     my_store.set(
         ns_2,
-        ExpectationSuite(expectation_suite_name="a.b.c.failure"),
+        ExpectationSuite(name="a.b.c.failure"),
     )
     ns_2_dict: dict = my_store.get(ns_2)
     ns_2_suite = ExpectationSuite(**ns_2_dict)
     assert ns_2_suite == ExpectationSuite(
-        expectation_suite_name="a.b.c.failure",
+        name="a.b.c.failure",
     )
 
     assert set(my_store.list_keys()) == {
@@ -195,13 +195,13 @@ def test_expectations_store_report_same_id_with_same_configuration_TupleFilesyst
                     "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
                     "attributes": {
                         "suite": {
-                            "expectation_suite_name": "my_suite",
+                            "name": "my_suite",
                         },
                     },
                 }
             },
             {
-                "expectation_suite_name": "my_suite",
+                "name": "my_suite",
                 "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
             },
             None,
@@ -215,14 +215,14 @@ def test_expectations_store_report_same_id_with_same_configuration_TupleFilesyst
                         "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
                         "attributes": {
                             "suite": {
-                                "expectation_suite_name": "my_suite",
+                                "name": "my_suite",
                             },
                         },
                     }
                 ]
             },
             {
-                "expectation_suite_name": "my_suite",
+                "name": "my_suite",
                 "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
             },
             None,
@@ -244,7 +244,7 @@ def test_gx_cloud_response_json_to_object_dict(
 @pytest.mark.unit
 def test_get_key_in_non_cloud_mode(empty_data_context):
     name = "test-name"
-    suite = ExpectationSuite(expectation_suite_name=name)
+    suite = ExpectationSuite(name=name)
     key = empty_data_context.expectations_store.get_key(name=suite.name, id=suite.id)
     assert isinstance(key, ExpectationSuiteIdentifier)
     assert key.expectation_suite_name == name
@@ -254,7 +254,7 @@ def test_get_key_in_non_cloud_mode(empty_data_context):
 def test_get_key_in_cloud_mode(empty_data_context_in_cloud_mode):
     cloud_data_context = empty_data_context_in_cloud_mode
     name = "test-name"
-    suite = ExpectationSuite(expectation_suite_name=name)
+    suite = ExpectationSuite(name=name)
     key = cloud_data_context.expectations_store.get_key(name=suite.name, id=suite.id)
     assert isinstance(key, GXCloudIdentifier)
     assert key.resource_name == name

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -134,9 +134,9 @@ def validation_operators_data_context(
     df.expect_column_values_to_not_be_null(column="y")
     warning_expectations = df.get_expectation_suite(discard_failed_expectations=False)
 
-    failure_expectations.expectation_suite_name = "f1.failure"
+    failure_expectations.name = "f1.failure"
     data_context.add_expectation_suite(expectation_suite=failure_expectations)
-    warning_expectations.expectation_suite_name = "f1.warning"
+    warning_expectations.name = "f1.warning"
     data_context.add_expectation_suite(expectation_suite=warning_expectations)
 
     return data_context

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -129,9 +129,7 @@ def test_get_existing_expectation_suite(data_context_parameterized_expectation_s
             parameterized_expectation_suite_name
         )
     )
-    assert (
-        expectation_suite.expectation_suite_name == parameterized_expectation_suite_name
-    )
+    assert expectation_suite.name == parameterized_expectation_suite_name
     assert len(expectation_suite.expectations) == 2
 
 
@@ -142,10 +140,7 @@ def test_get_new_expectation_suite(data_context_parameterized_expectation_suite)
             "this_data_asset_does_not_exist.default"
         )
     )
-    assert (
-        expectation_suite.expectation_suite_name
-        == "this_data_asset_does_not_exist.default"
-    )
+    assert expectation_suite.name == "this_data_asset_does_not_exist.default"
     assert len(expectation_suite.expectations) == 0
 
 
@@ -455,7 +450,7 @@ def test_data_context_updates_expectation_suite_names(
 
     # Note we codify here the current behavior of having a string data_asset_name though typed ExpectationSuite objects
     # will enable changing that
-    assert expectation_suite.expectation_suite_name == expectation_suite_name
+    assert expectation_suite.name == expectation_suite_name
 
     # We will now change the data_asset_name and then save the suite in three ways:
     #   1. Directly using the new name,
@@ -464,7 +459,7 @@ def test_data_context_updates_expectation_suite_names(
 
     # Finally, we will try to save without a name (deleting it first) to demonstrate that saving will fail.
 
-    expectation_suite.expectation_suite_name = "a_new_suite_name"
+    expectation_suite.name = "a_new_suite_name"
 
     data_context_parameterized_expectation_suite.save_expectation_suite(
         expectation_suite=expectation_suite, expectation_suite_name="a_new_suite_name"
@@ -476,7 +471,7 @@ def test_data_context_updates_expectation_suite_names(
         )
     )
 
-    assert fetched_expectation_suite.expectation_suite_name == "a_new_suite_name"
+    assert fetched_expectation_suite.name == "a_new_suite_name"
 
     #   2. Using a different name that should be overwritten
     data_context_parameterized_expectation_suite.save_expectation_suite(
@@ -490,7 +485,7 @@ def test_data_context_updates_expectation_suite_names(
         )
     )
 
-    assert fetched_expectation_suite.expectation_suite_name == "a_new_new_suite_name"
+    assert fetched_expectation_suite.name == "a_new_new_suite_name"
 
     # Check that the saved name difference is actually persisted on disk
     with open(
@@ -504,10 +499,10 @@ def test_data_context_updates_expectation_suite_names(
         loaded_suite = ExpectationSuite(
             **loaded_suite_dict,
         )
-        assert loaded_suite.expectation_suite_name == "a_new_new_suite_name"
+        assert loaded_suite.name == "a_new_new_suite_name"
 
     #   3. Using the new name but having the context draw that from the suite
-    expectation_suite.expectation_suite_name = "a_third_suite_name"
+    expectation_suite.name = "a_third_suite_name"
     data_context_parameterized_expectation_suite.save_expectation_suite(
         expectation_suite=expectation_suite
     )
@@ -517,7 +512,7 @@ def test_data_context_updates_expectation_suite_names(
             "a_third_suite_name"
         )
     )
-    assert fetched_expectation_suite.expectation_suite_name == "a_third_suite_name"
+    assert fetched_expectation_suite.name == "a_third_suite_name"
 
 
 @pytest.mark.filesystem

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -497,7 +497,7 @@ def test_add_expectation_suite_success(
                 kwargs={"column": "x", "value_set": [1, 2, 4]},
             ),
         ],
-        expectation_suite_name="default",
+        name="default",
         meta={"great_expectations_version": "0.15.44"},
     )
 
@@ -543,7 +543,7 @@ def test_add_expectation_suite_conflicting_args_failure(
     context = in_memory_data_context
     project_manager.set_project(context)
     if use_suite:
-        suite = ExpectationSuite(expectation_suite_name="default")
+        suite = ExpectationSuite(name="default")
     else:
         suite = None
 
@@ -562,7 +562,7 @@ def test_update_expectation_suite_failure(
     context = in_memory_data_context
 
     suite_name = "my_brand_new_suite"
-    suite = ExpectationSuite(expectation_suite_name=suite_name)
+    suite = ExpectationSuite(name=suite_name)
 
     with pytest.raises(gx_exceptions.ExpectationSuiteError) as e:
         _ = context.update_expectation_suite(suite)
@@ -612,7 +612,7 @@ def test_add_or_update_expectation_suite_adds_successfully(
                         kwargs={"column": "x", "value_set": [1, 2, 4]},
                     ),
                 ],
-                expectation_suite_name="default",
+                name="default",
                 meta={"great_expectations_version": "0.15.44"},
             ),
         },
@@ -631,7 +631,7 @@ def test_add_or_update_expectation_suite_adds_successfully(
 
     suite = context.add_or_update_expectation_suite(**kwargs)
 
-    assert suite.expectation_suite_name == expectation_suite_name
+    assert suite.name == expectation_suite_name
     assert suite.expectation_configurations == expectations
     assert suite.meta == meta
     assert context.expectations_store.save_count == 1
@@ -704,7 +704,7 @@ def test_add_or_update_expectation_suite_conflicting_args_failure(
     project_manager.set_project(in_memory_data_context)
 
     if use_suite:
-        suite = ExpectationSuite(expectation_suite_name="default")
+        suite = ExpectationSuite(name="default")
     else:
         suite = None
     context = in_memory_data_context

--- a/tests/datasource/fluent/integration/test_sql_datasources.py
+++ b/tests/datasource/fluent/integration/test_sql_datasources.py
@@ -578,7 +578,7 @@ class TestTableIdentifiers:
             "name": f"{datasource.name}-{asset.name}",
             "validations": [
                 {
-                    "expectation_suite_name": suite.expectation_suite_name,
+                    "expectation_suite_name": suite.name,
                     "batch_request": {
                         "datasource_name": datasource.name,
                         "data_asset_name": asset.name,
@@ -878,7 +878,7 @@ class TestColumnIdentifiers:
             "name": f"{datasource.name}-{asset.name}",
             "validations": [
                 {
-                    "expectation_suite_name": suite.expectation_suite_name,
+                    "expectation_suite_name": suite.name,
                     "batch_request": {
                         "datasource_name": datasource.name,
                         "data_asset_name": asset.name,

--- a/tests/datasource/test_pandas_datasource.py
+++ b/tests/datasource/test_pandas_datasource.py
@@ -346,7 +346,7 @@ def test_pandas_datasource_processes_dataset_options(test_folder_connection_path
     )
     batch_kwargs["dataset_options"] = {"caching": False}
     batch = datasource.get_batch(batch_kwargs)
-    validator = BridgeValidator(batch, ExpectationSuite(expectation_suite_name="foo"))
+    validator = BridgeValidator(batch, ExpectationSuite(name="foo"))
     dataset = validator.get_dataset()
     assert dataset.caching is False
 

--- a/tests/integration/cloud/end_to_end/conftest.py
+++ b/tests/integration/cloud/end_to_end/conftest.py
@@ -87,14 +87,14 @@ def validator(
 ) -> Iterator[Validator]:
     validator: Validator = context.get_validator(
         batch_request=batch_request,
-        expectation_suite_name=expectation_suite.expectation_suite_name,
+        expectation_suite_name=expectation_suite.name,
     )
     validator.head()
     yield validator
     validator.save_expectation_suite()
     expectation_suite = validator.get_expectation_suite()
     _ = context.suites.get(
-        name=expectation_suite.expectation_suite_name,
+        name=expectation_suite.name,
     )
 
 
@@ -104,18 +104,16 @@ def checkpoint(
     batch_request: BatchRequest,
     expectation_suite: ExpectationSuite,
 ) -> Iterator[Checkpoint]:
-    checkpoint_name = (
-        f"{batch_request.data_asset_name} | {expectation_suite.expectation_suite_name}"
-    )
+    checkpoint_name = f"{batch_request.data_asset_name} | {expectation_suite.name}"
     _ = context.add_checkpoint(
         name=checkpoint_name,
         validations=[
             {
-                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "expectation_suite_name": expectation_suite.name,
                 "batch_request": batch_request,
             },
             {
-                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "expectation_suite_name": expectation_suite.name,
                 "batch_request": batch_request,
             },
         ],
@@ -124,7 +122,7 @@ def checkpoint(
         name=checkpoint_name,
         validations=[
             {
-                "expectation_suite_name": expectation_suite.expectation_suite_name,
+                "expectation_suite_name": expectation_suite.name,
                 "batch_request": batch_request,
             }
         ],

--- a/tests/integration/db/awsathena.py
+++ b/tests/integration/db/awsathena.py
@@ -82,11 +82,11 @@ expectation_suite_name = "my_awsathena_expectation_suite"
 try:
     suite = context.suites.get(name=expectation_suite_name)
     print(
-        f'Loaded ExpectationSuite "{suite.expectation_suite_name}" containing {len(suite.expectations)} expectations.'
+        f'Loaded ExpectationSuite "{suite.name}" containing {len(suite.expectations)} expectations.'
     )
 except DataContextError:
     suite = context.add_expectation_suite(expectation_suite_name=expectation_suite_name)
-    print(f'Created ExpectationSuite "{suite.expectation_suite_name}".')
+    print(f'Created ExpectationSuite "{suite.name}".')
 
 validator = context.get_validator(
     batch_request=BatchRequest(**batch_request),

--- a/tests/performance/taxi_benchmark_util.py
+++ b/tests/performance/taxi_benchmark_util.py
@@ -442,5 +442,5 @@ def _add_expectation_configuration(context: AbstractDataContext, suite_name: str
     )
 
     # Save the expectation suite or else it doesn't show up in the data docs.
-    suite.expectation_suite_name = suite_name
+    suite.name = suite_name
     context.add_or_update_expectation_suite(expectation_suite=suite)

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.filesystem
 
 def test_ExpectationSuitePageRenderer_render_expectation_suite_notes():
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
-        ExpectationSuite(expectation_suite_name="test", notes="*hi*")
+        ExpectationSuite(name="test", notes="*hi*")
     )
     # print(RenderedContent.rendered_content_list_to_json(result.text))
     assert RenderedContent.rendered_content_list_to_json(result.text) == [
@@ -36,7 +36,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes():
 
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             notes=["*alpha*", "_bravo_", "charlie"],
         )
     )
@@ -62,7 +62,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes():
 
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             notes="*alpha*",
         )
     )
@@ -86,7 +86,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes():
 
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             notes=["*alpha*", "_bravo_", "charlie"],
         )
     )
@@ -124,7 +124,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes():
 def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_suite_notes():
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             meta={},
             expectations=None,
         )
@@ -136,7 +136,7 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
 
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             notes=["hi"],
         )
     )
@@ -160,7 +160,7 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
 
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
-            expectation_suite_name="test",
+            name="test",
             meta={},
             expectations=[
                 ExpectationConfiguration(

--- a/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
+++ b/tests/rule_based_profiler/data_assistant/test_data_assistant_result.py
@@ -69,11 +69,11 @@ def test_get_expectation_suite_should_use_default_name_if_none():
     )
     assert expectation_suite
     assert isinstance(expectation_suite, ExpectationSuite)
-    assert expectation_suite.expectation_suite_name
+    assert expectation_suite.name
 
     expectation_suite = data_assistant_result.get_expectation_suite(
         expectation_suite_name=None
     )
     assert expectation_suite
     assert isinstance(expectation_suite, ExpectationSuite)
-    assert expectation_suite.expectation_suite_name
+    assert expectation_suite.name

--- a/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
+++ b/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
@@ -1,5 +1,5 @@
 {
-    "expectation_suite_name": "my_dag_node.default",
+    "name": "my_dag_node.default",
     "data_asset_type": "Dataset",
     "meta": {
         "great_expectations_version": "0.9.4"

--- a/tests/test_fixtures/expectation_suites/parameterized_expression_expectation_suite_fixture.json
+++ b/tests/test_fixtures/expectation_suites/parameterized_expression_expectation_suite_fixture.json
@@ -1,5 +1,5 @@
 {
-    "expectation_suite_name": "my_dag_node.default",
+    "name": "my_dag_node.default",
     "data_asset_type": "Dataset",
     "meta": {
         "great_expectations_version": "0.9.4"

--- a/tests/test_sets/titanic_expectations.json
+++ b/tests/test_sets/titanic_expectations.json
@@ -72,6 +72,6 @@
       }
     }
   ],
-  "expectation_suite_name": "titanic",
+  "name": "titanic",
   "meta": {}
 }


### PR DESCRIPTION
`name` is preferred

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
