### PR TITLE
[DOCS] Hide duplicate tabs

### DIFF
--- a/docs/docusaurus/docs/oss/guides/setup/installation/components_local/_install_great_expectations.mdx
+++ b/docs/docusaurus/docs/oss/guides/setup/installation/components_local/_install_great_expectations.mdx
@@ -17,6 +17,7 @@ Once you have your virtual environment created and activated, you will be able t
 <Tabs
   groupId="pip-or-conda"
   defaultValue='pip'
+  className="hidden"
   values={[
   {label: 'pip', value:'pip'},
   {label: 'conda', value:'conda'},

--- a/docs/docusaurus/src/css/tabs.scss
+++ b/docs/docusaurus/src/css/tabs.scss
@@ -8,6 +8,10 @@ div[role="tabpanel"]{
   font-weight: var(--ifm-font-weight-normal);
   line-height: var(--p-line-height);
 
+  &.hidden {
+    display: none;
+  }
+
   & .tabs__item--active {
     border-bottom: 0;
     font-weight: var(--ifm-font-weight-bold);

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/installation/components_local/_install_great_expectations.mdx
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/setup/installation/components_local/_install_great_expectations.mdx
@@ -17,6 +17,7 @@ Once you have your virtual environment created and activated, you will be able t
 <Tabs
   groupId="pip-or-conda"
   defaultValue='pip'
+  className="hidden"
   values={[
   {label: 'pip', value:'pip'},
   {label: 'conda', value:'conda'},


### PR DESCRIPTION
# Description
If `className="hidden"` is added to a Tabs component, it will have its tabs hidden (useful for nested tabs inside the same document that will always have the same value).

You can check this does not break the logic of switching tabs, there's an example in this page: [https://deploy-preview-9570.docs.greatexpectations.io/docs/oss/guides/setup/installation/install_gx](). If you select `pip` or `conda` tabs inside the `local` tab, you will see the content is updated properly, even though the second set of tabs that previously showed options `pip` and `conda` again is hidden.

# Screenshots
## Before
![screencapture-docs-greatexpectations-io-docs-oss-guides-setup-installation-install-gx-2024-03-04-15_31_27](https://github.com/great-expectations/great_expectations/assets/7197057/bb3e6714-81c9-4468-bea6-41a18b02b9bf)

## After
![screencapture-localhost-3000-docs-oss-guides-setup-installation-install-gx-2024-03-04-15_31_56](https://github.com/great-expectations/great_expectations/assets/7197057/d6667295-7ab5-4e7d-92bf-5b9bdff9bd1d)

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `black` + `ruff`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
