### PR TITLE
[DOCS] Updating breadcrumbs styles

### DIFF
--- a/docs/docusaurus/src/css/breadcrumbs.scss
+++ b/docs/docusaurus/src/css/breadcrumbs.scss
@@ -1,0 +1,14 @@
+:root {
+  --ifm-breadcrumb-spacing: 0;
+  --ifm-breadcrumb-size-multiplier: 1;
+}
+
+.breadcrumbs .breadcrumbs__link {
+  background: none;
+  color: var(--ifm-color-primary);
+
+  &:any-link:hover {
+    background: none;
+    color: var(--link-hover-color);
+  }
+}

--- a/docs/docusaurus/src/css/custom.scss
+++ b/docs/docusaurus/src/css/custom.scss
@@ -9,6 +9,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap');
 
+@import "sass_variables";
 @import "typography.scss";
 @import "left_navigation.scss";
 @import "navbar.scss";
@@ -17,8 +18,7 @@
 @import "alerts.scss";
 @import "pagination.scss";
 @import "overview_pages";
-@import "sass_variables";
-
+@import "breadcrumbs.scss";
 /* You can override the default Infima variables here. */
 :root {
     --ifm-font-color-base: #404041;


### PR DESCRIPTION
# Description 

Updating breadcrums styles based on [this mockup](https://xd.adobe.com/view/9ef7232c-80ce-4ad7-9c3f-1a96126f84b4-cba4/screen/b06033cc-5ac9-4d19-b4fa-547a1138f2d0/)

[Deploy Preview](https://deploy-preview-9554.docs.greatexpectations.io/)

## Previous style

![image](https://github.com/great-expectations/great_expectations/assets/38264052/067bbd63-f902-4b7e-b217-a2a7f01611a3)

### On hover:
![image](https://github.com/great-expectations/great_expectations/assets/38264052/f16ff309-7080-4055-89b5-d2567b30cdb9)


## New Style

![image](https://github.com/great-expectations/great_expectations/assets/38264052/10706be8-cd3d-4c0f-b7a7-c9e070b210d3)

### On hover:

![image](https://github.com/great-expectations/great_expectations/assets/38264052/763b34c7-5869-4ad7-abbe-621d33fbbd60)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
