### PR TITLE
[MAINTENANCE] Backfill test around BatchConfig partitioners being used by validators

### DIFF
--- a/tests/datasource/fluent/integration/test_integration_datasource.py
+++ b/tests/datasource/fluent/integration/test_integration_datasource.py
@@ -455,8 +455,8 @@ def test_partitioner_build_batch_request_allows_selecting_by_date_and_datetime_a
         (2, 342),
     ],
 )
+@pytest.mark.sqlite
 def test_success_with_partitioners_from_batch_configs(
-    self,
     empty_data_context,
     month: int,
     expected: int,


### PR DESCRIPTION
Adds a test to show that partitioners from batch configs are used.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
