### PR TITLE
[DOCS] Update font size of left navigation

### DIFF
--- a/docs/docusaurus/src/css/left_navigation.scss
+++ b/docs/docusaurus/src/css/left_navigation.scss
@@ -1,6 +1,6 @@
 .theme-doc-sidebar-item-link,
 .theme-doc-sidebar-item-category {
-  font-size: var(--p-sm-font-size);
+  font-size: var(--p-md-font-size);
   font-weight: var(--ifm-font-weight-normal);
 }
 


### PR DESCRIPTION
# Description
- All font sizes in left navigation sidebar have now a font size of 1rem (16px)

# Screenshots
![Captura desde 2024-03-01 16-51-46](https://github.com/great-expectations/great_expectations/assets/7197057/c4362abc-e07f-453e-9ac9-58bb1b84217f)

![Captura desde 2024-03-01 16-52-25](https://github.com/great-expectations/great_expectations/assets/7197057/91e759a4-ce8d-4836-8888-0b827240af92)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
