### PR TITLE
[MAINTENANCE] Update incorrect contract tests

### DIFF
--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -56,7 +56,7 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
 
 
 @pytest.mark.cloud
-def test_get_expectation_suite(
+def test_get_data_source_suite(
     pact_test: pact.Pact,
     cloud_data_context: CloudDataContext,
     gx_cloud_session: Session,

--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -37,9 +37,11 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
             "id": pact.Format().uuid,
             "type": "pandas",
             "attributes": {
-                "datasource_config": {
-                    "assets": pact.EachLike({}),
-                },
+                "datasource_config": pact.Like(
+                    {
+                        "assets": pact.Like([]),
+                    }
+                ),
             },
         },
     )

--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-import pathlib
-from typing import TYPE_CHECKING, Callable, Final
+from typing import TYPE_CHECKING, Final
 
 import pact
 import pytest
 
+from great_expectations.data_context import CloudDataContext
 from tests.integration.cloud.rest_contracts.conftest import (
     EXISTING_ORGANIZATION_ID,
-    ContractInteraction,
 )
 
 if TYPE_CHECKING:
+    from requests import Session
+
     from tests.integration.cloud.rest_contracts.conftest import PactBody
 
 
@@ -31,15 +32,23 @@ POST_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
     )
 }
 
+GET_DATASOURCE_NAME: Final[str] = "david_datasource"
+
 GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
     "data": pact.Like(
         {
             "id": pact.Format().uuid,
-            "type": "pandas",
+            "type": "datasource",
             "attributes": {
                 # pact doesn't test optional attributes like an empty "assets" list
                 # this is the minimum response. https://docs.pact.io/faq#why-is-there-no-support-for-specifying-optional-attributes
-                "datasource_config": pact.Like({}),
+                "datasource_config": pact.Like(
+                    {
+                        "id": pact.Format().uuid,
+                        "name": GET_DATASOURCE_NAME,
+                        "type": "pandas",
+                    }
+                ),
             },
         },
     )
@@ -47,40 +56,31 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
 
 
 @pytest.mark.cloud
-@pytest.mark.parametrize(
-    "contract_interaction",
-    [
-        # ContractInteraction(
-        #     method="POST",
-        #     request_path=pathlib.Path(
-        #         "/",
-        #         "organizations",
-        #         EXISTING_ORGANIZATION_ID,
-        #         "datasources",
-        #     ),
-        #     upon_receiving="a request to add a Data Source",
-        #     given="the Data Source does not exist",
-        #     response_status=200,
-        #     response_body=POST_DATASOURCE_MIN_RESPONSE_BODY,
-        # ),
-        ContractInteraction(
-            method="GET",
-            request_path=pathlib.Path(
-                "/",
-                "organizations",
-                EXISTING_ORGANIZATION_ID,
-                "datasources",
-                EXISTING_DATASOURCE_ID,
-            ),
-            upon_receiving="a request to get a Data Source",
-            given="the Data Source exists",
-            response_status=200,
-            response_body=GET_DATASOURCE_MIN_RESPONSE_BODY,
-        ),
-    ],
-)
-def test_datasource(
-    contract_interaction: ContractInteraction,
-    run_rest_api_pact_test: Callable[[ContractInteraction], None],
+def test_get_expectation_suite(
+    pact_test: pact.Pact,
+    cloud_data_context: CloudDataContext,
+    gx_cloud_session: Session,
 ) -> None:
-    run_rest_api_pact_test(contract_interaction)
+    provider_state = "the Data Source exists"
+    scenario = "a request to get a Data Source"
+    method = "GET"
+    path = f"/organizations/{EXISTING_ORGANIZATION_ID}/datasources/{EXISTING_DATASOURCE_ID}"
+    status = 200
+    response_body = GET_DATASOURCE_MIN_RESPONSE_BODY
+
+    (
+        pact_test.given(provider_state=provider_state)
+        .upon_receiving(scenario=scenario)
+        .with_request(
+            method=method,
+            path=path,
+            headers=dict(gx_cloud_session.headers),
+        )
+        .will_respond_with(
+            status=status,
+            body=response_body,
+        )
+    )
+
+    with pact_test:
+        cloud_data_context.get_datasource(datasource_name=GET_DATASOURCE_NAME)

--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -37,11 +37,9 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
             "id": pact.Format().uuid,
             "type": "pandas",
             "attributes": {
-                "datasource_config": pact.Like(
-                    {
-                        "assets": pact.Like([]),
-                    }
-                ),
+                # pact doesn't test optional attributes like an empty "assets" list
+                # this is the minimum response. https://docs.pact.io/faq#why-is-there-no-support-for-specifying-optional-attributes
+                "datasource_config": pact.Like({}),
             },
         },
     )

--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -46,6 +46,7 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
 }
 
 
+@pytest.mark.cloud
 @pytest.mark.parametrize(
     "contract_interaction",
     [

--- a/tests/integration/cloud/rest_contracts/test_datasource.py
+++ b/tests/integration/cloud/rest_contracts/test_datasource.py
@@ -38,9 +38,7 @@ GET_DATASOURCE_MIN_RESPONSE_BODY: Final[PactBody] = {
             "type": "pandas",
             "attributes": {
                 "datasource_config": {
-                    "assets": [
-                        {},
-                    ],
+                    "assets": pact.EachLike({}),
                 },
             },
         },

--- a/tests/integration/cloud/rest_contracts/test_expectation_suites.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suites.py
@@ -76,7 +76,6 @@ GET_EXPECTATION_SUITE_MIN_RESPONSE_BODY: Final[PactBody] = {
             "created_by_id": pact.Format().uuid,
             "organization_id": "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
             "suite": {
-                "data_asset_type": None,
                 "expectation_suite_name": pact.Like("no_checkpoint_suite"),
                 "expectations": [
                     {

--- a/tests/integration/cloud/rest_contracts/test_expectation_suites.py
+++ b/tests/integration/cloud/rest_contracts/test_expectation_suites.py
@@ -39,7 +39,6 @@ POST_EXPECTATION_SUITE_MIN_REQUEST_BODY: Final[PactBody] = {
                     },
                 ],
                 "expectation_suite_name": "brand new suite",
-                "data_asset_type": "pandas",
             },
             "organization_id": EXISTING_ORGANIZATION_ID,
         },


### PR DESCRIPTION
Update contract tests to reflect correct error messages from Mercury given our seed data.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [x] Appropriate tests and docs have been updated
