### PR TITLE
[MAINTENANCE] Add Sorters to BatchConfig

### DIFF
--- a/great_expectations/core/batch_config.py
+++ b/great_expectations/core/batch_config.py
@@ -26,7 +26,7 @@ class BatchConfig(pydantic.BaseModel):
     id: Optional[str] = None
     name: str
     partitioner: Optional[Partitioner] = None
-    sorters: List[Sorter]
+    sorters: List[Sorter] = pydantic.Field(default_factory=list)
 
     # private attributes that must be set immediately after instantiation
     _data_asset: DataAsset = pydantic.PrivateAttr()

--- a/great_expectations/core/batch_config.py
+++ b/great_expectations/core/batch_config.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from great_expectations.compatibility import pydantic
 
-# if we move this import into the TYPE_CHECKING block, we need to provide the
+# if we move these imports into the TYPE_CHECKING block, we need to provide the
 # Partitioner class when we update forward refs, so we just import here.
 from great_expectations.core.partitioners import Partitioner  # noqa: TCH001
+from great_expectations.core.sorters import Sorter  # noqa: TCH001
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent.batch_request import (
@@ -25,6 +26,7 @@ class BatchConfig(pydantic.BaseModel):
     id: Optional[str] = None
     name: str
     partitioner: Optional[Partitioner] = None
+    sorters: List[Sorter]
 
     # private attributes that must be set immediately after instantiation
     _data_asset: DataAsset = pydantic.PrivateAttr()

--- a/great_expectations/core/sorters.py
+++ b/great_expectations/core/sorters.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Union
+
+from great_expectations.compatibility.pydantic import dataclasses as pydantic_dc
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias, TypeGuard
+
+
+@pydantic_dc.dataclass(frozen=True)
+class Sorter:
+    key: str
+    reverse: bool = False
+
+    @classmethod
+    def sorter_from_list(cls, sorters: SortersDefinition) -> List[Sorter]:
+        return _sorter_from_list(sorters=sorters)
+
+    @classmethod
+    def sorter_from_str(cls, sort_key: str) -> Sorter:
+        return _sorter_from_str(sort_key=sort_key)
+
+
+SortersDefinition: TypeAlias = List[Union[Sorter, str, dict]]
+
+
+def _is_sorter_list(
+    sorters: SortersDefinition,
+) -> TypeGuard[list[Sorter]]:
+    if len(sorters) == 0 or isinstance(sorters[0], Sorter):
+        return True
+    return False
+
+
+def _is_str_sorter_list(sorters: SortersDefinition) -> TypeGuard[list[str]]:
+    if len(sorters) > 0 and isinstance(sorters[0], str):
+        return True
+    return False
+
+
+def _sorter_from_list(sorters: SortersDefinition) -> list[Sorter]:
+    if _is_sorter_list(sorters):
+        return sorters
+
+    # mypy doesn't successfully type-narrow sorters to a list[str] here, so we use
+    # another TypeGuard. We could cast instead which may be slightly faster.
+    sring_valued_sorter: str
+    if _is_str_sorter_list(sorters):
+        return [
+            _sorter_from_str(sring_valued_sorter) for sring_valued_sorter in sorters
+        ]
+
+    # This should never be reached because of static typing but is necessary because
+    # mypy doesn't know of the if conditions must evaluate to True.
+    raise ValueError(f"sorters is a not a SortersDefinition but is a {type(sorters)}")
+
+
+def _sorter_from_str(sort_key: str) -> Sorter:
+    """Convert a list of strings to Sorter objects
+
+    Args:
+        sort_key: A batch metadata key which will be used to sort batches on a data asset.
+                  This can be prefixed with a + or - to indicate increasing or decreasing
+                  sorting.  If not specified, defaults to increasing order.
+    """
+    if sort_key[0] == "-":
+        return Sorter(key=sort_key[1:], reverse=True)
+
+    if sort_key[0] == "+":
+        return Sorter(key=sort_key[1:], reverse=False)
+
+    return Sorter(key=sort_key, reverse=False)

--- a/great_expectations/datasource/fluent/__init__.py
+++ b/great_expectations/datasource/fluent/__init__.py
@@ -5,11 +5,11 @@ import pathlib
 from great_expectations.datasource.fluent.interfaces import (
     DataAsset,
     Datasource,
-    Sorter,
     BatchMetadata,
     GxDatasourceWarning,
     TestConnectionError,
 )
+from great_expectations.core.sorters import Sorter
 
 # Now that DataAsset has both been defined, we need to
 # provide it to the BatchConfig pydantic model.

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.pyi
@@ -16,6 +16,7 @@ from typing import (
 from great_expectations._docs_decorators import public_api as public_api
 from great_expectations.compatibility import azure
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
 from great_expectations.core.util import AzureUrl as AzureUrl
 from great_expectations.datasource.fluent import _PandasFilePathDatasource
 from great_expectations.datasource.fluent.config_str import ConfigStr
@@ -33,9 +34,6 @@ from great_expectations.datasource.fluent.dynamic_pandas import (
     StorageOptions,
 )
 from great_expectations.datasource.fluent.interfaces import BatchMetadata
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
-)
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,
 )

--- a/great_expectations/datasource/fluent/pandas_dbfs_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_dbfs_datasource.pyi
@@ -5,7 +5,9 @@ from typing import Hashable, Iterable, Literal, Optional, Sequence, Union
 
 from great_expectations._docs_decorators import public_api as public_api
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.datasource.fluent import PandasFilesystemDatasource, Sorter
+from great_expectations.core.sorters import Sorter
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
+from great_expectations.datasource.fluent import PandasFilesystemDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     DBFSDataConnector as DBFSDataConnector,
 )
@@ -17,9 +19,6 @@ from great_expectations.datasource.fluent.dynamic_pandas import (
     StorageOptions,
 )
 from great_expectations.datasource.fluent.interfaces import BatchMetadata
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
-)
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,
 )

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.pyi
@@ -14,7 +14,9 @@ from typing import (
 
 from great_expectations._docs_decorators import public_api as public_api
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.datasource.fluent import Sorter, _PandasFilePathDatasource
+from great_expectations.core.sorters import Sorter
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
+from great_expectations.datasource.fluent import _PandasFilePathDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector as FilesystemDataConnector,
 )
@@ -26,9 +28,6 @@ from great_expectations.datasource.fluent.dynamic_pandas import (
     StorageOptions,
 )
 from great_expectations.datasource.fluent.interfaces import BatchMetadata
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
-)
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,
 )

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.pyi
@@ -16,6 +16,7 @@ from typing import (
 from great_expectations._docs_decorators import public_api as public_api
 from great_expectations.compatibility import google
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
 from great_expectations.core.util import GCSUrl as GCSUrl
 from great_expectations.datasource.fluent import _PandasFilePathDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
@@ -32,9 +33,6 @@ from great_expectations.datasource.fluent.dynamic_pandas import (
     StorageOptions,
 )
 from great_expectations.datasource.fluent.interfaces import BatchMetadata
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
-)
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,
 )

--- a/great_expectations/datasource/fluent/pandas_s3_datasource.pyi
+++ b/great_expectations/datasource/fluent/pandas_s3_datasource.pyi
@@ -17,6 +17,7 @@ from botocore.client import BaseClient as BaseClient
 
 from great_expectations._docs_decorators import public_api as public_api
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
 from great_expectations.core.util import S3Url as S3Url
 from great_expectations.datasource.fluent import _PandasFilePathDatasource
 from great_expectations.datasource.fluent.config_str import ConfigStr
@@ -34,9 +35,6 @@ from great_expectations.datasource.fluent.dynamic_pandas import (
     StorageOptions,
 )
 from great_expectations.datasource.fluent.interfaces import BatchMetadata
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
-)
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,
 )

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource.json
@@ -373,6 +373,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/DatabricksTableAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/DatabricksSQLDatasource/QueryAsset.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/Datasource.json
@@ -318,6 +318,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIDax.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBIMeasure.json
@@ -376,6 +376,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
+++ b/great_expectations/datasource/fluent/schemas/FabricPowerBIDatasource/PowerBITable.json
@@ -360,6 +360,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/CSVAsset.json
@@ -644,6 +644,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ExcelAsset.json
@@ -535,6 +535,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FWFAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/FeatherAsset.json
@@ -358,6 +358,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HDFAsset.json
@@ -396,6 +396,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/HTMLAsset.json
@@ -456,6 +456,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/JSONAsset.json
@@ -443,6 +443,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ORCAsset.json
@@ -354,6 +354,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/ParquetAsset.json
@@ -368,6 +368,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/PickleAsset.json
@@ -367,6 +367,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SASAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/SPSSAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/StataAsset.json
@@ -412,6 +412,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasAzureBlobStorageDatasource/XMLAsset.json
@@ -420,6 +420,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource.json
@@ -332,6 +332,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/CSVAsset.json
@@ -644,6 +644,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ExcelAsset.json
@@ -535,6 +535,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FWFAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/FeatherAsset.json
@@ -358,6 +358,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HDFAsset.json
@@ -396,6 +396,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/HTMLAsset.json
@@ -456,6 +456,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/JSONAsset.json
@@ -443,6 +443,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ORCAsset.json
@@ -354,6 +354,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/ParquetAsset.json
@@ -368,6 +368,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/PickleAsset.json
@@ -367,6 +367,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SASAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/SPSSAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/StataAsset.json
@@ -412,6 +412,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDBFSDatasource/XMLAsset.json
@@ -420,6 +420,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource.json
@@ -321,6 +321,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/CSVAsset.json
@@ -650,6 +650,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ClipboardAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/DataFrameAsset.json
@@ -334,6 +334,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ExcelAsset.json
@@ -541,6 +541,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FWFAsset.json
@@ -390,6 +390,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/FeatherAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/GBQAsset.json
@@ -388,6 +388,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HDFAsset.json
@@ -402,6 +402,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/HTMLAsset.json
@@ -462,6 +462,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/JSONAsset.json
@@ -449,6 +449,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ORCAsset.json
@@ -360,6 +360,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/ParquetAsset.json
@@ -374,6 +374,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/PickleAsset.json
@@ -373,6 +373,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SASAsset.json
@@ -390,6 +390,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SPSSAsset.json
@@ -370,6 +370,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLQueryAsset.json
@@ -411,6 +411,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SQLTableAsset.json
@@ -403,6 +403,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/SqlAsset.json
@@ -386,6 +386,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/StataAsset.json
@@ -418,6 +418,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/TableAsset.json
@@ -646,6 +646,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasDatasource/XMLAsset.json
@@ -426,6 +426,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -332,6 +332,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/CSVAsset.json
@@ -644,6 +644,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ExcelAsset.json
@@ -535,6 +535,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FWFAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/FeatherAsset.json
@@ -358,6 +358,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HDFAsset.json
@@ -396,6 +396,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/HTMLAsset.json
@@ -456,6 +456,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/JSONAsset.json
@@ -443,6 +443,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ORCAsset.json
@@ -354,6 +354,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/ParquetAsset.json
@@ -368,6 +368,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/PickleAsset.json
@@ -367,6 +367,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SASAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/SPSSAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/StataAsset.json
@@ -412,6 +412,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource/XMLAsset.json
@@ -420,6 +420,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/CSVAsset.json
@@ -644,6 +644,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ExcelAsset.json
@@ -535,6 +535,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FWFAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/FeatherAsset.json
@@ -358,6 +358,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HDFAsset.json
@@ -396,6 +396,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/HTMLAsset.json
@@ -456,6 +456,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/JSONAsset.json
@@ -443,6 +443,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ORCAsset.json
@@ -354,6 +354,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/ParquetAsset.json
@@ -368,6 +368,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/PickleAsset.json
@@ -367,6 +367,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SASAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/SPSSAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/StataAsset.json
@@ -412,6 +412,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasGoogleCloudStorageDatasource/XMLAsset.json
@@ -420,6 +420,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/CSVAsset.json
@@ -644,6 +644,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ExcelAsset.json
@@ -535,6 +535,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FWFAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/FeatherAsset.json
@@ -358,6 +358,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HDFAsset.json
@@ -396,6 +396,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/HTMLAsset.json
@@ -456,6 +456,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/JSONAsset.json
@@ -443,6 +443,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ORCAsset.json
@@ -354,6 +354,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/ParquetAsset.json
@@ -368,6 +368,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/PickleAsset.json
@@ -367,6 +367,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SASAsset.json
@@ -384,6 +384,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/SPSSAsset.json
@@ -364,6 +364,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/StataAsset.json
@@ -412,6 +412,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PandasS3Datasource/XMLAsset.json
@@ -420,6 +420,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource.json
@@ -373,6 +373,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/QueryAsset.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/PostgresDatasource/TableAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource.json
@@ -370,6 +370,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/QueryAsset.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SQLDatasource/TableAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource.json
@@ -376,6 +376,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/QueryAsset.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SnowflakeDatasource/TableAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource.json
@@ -403,6 +403,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/CSVAsset.json
@@ -591,6 +591,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DeltaAsset.json
@@ -350,6 +350,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryCSVAsset.json
@@ -597,6 +597,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryDeltaAsset.json
@@ -356,6 +356,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryJSONAsset.json
@@ -568,6 +568,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryORCAsset.json
@@ -404,6 +404,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryParquetAsset.json
@@ -421,6 +421,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/DirectoryTextAsset.json
@@ -401,6 +401,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/JSONAsset.json
@@ -562,6 +562,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ORCAsset.json
@@ -398,6 +398,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/ParquetAsset.json
@@ -415,6 +415,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkAzureBlobStorageDatasource/TextAsset.json
@@ -395,6 +395,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -399,6 +399,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/CSVAsset.json
@@ -591,6 +591,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DeltaAsset.json
@@ -350,6 +350,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryCSVAsset.json
@@ -597,6 +597,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryDeltaAsset.json
@@ -356,6 +356,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryJSONAsset.json
@@ -568,6 +568,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryORCAsset.json
@@ -404,6 +404,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryParquetAsset.json
@@ -421,6 +421,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/DirectoryTextAsset.json
@@ -401,6 +401,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/JSONAsset.json
@@ -562,6 +562,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ORCAsset.json
@@ -398,6 +398,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/ParquetAsset.json
@@ -415,6 +415,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource/TextAsset.json
@@ -395,6 +395,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource.json
@@ -351,6 +351,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDatasource/DataFrameAsset.json
@@ -334,6 +334,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource.json
@@ -399,6 +399,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/CSVAsset.json
@@ -591,6 +591,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DeltaAsset.json
@@ -350,6 +350,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryCSVAsset.json
@@ -597,6 +597,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryDeltaAsset.json
@@ -356,6 +356,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryJSONAsset.json
@@ -568,6 +568,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryORCAsset.json
@@ -404,6 +404,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryParquetAsset.json
@@ -421,6 +421,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/DirectoryTextAsset.json
@@ -401,6 +401,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/JSONAsset.json
@@ -562,6 +562,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ORCAsset.json
@@ -398,6 +398,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/ParquetAsset.json
@@ -415,6 +415,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkFilesystemDatasource/TextAsset.json
@@ -395,6 +395,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource.json
@@ -408,6 +408,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/CSVAsset.json
@@ -591,6 +591,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DeltaAsset.json
@@ -350,6 +350,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryCSVAsset.json
@@ -597,6 +597,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryDeltaAsset.json
@@ -356,6 +356,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryJSONAsset.json
@@ -568,6 +568,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryORCAsset.json
@@ -404,6 +404,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryParquetAsset.json
@@ -421,6 +421,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/DirectoryTextAsset.json
@@ -401,6 +401,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/JSONAsset.json
@@ -562,6 +562,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ORCAsset.json
@@ -398,6 +398,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/ParquetAsset.json
@@ -415,6 +415,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkGoogleCloudStorageDatasource/TextAsset.json
@@ -395,6 +395,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource.json
@@ -408,6 +408,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/CSVAsset.json
@@ -591,6 +591,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DeltaAsset.json
@@ -350,6 +350,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryCSVAsset.json
@@ -597,6 +597,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryDeltaAsset.json
@@ -356,6 +356,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryJSONAsset.json
@@ -568,6 +568,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryORCAsset.json
@@ -404,6 +404,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryParquetAsset.json
@@ -421,6 +421,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/DirectoryTextAsset.json
@@ -401,6 +401,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/JSONAsset.json
@@ -562,6 +562,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ORCAsset.json
@@ -398,6 +398,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/ParquetAsset.json
@@ -415,6 +415,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SparkS3Datasource/TextAsset.json
@@ -395,6 +395,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource.json
@@ -373,6 +373,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -336,6 +336,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/datasource/fluent/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -341,6 +341,13 @@
                             "$ref": "#/definitions/PartitionerConvertedDatetime"
                         }
                     ]
+                },
+                "sorters": {
+                    "title": "Sorters",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sorter"
+                    }
                 }
             },
             "required": [

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.pyi
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.pyi
@@ -3,6 +3,7 @@ from logging import Logger
 from typing import Any, ClassVar, Literal, Optional, Type
 
 from great_expectations.compatibility import azure
+from great_expectations.core.sorters import SortersDefinition
 from great_expectations.datasource.fluent import _SparkFilePathDatasource
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
@@ -12,7 +13,6 @@ from great_expectations.datasource.fluent.data_asset.data_connector import (
 )
 from great_expectations.datasource.fluent.interfaces import (
     BatchMetadata,
-    SortersDefinition,
 )
 from great_expectations.datasource.fluent.spark_datasource import (
     SparkDatasourceError,

--- a/great_expectations/datasource/fluent/spark_dbfs_datasource.pyi
+++ b/great_expectations/datasource/fluent/spark_dbfs_datasource.pyi
@@ -7,15 +7,13 @@ from great_expectations.compatibility.pyspark import (
     types as pyspark_types,
 )
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.sorters import SortersDefinition as SortersDefinition
 from great_expectations.datasource.fluent import SparkFilesystemDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     DBFSDataConnector as DBFSDataConnector,
 )
 from great_expectations.datasource.fluent.interfaces import (
     BatchMetadata,
-)
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition as SortersDefinition,
 )
 from great_expectations.datasource.fluent.interfaces import (
     TestConnectionError as TestConnectionError,

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.pyi
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.pyi
@@ -6,12 +6,10 @@ from typing import ClassVar, Literal, Optional, Type, Union
 from great_expectations.compatibility.pyspark import (
     types as pyspark_types,
 )
+from great_expectations.core.sorters import SortersDefinition
 from great_expectations.datasource.fluent import BatchMetadata, _SparkFilePathDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector,
-)
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition,
 )
 from great_expectations.datasource.fluent.spark_file_path_datasource import (
     CSVAsset,

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.pyi
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.pyi
@@ -3,15 +3,13 @@ from logging import Logger
 from typing import Any, ClassVar, Literal, Optional, Type
 
 from great_expectations.compatibility import google
+from great_expectations.core.sorters import SortersDefinition
 from great_expectations.datasource.fluent import BatchMetadata, _SparkFilePathDatasource
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
 )
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     GoogleCloudStorageDataConnector,
-)
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition,
 )
 from great_expectations.datasource.fluent.spark_file_path_datasource import (
     CSVAsset,

--- a/great_expectations/datasource/fluent/spark_s3_datasource.pyi
+++ b/great_expectations/datasource/fluent/spark_s3_datasource.pyi
@@ -2,15 +2,13 @@ import re
 from logging import Logger
 from typing import Any, ClassVar, Literal, Optional, Type
 
+from great_expectations.core.sorters import SortersDefinition
 from great_expectations.datasource.fluent import BatchMetadata, _SparkFilePathDatasource
 from great_expectations.datasource.fluent.config_str import (
     ConfigStr,
 )
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     S3DataConnector,
-)
-from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition,
 )
 from great_expectations.datasource.fluent.spark_file_path_datasource import (
     CSVAsset,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -60,8 +60,6 @@ from great_expectations.datasource.fluent.interfaces import (
     DataAsset,
     Datasource,
     GxDatasourceWarning,
-    Sorter,
-    SortersDefinition,
     TestConnectionError,
 )
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
@@ -76,6 +74,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import quoted_name  # noqa: TID251 # type-checking only
 
     from great_expectations.compatibility import sqlalchemy
+    from great_expectations.core.sorters import Sorter, SortersDefinition
     from great_expectations.datasource.fluent import BatchRequestOptions
     from great_expectations.datasource.fluent.interfaces import (
         BatchMetadata,

--- a/great_expectations/datasource/fluent/sqlite_datasource.py
+++ b/great_expectations/datasource/fluent/sqlite_datasource.py
@@ -35,12 +35,13 @@ from great_expectations.datasource.fluent.sql_datasource import (
 if TYPE_CHECKING:
     # min version of typing_extension missing `Self`, so it can't be imported at runtime
 
+    from great_expectations.core.sorters import SortersDefinition
     from great_expectations.datasource.fluent.interfaces import (
         BatchMetadata,
         BatchRequestOptions,
         DataAsset,
-        SortersDefinition,
     )
+
 
 # This module serves as an example of how to extend _SQLAssets for specific backends. The steps are:
 # 1. Create a plain class with the extensions necessary for the specific backend.

--- a/great_expectations/experimental/datasource/fabric.py
+++ b/great_expectations/experimental/datasource/fabric.py
@@ -27,13 +27,13 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import pydantic
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch_spec import FabricBatchSpec
+from great_expectations.core.sorters import Sorter
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
 from great_expectations.datasource.fluent.interfaces import (
     Batch,
     DataAsset,
     Datasource,
-    Sorter,
     TestConnectionError,
 )
 

--- a/tests/datasource/fluent/test_pandas_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_pandas_filesystem_datasource.py
@@ -30,11 +30,11 @@ from great_expectations.datasource.fluent.sources import _get_field_details
 
 if TYPE_CHECKING:
     from great_expectations.alias_types import PathStr
+    from great_expectations.core.sorters import SortersDefinition
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.interfaces import (
         BatchMetadata,
         BatchSlice,
-        SortersDefinition,
     )
 
 logger = logging.getLogger(__file__)

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -35,6 +35,7 @@ from great_expectations.core.partitioners import (
     PartitionerYearAndMonth,
     PartitionerYearAndMonthAndDay,
 )
+from great_expectations.core.sorters import Sorter
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
@@ -44,7 +45,6 @@ from great_expectations.datasource.fluent.batch_request import (
     BatchRequestOptions,
 )
 from great_expectations.datasource.fluent.interfaces import (
-    Sorter,
     TestConnectionError,
 )
 from great_expectations.datasource.fluent.postgres_datasource import (

--- a/tests/datasource/fluent/test_spark_filesystem_datasource.py
+++ b/tests/datasource/fluent/test_spark_filesystem_datasource.py
@@ -18,12 +18,12 @@ from great_expectations.core.partitioners import (
     PartitionerColumnValue,
     PartitionerYearAndMonth,
 )
+from great_expectations.core.sorters import SortersDefinition
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector,
 )
 from great_expectations.datasource.fluent.file_path_data_asset import _FilePathDataAsset
 from great_expectations.datasource.fluent.interfaces import (
-    SortersDefinition,
     TestConnectionError,
 )
 from great_expectations.datasource.fluent.spark_file_path_datasource import (


### PR DESCRIPTION
This PR adds `BatchConfig.sorters`. It also moves the Sorter definition into Core, since they are now primarily a property of BatchConfig. It also includes a small refactor to make stand alone functions related to Sorters available via the Sorter object as class level methods.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
