### PR TITLE
[MAINTENANCE] Ban direct `unittest.mock.Mock/MagicMock` usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,12 @@ filterwarnings = [
     # PendingDeprecationWarning: these relate to the use of methods that are not even deprecated yet.
     # We want to see the warnings in the logs, but not have them cause CI to fail.
     "once::PendingDeprecationWarning",
+    # Generally we shouldn't need to use a context manger with `mocker` but it can be useful
+    # if we want the patch/mock to end before the test finishes.
+    # Example: Mocks returned by pytest-mock do not need to be used as context managers.
+    # The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager.
+    # https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
+    "default::pytest_mock.plugin.PytestMockWarning",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -650,7 +650,7 @@ def test_api_action_run(
     validation_result_suite_id,
     data_context_simple_expectation_suite,
 ):
-    mock_response = mock.MagicMock()
+    mock_response = mock.MagicMock()  # noqa: TID251
     mock_response.status_code = 200
     mock_requests.post.return_value = mock_response
     api_notification_action = APINotificationAction(

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from freezegun import freeze_time
+from pytest_mock import MockerFixture
 from requests import Session
 
 from great_expectations.checkpoint.actions import (
@@ -649,8 +650,9 @@ def test_api_action_run(
     validation_result_suite,
     validation_result_suite_id,
     data_context_simple_expectation_suite,
+    mocker: MockerFixture,
 ):
-    mock_response = mock.MagicMock()  # noqa: TID251
+    mock_response = mocker.MagicMock()
     mock_response.status_code = 200
     mock_requests.post.return_value = mock_response
     api_notification_action = APINotificationAction(

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -2651,7 +2651,7 @@ def test_run_spark_checkpoint_with_schema(
 def test_checkpoint_conflicting_validator_and_validation_args_raises_error(
     validator_with_mock_execution_engine,
 ):
-    context = mock.MagicMock()
+    context = mock.MagicMock()  # noqa: TID251
     validator = validator_with_mock_execution_engine
     validations = [
         {

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -6,7 +6,6 @@ import pathlib
 import pickle
 import shutil
 from typing import TYPE_CHECKING, Dict, Optional, Union, cast
-from unittest import mock
 
 import pandas as pd
 import pytest
@@ -39,10 +38,13 @@ from great_expectations.validator.validator import Validator
 from tests.checkpoint import cloud_config
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from great_expectations.core.data_context_key import DataContextKey
     from great_expectations.data_context.data_context.ephemeral_data_context import (
         EphemeralDataContext,
     )
+
 
 yaml = YAMLHandler()
 
@@ -2650,8 +2652,9 @@ def test_run_spark_checkpoint_with_schema(
 @pytest.mark.unit
 def test_checkpoint_conflicting_validator_and_validation_args_raises_error(
     validator_with_mock_execution_engine,
+    mocker: MockerFixture,
 ):
-    context = mock.MagicMock()  # noqa: TID251
+    context = mocker.MagicMock()
     validator = validator_with_mock_execution_engine
     validations = [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,8 @@ from tests.rule_based_profiler.parameter_builder.conftest import (
 )
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from great_expectations.compatibility import pyspark
     from great_expectations.compatibility.sqlalchemy import Engine
 
@@ -3511,7 +3513,7 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode(
-    mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation  # noqa: TID251
+    mock_list_keys: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -3626,7 +3628,7 @@ def empty_cloud_context_fluent(
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode_custom_base_url(
-    mock_get_all: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation  # noqa: TID251
+    mock_get_all: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -8265,8 +8267,8 @@ def ephemeral_context_with_defaults() -> EphemeralDataContext:
 
 
 @pytest.fixture
-def validator_with_mock_execution_engine() -> Validator:
-    execution_engine = mock.MagicMock()  # noqa: TID251
+def validator_with_mock_execution_engine(mocker: MockerFixture) -> Validator:
+    execution_engine = mocker.MagicMock()
     validator = Validator(execution_engine=execution_engine)
     return validator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,8 @@ from tests.rule_based_profiler.parameter_builder.conftest import (
 )
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock  # noqa: TID251 # type-checking only
+
     from pytest_mock import MockerFixture
 
     from great_expectations.compatibility import pyspark
@@ -3512,7 +3514,7 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode(
-    mock_list_keys: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_list_keys: Mock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -3627,7 +3629,7 @@ def empty_cloud_context_fluent(
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode_custom_base_url(
-    mock_get_all: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_get_all: Mock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3511,7 +3511,7 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode(
-    mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation  # noqa: TID251
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -3626,7 +3626,7 @@ def empty_cloud_context_fluent(
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode_custom_base_url(
-    mock_get_all: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_get_all: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation  # noqa: TID251
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -8266,7 +8266,7 @@ def ephemeral_context_with_defaults() -> EphemeralDataContext:
 
 @pytest.fixture
 def validator_with_mock_execution_engine() -> Validator:
-    execution_engine = mock.MagicMock()
+    execution_engine = mock.MagicMock()  # noqa: TID251
     validator = Validator(execution_engine=execution_engine)
     return validator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,8 @@ from tests.rule_based_profiler.parameter_builder.conftest import (
 )
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock  # noqa: TID251 # type-checking only
+
     from pytest_mock import MockerFixture
 
     from great_expectations.compatibility import pyspark
@@ -3512,7 +3514,7 @@ def ge_cloud_config_e2e() -> GXCloudConfig:
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode(
-    mock_list_keys: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_list_keys: MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,
@@ -3627,7 +3629,7 @@ def empty_cloud_context_fluent(
     return_value=[],
 )
 def empty_base_data_context_in_cloud_mode_custom_base_url(
-    mock_get_all: MockerFixture,  # Avoid making a call to Cloud backend during datasource instantiation
+    mock_get_all: MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GXCloudConfig,

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -71,7 +71,7 @@ def test_checkpoint_factory_get_raises_error_on_missing_key(
     store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
     store.get.return_value = checkpoint_dict
-    context = MockerFixture(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
 

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -1,6 +1,5 @@
-from unittest.mock import Mock  # noqa: TID251
-
 import pytest
+from pytest_mock import MockerFixture
 
 from great_expectations import set_context
 from great_expectations.checkpoint.checkpoint import Checkpoint
@@ -42,14 +41,16 @@ def _assert_checkpoint_equality(actual: Checkpoint, expected: Checkpoint):
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_get_uses_store_get(checkpoint_dict: dict):
+def test_checkpoint_factory_get_uses_store_get(
+    checkpoint_dict: dict, mocker: MockerFixture
+):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
     store.get.return_value = checkpoint_dict
-    context = Mock(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
 
@@ -62,13 +63,15 @@ def test_checkpoint_factory_get_uses_store_get(checkpoint_dict: dict):
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_get_raises_error_on_missing_key(checkpoint_dict: dict):
+def test_checkpoint_factory_get_raises_error_on_missing_key(
+    checkpoint_dict: dict, mocker: MockerFixture
+):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
     store.get.return_value = checkpoint_dict
-    context = Mock(spec=AbstractDataContext)
+    context = MockerFixture(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
 
@@ -83,13 +86,13 @@ def test_checkpoint_factory_get_raises_error_on_missing_key(checkpoint_dict: dic
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_add_uses_store_add():
+def test_checkpoint_factory_add_uses_store_add(mocker: MockerFixture):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
     key = store.get_key.return_value
-    context = Mock(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
     checkpoint = Checkpoint(name=name)
@@ -104,12 +107,12 @@ def test_checkpoint_factory_add_uses_store_add():
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_add_raises_for_duplicate_key():
+def test_checkpoint_factory_add_raises_for_duplicate_key(mocker: MockerFixture):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = True
-    context = Mock(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
     checkpoint = Checkpoint(name=name)
@@ -126,13 +129,13 @@ def test_checkpoint_factory_add_raises_for_duplicate_key():
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_delete_uses_store_remove_key():
+def test_checkpoint_factory_delete_uses_store_remove_key(mocker: MockerFixture):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
-    context = Mock(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
     checkpoint = Checkpoint(name=name)
@@ -147,12 +150,12 @@ def test_checkpoint_factory_delete_uses_store_remove_key():
 
 
 @pytest.mark.unit
-def test_checkpoint_factory_delete_raises_for_missing_checkpoint():
+def test_checkpoint_factory_delete_raises_for_missing_checkpoint(mocker: MockerFixture):
     # Arrange
     name = "test-checkpoint"
-    store = Mock(spec=CheckpointStore)
+    store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
-    context = Mock(spec=AbstractDataContext)
+    context = mocker.MagicMock(spec=AbstractDataContext)
     factory = CheckpointFactory(store=store, context=context)
     set_context(context)
     checkpoint = Checkpoint(name=name)

--- a/tests/core/factory/test_suite_factory.py
+++ b/tests/core/factory/test_suite_factory.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/core/factory/test_validation_factory.py
+++ b/tests/core/factory/test_validation_factory.py
@@ -1,8 +1,7 @@
 import json
-from unittest import mock
-from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from great_expectations.core.batch_config import BatchConfig
 from great_expectations.core.expectation_suite import ExpectationSuite
@@ -24,9 +23,9 @@ from great_expectations.exceptions import DataContextError
 
 
 @pytest.fixture
-def validation_config() -> ValidationConfig:
-    data = Mock(spec=BatchConfig)
-    suite = Mock(spec=ExpectationSuite)
+def validation_config(mocker: MockerFixture) -> ValidationConfig:
+    data = mocker.Mock(spec=BatchConfig)
+    suite = mocker.Mock(spec=ExpectationSuite)
     return ValidationConfig(
         name="test-validation",
         data=data,
@@ -63,10 +62,12 @@ def validation_config_json(validation_config: ValidationConfig) -> str:
 
 
 @pytest.mark.unit
-def test_validation_factory_get_uses_store_get(validation_config: ValidationConfig):
+def test_validation_factory_get_uses_store_get(
+    mocker: MockerFixture, validation_config: ValidationConfig
+):
     # Arrange
     name = validation_config.name
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
     store.get.return_value = validation_config
@@ -82,11 +83,12 @@ def test_validation_factory_get_uses_store_get(validation_config: ValidationConf
 
 @pytest.mark.unit
 def test_validation_factory_get_raises_error_on_missing_key(
+    mocker: MockerFixture,
     validation_config: ValidationConfig,
 ):
     # Arrange
     name = validation_config.name
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = False
     store.get.return_value = validation_config
     factory = ValidationFactory(store=store)
@@ -102,9 +104,11 @@ def test_validation_factory_get_raises_error_on_missing_key(
 
 
 @pytest.mark.unit
-def test_validation_factory_add_uses_store_add(validation_config: ValidationConfig):
+def test_validation_factory_add_uses_store_add(
+    mocker: MockerFixture, validation_config: ValidationConfig
+):
     # Arrange
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = False
     key = store.get_key.return_value
     factory = ValidationFactory(store=store)
@@ -119,11 +123,12 @@ def test_validation_factory_add_uses_store_add(validation_config: ValidationConf
 
 @pytest.mark.unit
 def test_validation_factory_add_raises_for_duplicate_key(
+    mocker: MockerFixture,
     validation_config: ValidationConfig,
 ):
     # Arrange
     name = validation_config.name
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = True
     factory = ValidationFactory(store=store)
 
@@ -140,10 +145,11 @@ def test_validation_factory_add_raises_for_duplicate_key(
 
 @pytest.mark.unit
 def test_validation_factory_delete_uses_store_remove_key(
+    mocker: MockerFixture,
     validation_config: ValidationConfig,
 ):
     # Arrange
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = True
     key = store.get_key.return_value
     factory = ValidationFactory(store=store)
@@ -159,11 +165,12 @@ def test_validation_factory_delete_uses_store_remove_key(
 
 @pytest.mark.unit
 def test_validation_factory_delete_raises_for_missing_validation(
+    mocker: MockerFixture,
     validation_config: ValidationConfig,
 ):
     # Arrange
     name = validation_config.name
-    store = Mock(spec=ValidationConfigStore)
+    store = mocker.Mock(spec=ValidationConfigStore)
     store.has_key.return_value = False
     factory = ValidationFactory(store=store)
 
@@ -219,6 +226,7 @@ def test_validation_factory_add_success_cloud(
 
 
 def _test_validation_factory_add_success(
+    mocker: MockerFixture,
     context: AbstractDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
@@ -231,7 +239,7 @@ def _test_validation_factory_add_success(
         context.validations.get(name)
 
     # Act
-    with mock.patch.object(
+    with mocker.patch.object(
         ValidationConfig, "json", return_value=validation_config_json
     ):
         created_validation = context.validations.add(validation=validation_config)
@@ -270,6 +278,7 @@ def test_validation_factory_delete_success_cloud(
 
 
 def _test_validation_factory_delete_success(
+    mocker: MockerFixture,
     context: AbstractDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
@@ -277,7 +286,7 @@ def _test_validation_factory_delete_success(
     # Arrange
     name = validation_config.name
 
-    with mock.patch.object(
+    with mocker.patch.object(
         ValidationConfig, "json", return_value=validation_config_json
     ):
         validation_config = context.validations.add(validation=validation_config)

--- a/tests/core/factory/test_validation_factory.py
+++ b/tests/core/factory/test_validation_factory.py
@@ -204,8 +204,10 @@ def test_validation_factory_add_success_filesystem(
     empty_data_context: FileDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
+    mocker: MockerFixture,
 ):
     _test_validation_factory_add_success(
+        mocker=mocker,
         context=empty_data_context,
         validation_config=validation_config,
         validation_config_json=validation_config_json,
@@ -217,8 +219,10 @@ def test_validation_factory_add_success_cloud(
     empty_cloud_context_fluent: CloudDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
+    mocker: MockerFixture,
 ):
     _test_validation_factory_add_success(
+        mocker=mocker,
         context=empty_cloud_context_fluent,
         validation_config=validation_config,
         validation_config_json=validation_config_json,
@@ -256,8 +260,10 @@ def test_validation_factory_delete_success_filesystem(
     empty_data_context: FileDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
+    mocker: MockerFixture,
 ):
     _test_validation_factory_delete_success(
+        mocker=mocker,
         context=empty_data_context,
         validation_config=validation_config,
         validation_config_json=validation_config_json,
@@ -269,8 +275,10 @@ def test_validation_factory_delete_success_cloud(
     empty_cloud_context_fluent: CloudDataContext,
     validation_config: ValidationConfig,
     validation_config_json: str,
+    mocker: MockerFixture,
 ):
     _test_validation_factory_delete_success(
+        mocker=mocker,
         context=empty_cloud_context_fluent,
         validation_config=validation_config,
         validation_config_json=validation_config_json,

--- a/tests/core/test_batch_config.py
+++ b/tests/core/test_batch_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -5,7 +5,7 @@ import itertools
 from copy import copy, deepcopy
 from typing import Any, Dict, List, Union
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock  # noqa: TID251
 from uuid import UUID, uuid4
 
 import pytest

--- a/tests/core/test_validation_config.py
+++ b/tests/core/test_validation_config.py
@@ -56,7 +56,7 @@ class TestValidationRun:
             with mock.patch.object(OldValidator, "graph_validate"):
                 gx.get_context()
                 mock_validator = OldValidator(
-                    execution_engine=mock.MagicMock(spec=ExecutionEngine)
+                    execution_engine=mock.MagicMock(spec=ExecutionEngine)  # noqa: TID251
                 )
                 mock_get_validator.return_value = mock_validator
 
@@ -65,7 +65,7 @@ class TestValidationRun:
     @pytest.mark.unit
     def test_passes_simple_data_to_validator(
         self,
-        mock_validator: mock.MagicMock,
+        mock_validator: mock.MagicMock,  # noqa: TID251
         validation_config: ValidationConfig,
     ):
         validation_config.suite.add_expectation(
@@ -92,7 +92,7 @@ class TestValidationRun:
     def test_passes_complex_data_to_validator(
         self,
         mock_build_batch_request,
-        mock_validator: mock.MagicMock,
+        mock_validator: mock.MagicMock,  # noqa: TID251
         validation_config: ValidationConfig,
     ):
         validation_config.suite.add_expectation(
@@ -123,7 +123,7 @@ class TestValidationRun:
     @pytest.mark.unit
     def test_returns_expected_data(
         self,
-        mock_validator: mock.MagicMock,
+        mock_validator: mock.MagicMock,  # noqa: TID251
         validation_config: ValidationConfig,
     ):
         graph_validate_results = [ExpectationValidationResult(success=True)]

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -788,7 +788,7 @@ def test_list_checkpoints(
     checkpoint_name_2, checkpoint_id_2 = checkpoint_2
 
     with mock.patch("requests.Session.get", autospec=True) as mock_get:
-        mock_get.return_value = mock.Mock(
+        mock_get.return_value = mock.Mock(  # noqa: TID251
             status_code=200, json=lambda: mock_get_all_checkpoints_json
         )
         checkpoints = context.list_checkpoints()

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -220,7 +220,7 @@ def mocked_get_by_name_response(
 
 
 @pytest.fixture
-def mock_list_expectation_suite_names() -> mock.MagicMock:
+def mock_list_expectation_suite_names() -> mock.MagicMock:  # noqa: TID251
     """
     Expects a return value to be set within the test function.
     """
@@ -231,7 +231,7 @@ def mock_list_expectation_suite_names() -> mock.MagicMock:
 
 
 @pytest.fixture
-def mock_list_expectation_suites() -> mock.MagicMock:
+def mock_list_expectation_suites() -> mock.MagicMock:  # noqa: TID251
     """
     Expects a return value to be set within the test function.
     """
@@ -242,7 +242,7 @@ def mock_list_expectation_suites() -> mock.MagicMock:
 
 
 @pytest.fixture
-def mock_expectations_store_has_key() -> mock.MagicMock:
+def mock_expectations_store_has_key() -> mock.MagicMock:  # noqa: TID251
     """
     Expects a return value to be set within the test function.
     """
@@ -272,7 +272,7 @@ def test_list_expectation_suites(
     )
 
     with mock.patch("requests.Session.get", autospec=True) as mock_get:
-        mock_get.return_value = mock.Mock(
+        mock_get.return_value = mock.Mock(  # noqa: TID251
             status_code=200, json=lambda: mock_get_all_suites_json
         )
         suites = context.list_expectation_suites()
@@ -295,7 +295,7 @@ def test_list_expectation_suites(
 def test_create_expectation_suite_saves_suite_to_cloud(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     mocked_post_response: Callable[[], MockResponse],
-    mock_list_expectation_suite_names: mock.MagicMock,
+    mock_list_expectation_suite_names: mock.MagicMock,  # noqa: TID251
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
 
@@ -314,8 +314,8 @@ def test_create_expectation_suite_saves_suite_to_cloud(
 @pytest.mark.cloud
 def test_create_expectation_suite_overwrites_existing_suite(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
-    mock_list_expectation_suite_names: mock.MagicMock,
-    mock_list_expectation_suites: mock.MagicMock,
+    mock_list_expectation_suite_names: mock.MagicMock,  # noqa: TID251
+    mock_list_expectation_suites: mock.MagicMock,  # noqa: TID251
     suite_1: SuiteIdentifierTuple,
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
@@ -345,7 +345,7 @@ def test_create_expectation_suite_overwrites_existing_suite(
 @pytest.mark.cloud
 def test_create_expectation_suite_namespace_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
-    mock_list_expectation_suite_names: mock.MagicMock,
+    mock_list_expectation_suite_names: mock.MagicMock,  # noqa: TID251
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
 
@@ -487,7 +487,7 @@ def test_save_expectation_suite_overwrites_existing_suite(
     suite = ExpectationSuite(suite_name, id=suite_id)
 
     with mock.patch(
-        "requests.Session.put", autospec=True, return_value=mock.Mock(status_code=405)
+        "requests.Session.put", autospec=True, return_value=mock.Mock(status_code=405)  # noqa: TID251
     ) as mock_put, mock.patch(
         "requests.Session.patch", autospec=True
     ) as mock_patch, pytest.deprecated_call():
@@ -514,8 +514,8 @@ def test_save_expectation_suite_overwrites_existing_suite(
 @pytest.mark.cloud
 def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
-    mock_expectations_store_has_key: mock.MagicMock,
-    mock_list_expectation_suite_names: mock.MagicMock,
+    mock_expectations_store_has_key: mock.MagicMock,  # noqa: TID251
+    mock_list_expectation_suite_names: mock.MagicMock,  # noqa: TID251
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
 
@@ -539,7 +539,7 @@ def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
 def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
     empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
-    mock_expectations_store_has_key: mock.MagicMock,
+    mock_expectations_store_has_key: mock.MagicMock,  # noqa: TID251
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
 

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -487,7 +487,9 @@ def test_save_expectation_suite_overwrites_existing_suite(
     suite = ExpectationSuite(suite_name, id=suite_id)
 
     with mock.patch(
-        "requests.Session.put", autospec=True, return_value=mock.Mock(status_code=405)  # noqa: TID251
+        "requests.Session.put",
+        autospec=True,
+        return_value=mock.Mock(status_code=405),  # noqa: TID251
     ) as mock_put, mock.patch(
         "requests.Session.patch", autospec=True
     ) as mock_patch, pytest.deprecated_call():

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import unittest.mock
 from typing import Any, Callable, Dict, Optional, Union, cast
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch  # noqa: TID251
 
 import pytest
 import requests

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -36,7 +36,7 @@ def migrator_factory(
 def migrator_with_mock_context(
     migrator_factory: Callable,
 ) -> CloudMigrator:
-    return migrator_factory(context=mock.MagicMock)
+    return migrator_factory(context=mock.MagicMock)  # noqa: TID251
 
 
 @pytest.fixture
@@ -53,8 +53,8 @@ def mock_successful_migration(
 ) -> Callable:
     def _build_mock_migrate(
         test_migrate: bool,
-    ) -> mock.MagicMock:
-        context = mock.MagicMock()
+    ) -> mock.MagicMock:  # noqa: TID251
+        context = mock.MagicMock()  # noqa: TID251
 
         with mock.patch.object(
             CloudMigrator,
@@ -83,8 +83,8 @@ def mock_failed_migration(
 ) -> Callable:
     def _build_mock_migrate(
         test_migrate: bool,
-    ) -> mock.MagicMock:
-        context = mock.MagicMock()
+    ) -> mock.MagicMock:  # noqa: TID251
+        context = mock.MagicMock()  # noqa: TID251
 
         with mock.patch.object(
             CloudMigrator,

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
-from unittest.mock import ANY
+from unittest.mock import ANY as MOCK_MOCK_ANY
 
 import pytest
 from marshmallow.exceptions import ValidationError
@@ -481,5 +481,5 @@ def test_add_checkpoint(
 
     mock_backend.add.assert_called_once_with(
         (checkpoint_name,),
-        ANY,  # Complex serialized payload so keeping it simple
+        MOCK_ANY,  # Complex serialized payload so keeping it simple
     )

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
-from unittest.mock import ANY as MOCK_MOCK_ANY
 
 import pytest
 from marshmallow.exceptions import ValidationError

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from unittest.mock import ANY as MOCK_ANY
 
 import pytest
 from marshmallow.exceptions import ValidationError

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def checkpoint_store_with_mock_backend() -> Tuple[CheckpointStore, mock.MagicMock]:
+def checkpoint_store_with_mock_backend() -> Tuple[CheckpointStore, mock.MagicMock]:  # noqa: TID251
     store = CheckpointStore(store_name="checkpoint_store")
-    mock_backend = mock.MagicMock()
+    mock_backend = mock.MagicMock()  # noqa: TID251
     store._store_backend = mock_backend
 
     return store, mock_backend
@@ -339,7 +339,7 @@ def test_default_checkpoints_exist(path: str, exists: bool) -> None:
 
 @pytest.mark.unit
 def test_list_checkpoints(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
     mock_backend.list_keys.return_value = [("a", "b", "c"), ("d", "e", "f")]
@@ -350,7 +350,7 @@ def test_list_checkpoints(
 
 @pytest.mark.cloud
 def test_list_checkpoints_cloud_mode(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
     mock_backend.list_keys.return_value = [("a", "b", "c"), ("d", "e", "f")]
@@ -364,7 +364,7 @@ def test_list_checkpoints_cloud_mode(
 
 @pytest.mark.unit
 def test_delete_checkpoint(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
 
@@ -377,7 +377,7 @@ def test_delete_checkpoint(
 
 @pytest.mark.cloud
 def test_delete_checkpoint_with_cloud_id(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
 
@@ -390,7 +390,7 @@ def test_delete_checkpoint_with_cloud_id(
 
 @pytest.mark.unit
 def test_delete_checkpoint_with_invalid_key_raises_error(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     def _raise_key_error(_: Any) -> None:
         raise gx_exceptions.InvalidKeyError(message="invalid key")
@@ -408,7 +408,7 @@ def test_delete_checkpoint_with_invalid_key_raises_error(
 
 @pytest.mark.unit
 def test_get_checkpoint(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
     checkpoint_config: dict,
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
@@ -423,7 +423,7 @@ def test_get_checkpoint(
 
 @pytest.mark.unit
 def test_get_checkpoint_with_nonexistent_checkpoint_raises_error(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     def _raise_key_error(_: Any) -> None:
         raise gx_exceptions.InvalidKeyError(message="invalid key")
@@ -441,7 +441,7 @@ def test_get_checkpoint_with_nonexistent_checkpoint_raises_error(
 
 @pytest.mark.unit
 def test_get_checkpoint_with_invalid_checkpoint_config_raises_error(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     def _raise_validation_error(_: Any) -> None:
         raise ValidationError(message="invalid config")
@@ -460,11 +460,11 @@ def test_get_checkpoint_with_invalid_checkpoint_config_raises_error(
 
 @pytest.mark.unit
 def test_add_checkpoint(
-    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],
+    checkpoint_store_with_mock_backend: Tuple[CheckpointStore, mock.MagicMock],  # noqa: TID251
 ) -> None:
     store, mock_backend = checkpoint_store_with_mock_backend
 
-    context = mock.MagicMock(spec=FileDataContext)
+    context = mock.MagicMock(spec=FileDataContext)  # noqa: TID251
     checkpoint_name = "my_checkpoint"
     checkpoint = Checkpoint(name=checkpoint_name, data_context=context)
 

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import copy
 import pathlib
-from typing import Callable, List, Optional, cast
-from unittest import mock
+from typing import TYPE_CHECKING, Callable, List, Optional, cast
+from unittest.mock import ANY as MOCK_ANY
 
 import pytest
 
@@ -37,6 +37,9 @@ from great_expectations.datasource.datasource_serializer import (
 )
 from great_expectations.datasource.fluent.pandas_datasource import PandasDatasource
 from tests.data_context.conftest import MockResponse
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 yaml = YAMLHandler()
 
@@ -243,6 +246,7 @@ def test_datasource_store_set_cloud_mode(
     ge_cloud_base_url: str,
     ge_cloud_access_token: str,
     ge_cloud_organization_id: str,
+    mocker: MockerFixture,
 ) -> None:
     ge_cloud_store_backend_config: dict = {
         "class_name": GXCloudStoreBackend.__name__,
@@ -261,11 +265,11 @@ def test_datasource_store_set_cloud_mode(
         serializer=JsonConfigSerializer(schema=datasourceConfigSchema),
     )
 
-    with mock.patch(
+    with mocker.patch(
         "requests.Session.post",
         autospec=True,
         side_effect=mocked_datasource_post_response,
-    ) as mock_post, mock.patch(
+    ) as mock_post, mocker.patch(
         "requests.Session.get",
         autospec=True,
         side_effect=mocked_datasource_get_response,
@@ -280,7 +284,7 @@ def test_datasource_store_set_cloud_mode(
         )
 
         mock_post.assert_called_with(
-            mock.ANY,  # requests.Session object
+            MOCK_ANY,  # requests.Session object
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
             json={
                 "data": {

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -265,43 +265,42 @@ def test_datasource_store_set_cloud_mode(
         serializer=JsonConfigSerializer(schema=datasourceConfigSchema),
     )
 
-    with mocker.patch(
+    mock_post = mocker.patch(
         "requests.Session.post",
         autospec=True,
         side_effect=mocked_datasource_post_response,
-    ) as mock_post, mocker.patch(
+    )
+    _ = mocker.patch(
         "requests.Session.get",
         autospec=True,
         side_effect=mocked_datasource_get_response,
-    ):
-        retrieved_datasource_config = store.set(
-            key=None, value=block_config_datasource_config
-        )
+    )
+    retrieved_datasource_config = store.set(
+        key=None, value=block_config_datasource_config
+    )
 
-        serializer = NamedDatasourceSerializer(schema=datasourceConfigSchema)
-        expected_datasource_config = serializer.serialize(
-            block_config_datasource_config
-        )
+    serializer = NamedDatasourceSerializer(schema=datasourceConfigSchema)
+    expected_datasource_config = serializer.serialize(block_config_datasource_config)
 
-        mock_post.assert_called_with(
-            MOCK_ANY,  # requests.Session object
-            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
-            json={
-                "data": {
-                    "type": "datasource",
-                    "attributes": {
-                        "datasource_config": expected_datasource_config,
-                        "organization_id": ge_cloud_organization_id,
-                    },
-                }
-            },
-        )
+    mock_post.assert_called_with(
+        MOCK_ANY,  # requests.Session object
+        f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
+        json={
+            "data": {
+                "type": "datasource",
+                "attributes": {
+                    "datasource_config": expected_datasource_config,
+                    "organization_id": ge_cloud_organization_id,
+                },
+            }
+        },
+    )
 
-        json_serializer = JsonDatasourceConfigSerializer(schema=datasourceConfigSchema)
+    json_serializer = JsonDatasourceConfigSerializer(schema=datasourceConfigSchema)
 
-        assert json_serializer.serialize(
-            retrieved_datasource_config
-        ) == json_serializer.serialize(datasource_config_with_names_and_ids)
+    assert json_serializer.serialize(
+        retrieved_datasource_config
+    ) == json_serializer.serialize(datasource_config_with_names_and_ids)
 
 
 @pytest.mark.filesystem

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -206,7 +206,7 @@ def test_datasource_store_delete_by_id(
 )
 def test_datasource_http_error_handling(
     datasource_store_ge_cloud_backend: DatasourceStore,
-    mock_http_unavailable: Dict[str, mock.Mock],
+    mock_http_unavailable: Dict[str, mock.Mock],  # noqa: TID251
     http_verb: str,
     method: str,
     args: list,

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -328,7 +328,7 @@ def test_compile_evaluation_parameter_dependencies_broken_suite(
 @pytest.mark.filesystem
 @mock.patch("great_expectations.data_context.store.DatasourceStore.update_by_name")
 def test_update_datasource_persists_changes_with_store(
-    mock_update_by_name: mock.MagicMock,
+    mock_update_by_name: mock.MagicMock,  # noqa: TID251
     data_context_parameterized_expectation_suite,
 ) -> None:
     context = data_context_parameterized_expectation_suite

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -263,7 +263,7 @@ def test_add_datasource_with_existing_datasource(
     "datasource, datasource_name, error_message",
     [
         pytest.param(
-            mock.MagicMock(),
+            mock.MagicMock(),  # noqa: TID251
             "my_datasource",
             "an existing 'datasource' or individual constructor arguments (but not both)",
             id="both datasource and name",
@@ -278,7 +278,7 @@ def test_add_datasource_with_existing_datasource(
 )
 def test_add_datasource_conflicting_args_failure(
     in_memory_data_context: EphemeralDataContextSpy,
-    datasource: mock.MagicMock | None,
+    datasource: mock.MagicMock | None,  # noqa: TID251
     datasource_name: str | None,
     error_message: str,
 ):
@@ -446,7 +446,7 @@ def test_add_or_update_datasource_adds_successfully(
     "datasource, datasource_name, error_message",
     [
         pytest.param(
-            mock.MagicMock(),
+            mock.MagicMock(),  # noqa: TID251
             "my_datasource",
             "an existing 'datasource' or individual constructor arguments (but not both)",
             id="both datasource and name",
@@ -461,7 +461,7 @@ def test_add_or_update_datasource_adds_successfully(
 )
 def test_add_or_update_datasource_conflicting_args_failure(
     in_memory_data_context: EphemeralDataContextSpy,
-    datasource: mock.MagicMock | None,
+    datasource: mock.MagicMock | None,  # noqa: TID251
     datasource_name: str | None,
     error_message: str,
 ):
@@ -752,7 +752,7 @@ def test_add_checkpoint_namespace_collision(
     "checkpoint, checkpoint_name, error_message",
     [
         pytest.param(
-            mock.MagicMock(),
+            mock.MagicMock(),  # noqa: TID251
             "my_checkpoint_name",
             "an existing 'checkpoint' or individual constructor arguments (but not both)",
             id="both checkpoint and checkpoint_name",
@@ -768,7 +768,7 @@ def test_add_checkpoint_namespace_collision(
 def test_add_checkpoint_conflicting_args_failure(
     in_memory_data_context: EphemeralDataContextSpy,
     # Only care about the presence of the value (no need to construct a full Checkpoint obj)
-    checkpoint: mock.MagicMock | None,
+    checkpoint: mock.MagicMock | None,  # noqa: TID251
     checkpoint_name: str | None,
     error_message: str,
 ):
@@ -1007,7 +1007,7 @@ def test_add_or_update_checkpoint_existing_checkpoint_updates_successfully(
     "checkpoint, checkpoint_name, error_message",
     [
         pytest.param(
-            mock.MagicMock(),
+            mock.MagicMock(),  # noqa: TID251
             "my_checkpoint_name",
             "an existing 'checkpoint' or individual constructor arguments (but not both)",
             id="both checkpoint and checkpoint_name",
@@ -1023,7 +1023,7 @@ def test_add_or_update_checkpoint_existing_checkpoint_updates_successfully(
 def test_add_or_update_checkpoint_conflicting_args_failure(
     in_memory_data_context: EphemeralDataContextSpy,
     # Only care about the presence of the value (no need to construct a full Checkpoint obj)
-    checkpoint: mock.MagicMock | None,
+    checkpoint: mock.MagicMock | None,  # noqa: TID251
     checkpoint_name: str | None,
     error_message: str,
 ):

--- a/tests/data_context/test_data_context_types.py
+++ b/tests/data_context/test_data_context_types.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -594,7 +594,7 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     reason="GX Cloud E2E tests are failing due to env vars not being consistently recognized by Docker; x-failing for purposes of 0.15.22 release",
 )
 def test_cloud_enabled_data_context_variables_e2e(
-    mock_save_project_config: mock.MagicMock, data_docs_sites: dict, monkeypatch
+    mock_save_project_config: mock.MagicMock, data_docs_sites: dict, monkeypatch  # noqa: TID251
 ) -> None:
     """
     What does this test do and why?

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -594,7 +594,9 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     reason="GX Cloud E2E tests are failing due to env vars not being consistently recognized by Docker; x-failing for purposes of 0.15.22 release",
 )
 def test_cloud_enabled_data_context_variables_e2e(
-    mock_save_project_config: mock.MagicMock, data_docs_sites: dict, monkeypatch  # noqa: TID251
+    mock_save_project_config: mock.MagicMock,
+    data_docs_sites: dict,
+    monkeypatch,  # noqa: TID251
 ) -> None:
     """
     What does this test do and why?

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -444,55 +444,55 @@ def test_data_context_variables_save_config(
         assert mock_save.call_count == 1
 
     # CloudDataContextVariables
-    with mocker.patch("requests.Session.put", autospec=True) as mock_put:
-        type(mock_put.return_value).status_code = mocker.PropertyMock(return_value=200)
+    mock_put = mocker.patch("requests.Session.put", autospec=True)
+    type(mock_put.return_value).status_code = mocker.PropertyMock(return_value=200)
 
-        cloud_data_context_variables.save_config()
+    cloud_data_context_variables.save_config()
 
-        expected_config_dict = {
-            "config_variables_file_path": "uncommitted/config_variables.yml",
-            "config_version": 3.0,
-            "data_docs_sites": {},
-            "plugins_directory": "plugins/",
-            "stores": {
-                "expectations_store": {
-                    "class_name": "ExpectationsStore",
-                    "store_backend": {
-                        "class_name": "TupleFilesystemStoreBackend",
-                        "base_directory": "expectations/",
-                    },
+    expected_config_dict = {
+        "config_variables_file_path": "uncommitted/config_variables.yml",
+        "config_version": 3.0,
+        "data_docs_sites": {},
+        "plugins_directory": "plugins/",
+        "stores": {
+            "expectations_store": {
+                "class_name": "ExpectationsStore",
+                "store_backend": {
+                    "class_name": "TupleFilesystemStoreBackend",
+                    "base_directory": "expectations/",
                 },
-                "evaluation_parameter_store": {
-                    "module_name": "great_expectations.data_context.store",
-                    "class_name": "EvaluationParameterStore",
-                },
-                "checkpoint_store": {"class_name": "CheckpointStore"},
-                "profiler_store": {"class_name": "ProfilerStore"},
-                "validations_store": {"class_name": "ValidationsStore"},
-                "validation_config_store": {"class_name": "ValidationConfigStore"},
             },
-            "include_rendered_content": {
-                "expectation_suite": False,
-                "expectation_validation_result": False,
-                "globally": False,
+            "evaluation_parameter_store": {
+                "module_name": "great_expectations.data_context.store",
+                "class_name": "EvaluationParameterStore",
             },
-            "profiler_store_name": "profiler_store",
-        }
+            "checkpoint_store": {"class_name": "CheckpointStore"},
+            "profiler_store": {"class_name": "ProfilerStore"},
+            "validations_store": {"class_name": "ValidationsStore"},
+            "validation_config_store": {"class_name": "ValidationConfigStore"},
+        },
+        "include_rendered_content": {
+            "expectation_suite": False,
+            "expectation_validation_result": False,
+            "globally": False,
+        },
+        "profiler_store_name": "profiler_store",
+    }
 
-        assert mock_put.call_count == 1
-        mock_put.assert_called_with(
-            MOCK_ANY,  # requests.Session object
-            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables",
-            json={
-                "data": {
-                    "type": "data_context_variables",
-                    "attributes": {
-                        "organization_id": ge_cloud_organization_id,
-                        "data_context_variables": expected_config_dict,
-                    },
-                }
-            },
-        )
+    assert mock_put.call_count == 1
+    mock_put.assert_called_with(
+        MOCK_ANY,  # requests.Session object
+        f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables",
+        json={
+            "data": {
+                "type": "data_context_variables",
+                "attributes": {
+                    "organization_id": ge_cloud_organization_id,
+                    "data_context_variables": expected_config_dict,
+                },
+            }
+        },
+    )
 
 
 @pytest.mark.unit

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -596,7 +596,7 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
 def test_cloud_enabled_data_context_variables_e2e(
     mock_save_project_config: mock.MagicMock,
     data_docs_sites: dict,
-    monkeypatch,  # noqa: TID251
+    monkeypatch,
 ) -> None:
     """
     What does this test do and why?

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -435,13 +435,13 @@ def test_data_context_variables_save_config(
     )
 
     # FileDataContextVariables
-    with mocker.patch(
+    mock_save = mocker.patch(
         "great_expectations.data_context.store.InlineStoreBackend._save_changes",
         autospec=True,
-    ) as mock_save:
-        file_data_context_variables.save_config()
+    )
+    file_data_context_variables.save_config()
 
-        assert mock_save.call_count == 1
+    assert mock_save.call_count == 1
 
     # CloudDataContextVariables
     mock_put = mocker.patch("requests.Session.put", autospec=True)

--- a/tests/data_context/test_project_manager.py
+++ b/tests/data_context/test_project_manager.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -916,7 +916,7 @@ def test_more_complex_instantiation_of_InferredAssetSqlDataConnector(
 @mock.patch("great_expectations.execution_engine.SqlAlchemyExecutionEngine.__init__")
 @pytest.mark.parametrize("partitioner_method_name_prefix", ["_", ""])
 def test_more_complex_instantiation_of_ConfiguredAssetSqlDataConnector_include_schema_name(
-    mock_sql_alchemy_execution_engine: mock.MagicMock,
+    mock_sql_alchemy_execution_engine: mock.MagicMock,  # noqa: TID251
     partitioner_method_name_prefix,
     test_cases_for_sql_data_connector_sqlite_execution_engine,
 ):
@@ -955,7 +955,7 @@ def test_more_complex_instantiation_of_ConfiguredAssetSqlDataConnector_include_s
 @mock.patch("great_expectations.execution_engine.SqlAlchemyExecutionEngine.__init__")
 @pytest.mark.parametrize("partitioner_method_name_prefix", ["_", ""])
 def test_more_complex_instantiation_of_ConfiguredAssetSqlDataConnector_include_schema_name_prefix_suffix(
-    mock_sql_alchemy_execution_engine: mock.MagicMock,
+    mock_sql_alchemy_execution_engine: mock.MagicMock,  # noqa: TID251
     partitioner_method_name_prefix,
     test_cases_for_sql_data_connector_sqlite_execution_engine,
 ):
@@ -984,7 +984,7 @@ def test_more_complex_instantiation_of_ConfiguredAssetSqlDataConnector_include_s
 @mock.patch("great_expectations.execution_engine.SqlAlchemyExecutionEngine.__init__")
 @pytest.mark.parametrize("partitioner_method_name_prefix", ["_", ""])
 def test_more_complex_instantiation_of_ConfiguredAssetSqlDataConnector_include_schema_name_prefix_suffix_table_name(
-    mock_sql_alchemy_execution_engine: mock.MagicMock,
+    mock_sql_alchemy_execution_engine: mock.MagicMock,  # noqa: TID251
     partitioner_method_name_prefix,
     test_cases_for_sql_data_connector_sqlite_execution_engine,
 ):

--- a/tests/datasource/fluent/test_postgres_datasource.py
+++ b/tests/datasource/fluent/test_postgres_datasource.py
@@ -59,7 +59,7 @@ from tests.datasource.fluent.conftest import sqlachemy_execution_engine_mock_cls
 from tests.sqlalchemy_test_doubles import Dialect, MockSaEngine, MockSaInspector
 
 if TYPE_CHECKING:
-    from unittest.mock import Mock
+    from unittest.mock import Mock  # noqa: TID251
 
     from pytest_mock import MockFixture
     from typing_extensions import TypeAlias

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def create_engine_spy(mocker: MockerFixture) -> Generator[mock.MagicMock, None, None]:
+def create_engine_spy(mocker: MockerFixture) -> Generator[mock.MagicMock, None, None]:  # noqa: TID251
     spy = mocker.spy(sa, "create_engine")
     yield spy
     if not spy.call_count:
@@ -35,7 +35,7 @@ def create_engine_spy(mocker: MockerFixture) -> Generator[mock.MagicMock, None, 
 @pytest.fixture
 def gx_sqlalchemy_execution_engine_spy(
     mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-) -> Generator[mock.MagicMock, None, None]:
+) -> Generator[mock.MagicMock, None, None]:  # noqa: TID251
     """
     Mock the SQLDatasource.execution_engine_type property to return a spy so that what would be passed to
     the GX SqlAlchemyExecutionEngine constructor can be inspected.
@@ -104,7 +104,7 @@ def create_engine_fake(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestConfigPasstrough:
     def test_kwargs_passed_to_create_engine(
         self,
-        create_engine_spy: mock.MagicMock,
+        create_engine_spy: mock.MagicMock,  # noqa: TID251
         monkeypatch: pytest.MonkeyPatch,
         ephemeral_context_with_defaults: EphemeralDataContext,
         ds_kwargs: dict,
@@ -127,7 +127,7 @@ class TestConfigPasstrough:
 
     def test_ds_config_passed_to_gx_sqlalchemy_execution_engine(
         self,
-        gx_sqlalchemy_execution_engine_spy: mock.MagicMock,
+        gx_sqlalchemy_execution_engine_spy: mock.MagicMock,  # noqa: TID251
         monkeypatch: pytest.MonkeyPatch,
         ephemeral_context_with_defaults: EphemeralDataContext,
         ds_kwargs: dict,

--- a/tests/execution_engine/partition_and_sample/test_pandas_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_pandas_execution_engine_partitioning.py
@@ -240,7 +240,7 @@ def test_partition_on_date_parts_multiple_date_parts(
     ],
 )
 def test_named_date_part_methods(
-    mock_partition_on_date_parts: mock.MagicMock,
+    mock_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
     partitioner_method_name: str,
     called_with_date_parts: List[DatePart],
     simple_multi_year_pandas_df: pd.DataFrame,

--- a/tests/execution_engine/partition_and_sample/test_sparkdf_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sparkdf_execution_engine_partitioning.py
@@ -206,7 +206,7 @@ def test_partition_on_date_parts_multiple_date_parts(
     ],
 )
 def test_named_date_part_methods(
-    mock_partition_on_date_parts: mock.MagicMock,
+    mock_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
     partitioner_method_name: str,
     called_with_date_parts: List[DatePart],
     simple_multi_year_spark_df: pyspark.DataFrame,

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -81,7 +81,7 @@ pytestmark = [
 )
 @pytest.mark.sqlite
 def test_named_date_part_methods(
-    mock_partition_on_date_parts: mock.MagicMock,
+    mock_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
     partitioner_method_name: str,
     called_with_date_parts: List[DatePart],
 ):
@@ -203,8 +203,8 @@ def test_partition_on_date_parts_multiple_date_parts(
 @mock.patch("great_expectations.execution_engine.execution_engine.ExecutionEngine")
 @pytest.mark.sqlite
 def test_get_data_for_batch_identifiers_year(
-    mock_execution_engine: mock.MagicMock,
-    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,
+    mock_execution_engine: mock.MagicMock,  # noqa: TID251
+    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(
@@ -236,8 +236,8 @@ def test_get_data_for_batch_identifiers_year(
 @mock.patch("great_expectations.execution_engine.execution_engine.ExecutionEngine")
 @pytest.mark.sqlite
 def test_get_data_for_batch_identifiers_year_and_month(
-    mock_execution_engine: mock.MagicMock,
-    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,
+    mock_execution_engine: mock.MagicMock,  # noqa: TID251
+    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(
@@ -266,8 +266,8 @@ def test_get_data_for_batch_identifiers_year_and_month(
 @mock.patch("great_expectations.execution_engine.execution_engine.ExecutionEngine")
 @pytest.mark.sqlite
 def test_get_data_for_batch_identifiers_year_and_month_and_day(
-    mock_execution_engine: mock.MagicMock,
-    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,
+    mock_execution_engine: mock.MagicMock,  # noqa: TID251
+    mock_get_data_for_batch_identifiers_for_partition_on_date_parts: mock.MagicMock,  # noqa: TID251
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(

--- a/tests/execution_engine/test_sqlalchemy_batch_data.py
+++ b/tests/execution_engine/test_sqlalchemy_batch_data.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/experimental/metric_repository/test_batch_inspector.py
+++ b/tests/experimental/metric_repository/test_batch_inspector.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/experimental/metric_repository/test_cloud_data_store.py
+++ b/tests/experimental/metric_repository/test_cloud_data_store.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 from uuid import UUID
 
 import numpy

--- a/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_column_descriptive_metrics_metric_retriever.py
@@ -1,5 +1,5 @@
 from typing import Callable, List
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/experimental/metric_repository/test_metric_repository.py
+++ b/tests/experimental/metric_repository/test_metric_repository.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/render/test_microsoft_teams_renderer.py
+++ b/tests/render/test_microsoft_teams_renderer.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock  # noqa: TID251
 
 import pytest
 

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -8,8 +8,6 @@ lint.extend-ignore = [
     # This is likely to be a high-touch rule. Doing this in `tests` doesn't help circular imports.
     # Let's differ this for tests until there are auto-fixes
     "TCH001",
-    # https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid
-    "TID251",  # banned-api - is used to prevent opaque attribute errors caused by missing optional dependencies
     # https://beta.ruff.rs/docs/rules/#flake8-bugbear-b
     "B011", # assert-false - common pattern in pytest
     # https://beta.ruff.rs/docs/rules/#flake8-datetimez-dtz
@@ -21,3 +19,10 @@ lint.extend-ignore = [
 
 [lint.isort]
 known-first-party = ["great_expectations", "tests"]
+
+[lint.flake8-tidy-imports.banned-api]
+# https://pytest-mock.readthedocs.io/en/latest/index.html
+# standard library mock doesn't clean up after itself which can affect unrelated tests
+"unittest.mock.MagicMock".msg = "Do not use `unittest.mock.MagicMock` directly, use the pytest-mock `mocker` fixture or pytest.monkeypatch instead."
+"unittest.mock.Mock".msg = "Do not use `unittest.mock.Mock` directly, use the pytest-mock `mocker` fixture or pytest `monkeypatch` instead."
+"unittest.mock.patch".msg = "Do not use `unittest.mock.patch` directly, use the pytest-mock `mocker` fixture or pytest `monkeypatch` instead."

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -25,4 +25,5 @@ known-first-party = ["great_expectations", "tests"]
 # standard library mock doesn't clean up after itself which can affect unrelated tests
 "unittest.mock.MagicMock".msg = "Do not use `unittest.mock.MagicMock` directly, use the pytest-mock `mocker` fixture or pytest.monkeypatch instead."
 "unittest.mock.Mock".msg = "Do not use `unittest.mock.Mock` directly, use the pytest-mock `mocker` fixture or pytest `monkeypatch` instead."
-"unittest.mock.patch".msg = "Do not use `unittest.mock.patch` directly, use the pytest-mock `mocker` fixture or pytest `monkeypatch` instead."
+# TODO: ban patch too
+# "unittest.mock.patch".msg = "Do not use `unittest.mock.patch` directly, use the pytest-mock `mocker` fixture or pytest `monkeypatch` instead."

--- a/tests/rule_based_profiler/parameter_builder/test_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_parameter_builder.py
@@ -190,7 +190,7 @@ def test_resolve_evaluation_dependencies_two_parameter_builder_dependencies_spec
     return_value="my_json_string",
 )
 def test_parameter_builder_should_not_recompute_evaluation_parameter_builders_if_precomputed(
-    mock_convert_to_json_serializable: mock.MagicMock,
+    mock_convert_to_json_serializable: mock.MagicMock,  # noqa: TID251
     empty_rule_state: Dict[str, Union[Domain, Dict[str, ParameterContainer]]],
 ):
     my_evaluation_dependency_0_parameter_builder: ParameterBuilder = (
@@ -303,7 +303,7 @@ def test_parameter_builder_should_not_recompute_evaluation_parameter_builders_if
     return_value="my_json_string",
 )
 def test_parameter_builder_dependencies_evaluated_in_parameter_builder_if_not_precomputed(
-    mock_convert_to_json_serializable: mock.MagicMock,
+    mock_convert_to_json_serializable: mock.MagicMock,  # noqa: TID251
     empty_rule_state: Dict[str, Union[Domain, Dict[str, ParameterContainer]]],
 ):
     domain = empty_rule_state["domain"]
@@ -376,7 +376,7 @@ def test_parameter_builder_dependencies_evaluated_in_parameter_builder_if_not_pr
     return_value="my_json_string",
 )
 def test_parameter_builder_should_only_evaluate_dependencies_that_are_not_precomputed(
-    mock_convert_to_json_serializable: mock.MagicMock,
+    mock_convert_to_json_serializable: mock.MagicMock,  # noqa: TID251
     empty_rule_state: Dict[str, Union[Domain, Dict[str, ParameterContainer]]],
 ):
     domain = empty_rule_state["domain"]

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -67,7 +67,7 @@ def batch_fixture() -> Batch:
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
 @pytest.mark.unit
 def test_regex_pattern_string_parameter_builder_instantiation_with_defaults(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
 ):
     data_context = mock_data_context
 
@@ -100,7 +100,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_with_defaults(
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
 @pytest.mark.unit
 def test_regex_pattern_string_parameter_builder_instantiation_override_defaults(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
 ):
     data_context = mock_data_context
 
@@ -370,7 +370,7 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
 
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
 @pytest.mark.big
-def test_regex_wrong_domain(mock_data_context: mock.MagicMock, batch_fixture: Batch):
+def test_regex_wrong_domain(mock_data_context: mock.MagicMock, batch_fixture: Batch):  # noqa: TID251
     batch: Batch = batch_fixture
     mock_data_context.get_batch_list.return_value = [batch]
     mock_data_context.get_validator.return_value = Validator(
@@ -419,7 +419,7 @@ def test_regex_wrong_domain(mock_data_context: mock.MagicMock, batch_fixture: Ba
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
 @pytest.mark.big
 def test_regex_single_candidate(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     batch_fixture: Batch,
 ):
     batch: Batch = batch_fixture
@@ -492,7 +492,7 @@ def test_regex_single_candidate(
 
 @mock.patch("great_expectations.data_context.data_context.EphemeralDataContext")
 @pytest.mark.big
-def test_regex_two_candidates(mock_data_context: mock.MagicMock, batch_fixture: Batch):
+def test_regex_two_candidates(mock_data_context: mock.MagicMock, batch_fixture: Batch):  # noqa: TID251
     batch: Batch = batch_fixture
 
     data_context = mock_data_context

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1248,7 +1248,8 @@ def test_get_profiler(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_non_existent_profiler_raises_error(
-    mock_data_context: mock.MagicMock, empty_profiler_store: ProfilerStore  # noqa: TID251
+    mock_data_context: mock.MagicMock,
+    empty_profiler_store: ProfilerStore,  # noqa: TID251
 ):
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
         RuleBasedProfiler.get_profiler(

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -951,9 +951,9 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
 @mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_without_dynamic_args(
-    mocker: MockerFixture,
     mock_data_context: MagicMock,
     mock_profiler_run: MagicMock,
+    mocker: MockerFixture,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -986,9 +986,9 @@ def test_run_profiler_without_dynamic_args(
 @mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_with_dynamic_args(
-    mocker: MockerFixture,
     mock_data_context: MagicMock,
     mock_profiler_run: MagicMock,
+    mocker: MockerFixture,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1349,10 +1349,10 @@ def test_list_profilers_in_cloud_mode(mock_profiler_store: MagicMock):
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_single_rule(
-    mocker: MockerFixture,
     mock_expectation_configuration_builder: MagicMock,
     mock_domain_builder: MagicMock,
     mock_data_context: MagicMock,
+    mocker: MockerFixture,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1390,10 +1390,10 @@ def test_add_single_rule(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_rule_overwrite_first_rule(
-    mocker: MockerFixture,
     mock_expectation_configuration_builder: MagicMock,
     mock_domain_builder: MagicMock,
     mock_data_context: MagicMock,
+    mocker: MockerFixture,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1422,6 +1422,7 @@ def test_add_rule_add_second_rule(
     mock_expectation_configuration_builder: MagicMock,
     mock_domain_builder: MagicMock,
     mock_data_context: MagicMock,
+    mocker: MockerFixture,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1435,7 +1436,7 @@ def test_add_rule_add_second_rule(
         domain_builder=mock_domain_builder,
         expectation_configuration_builders=mock_expectation_configuration_builder,
     )
-    first_rule.to_json_dict = MagicMock(return_value=sample_rule_dict)
+    first_rule.to_json_dict = mocker.MagicMock(return_value=sample_rule_dict)
     profiler.add_rule(rule=first_rule)
     assert len(profiler.rules) == 1
 
@@ -1445,7 +1446,7 @@ def test_add_rule_add_second_rule(
         domain_builder=mock_domain_builder,
         expectation_configuration_builders=mock_expectation_configuration_builder,
     )
-    second_rule.to_json_dict = MagicMock(return_value=sample_rule_dict)
+    second_rule.to_json_dict = mocker.MagicMock(return_value=sample_rule_dict)
     profiler.add_rule(rule=second_rule)
     assert len(profiler.rules) == 2
 

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List, Optional
-from unittest import mock
-from unittest.mock import MagicMock  # noqa: TID251
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from unittest.mock import patch as mock_patch
 
 import pandas as pd
 import pytest
@@ -37,6 +38,11 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 from great_expectations.rule_based_profiler.rule import Rule
 from great_expectations.util import deep_filter_properties_iterable
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock  # noqa: TID251
+
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture()
@@ -942,11 +948,12 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_without_dynamic_args(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
-    mock_profiler_run: mock.MagicMock,  # noqa: TID251
+    mocker: MockerFixture,
+    mock_data_context: MagicMock,
+    mock_profiler_run: MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -957,7 +964,7 @@ def test_run_profiler_without_dynamic_args(
     )
 
     assert mock_profiler_run.called
-    assert mock_profiler_run.call_args == mock.call(
+    assert mock_profiler_run.call_args == mocker.call(
         variables=None,
         rules=None,
         batch_list=None,
@@ -976,11 +983,12 @@ def test_run_profiler_without_dynamic_args(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_with_dynamic_args(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
-    mock_profiler_run: mock.MagicMock,  # noqa: TID251
+    mocker: MockerFixture,
+    mock_data_context: MagicMock,
+    mock_profiler_run: MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -997,7 +1005,7 @@ def test_run_profiler_with_dynamic_args(
     )
 
     assert mock_profiler_run.called
-    assert mock_profiler_run.call_args == mock.call(
+    assert mock_profiler_run.call_args == mocker.call(
         variables=variables,
         rules=rules,
         batch_list=None,
@@ -1016,11 +1024,11 @@ def test_run_profiler_with_dynamic_args(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_on_data_creates_suite_with_dict_arg(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
-    mock_rule_based_profiler_run: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
+    mock_rule_based_profiler_run: MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1044,11 +1052,11 @@ def test_run_profiler_on_data_creates_suite_with_dict_arg(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
-    mock_rule_based_profiler_run: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
+    mock_rule_based_profiler_run: MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1077,9 +1085,9 @@ def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_with_too_many_args_raises_error(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
     populated_profiler_store: ProfilerStore,
 ):
     with pytest.raises(AssertionError) as e:
@@ -1094,9 +1102,9 @@ def test_get_profiler_with_too_many_args_raises_error(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_serialize_profiler_config(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     profiler = BaseRuleBasedProfiler(
@@ -1156,9 +1164,9 @@ def test_serialize_profiler_config(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_profiler(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
     profiler_key: ConfigurationIdentifier,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
@@ -1180,9 +1188,9 @@ def test_add_profiler(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_profiler_with_batch_request_containing_batch_data_raises_error(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
 ):
     name = "my_profiler_config"
     config_version = 1.0
@@ -1225,13 +1233,13 @@ def test_add_profiler_with_batch_request_containing_batch_data_raises_error(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
-    with mock.patch(
+    with mock_patch(
         "great_expectations.data_context.store.profiler_store.ProfilerStore.get",
         return_value=profiler_config_with_placeholder_args,
     ):
@@ -1246,9 +1254,9 @@ def test_get_profiler(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_non_existent_profiler_raises_error(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: MagicMock,
     empty_profiler_store: ProfilerStore,
 ):
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
@@ -1264,9 +1272,10 @@ def test_get_profiler_non_existent_profiler_raises_error(
 
 @pytest.mark.unit
 def test_delete_profiler(
+    mocker: MockerFixture,
     populated_profiler_store: ProfilerStore,
 ):
-    with mock.patch(
+    with mock_patch(
         "great_expectations.data_context.store.profiler_store.ProfilerStore.remove_key",
     ) as mock_remove_key:
         RuleBasedProfiler.delete_profiler(
@@ -1276,7 +1285,7 @@ def test_delete_profiler(
         )
 
     assert mock_remove_key.call_count == 1
-    assert mock_remove_key.call_args == mock.call(
+    assert mock_remove_key.call_args == mocker.call(
         key=ConfigurationIdentifier("my_profiler")
     )
 
@@ -1310,8 +1319,8 @@ def test_delete_profiler_non_existent_profiler_raises_error(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.store.ProfilerStore")
-def test_list_profilers(mock_profiler_store: mock.MagicMock):  # noqa: TID251
+@mock_patch("great_expectations.data_context.store.ProfilerStore")
+def test_list_profilers(mock_profiler_store: MagicMock):
     store = mock_profiler_store()
     keys = ["a", "b", "c"]
     store.list_keys.return_value = [ConfigurationIdentifier(char) for char in keys]
@@ -1322,8 +1331,8 @@ def test_list_profilers(mock_profiler_store: mock.MagicMock):  # noqa: TID251
 
 
 @pytest.mark.cloud
-@mock.patch("great_expectations.data_context.store.ProfilerStore")
-def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):  # noqa: TID251
+@mock_patch("great_expectations.data_context.store.ProfilerStore")
+def test_list_profilers_in_cloud_mode(mock_profiler_store: MagicMock):
     store = mock_profiler_store()
     keys = ["a", "b", "c"]
     store.list_keys.return_value = keys
@@ -1334,15 +1343,16 @@ def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):  # n
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
-@mock.patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
-@mock.patch(
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
+@mock_patch(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_single_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
-    mock_domain_builder: mock.MagicMock,  # noqa: TID251
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mocker: MockerFixture,
+    mock_expectation_configuration_builder: MagicMock,
+    mock_domain_builder: MagicMock,
+    mock_data_context: MagicMock,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1356,7 +1366,7 @@ def test_add_single_rule(
         domain_builder=mock_domain_builder,
         expectation_configuration_builders=mock_expectation_configuration_builder,
     )
-    first_rule.to_json_dict = MagicMock(return_value=sample_rule_dict)
+    first_rule.to_json_dict = mocker.MagicMock(return_value=sample_rule_dict)
     profiler.add_rule(rule=first_rule)
     assert len(profiler.rules) == 1
 
@@ -1366,21 +1376,24 @@ def test_add_single_rule(
         domain_builder=mock_domain_builder,
         expectation_configuration_builders=mock_expectation_configuration_builder,
     )
-    duplicate_of_first_rule.to_json_dict = MagicMock(return_value=sample_rule_dict)
+    duplicate_of_first_rule.to_json_dict = mocker.MagicMock(
+        return_value=sample_rule_dict
+    )
     profiler.add_rule(rule=duplicate_of_first_rule)
     assert len(profiler.rules) == 1
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
-@mock.patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
-@mock.patch(
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
+@mock_patch(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_rule_overwrite_first_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
-    mock_domain_builder: mock.MagicMock,  # noqa: TID251
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mocker: MockerFixture,
+    mock_expectation_configuration_builder: MagicMock,
+    mock_domain_builder: MagicMock,
+    mock_data_context: MagicMock,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1394,21 +1407,21 @@ def test_add_rule_overwrite_first_rule(
         domain_builder=mock_domain_builder,
         expectation_configuration_builders=mock_expectation_configuration_builder,
     )
-    first_rule.to_json_dict = MagicMock(return_value=sample_rule_dict)
+    first_rule.to_json_dict = mocker.MagicMock(return_value=sample_rule_dict)
     profiler.add_rule(rule=first_rule)
     assert len(profiler.rules) == 1
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
-@mock.patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
-@mock.patch(
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.rule_based_profiler.domain_builder.ColumnDomainBuilder")
+@mock_patch(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_rule_add_second_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
-    mock_domain_builder: mock.MagicMock,  # noqa: TID251
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_expectation_configuration_builder: MagicMock,
+    mock_domain_builder: MagicMock,
+    mock_data_context: MagicMock,
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1438,9 +1451,9 @@ def test_add_rule_add_second_rule(
 
 
 @pytest.mark.unit
-@mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
+@mock_patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_rule_bad_rule(
-    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_data_context: MagicMock,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
         name="my_rbp",

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1249,7 +1249,7 @@ def test_get_profiler(
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_non_existent_profiler_raises_error(
     mock_data_context: mock.MagicMock,
-    empty_profiler_store: ProfilerStore,  # noqa: TID251
+    empty_profiler_store: ProfilerStore,
 ):
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
         RuleBasedProfiler.get_profiler(

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock  # noqa: TID251
 
 import pandas as pd
 import pytest
@@ -945,8 +945,8 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
 @mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_without_dynamic_args(
-    mock_data_context: mock.MagicMock,
-    mock_profiler_run: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_profiler_run: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -979,8 +979,8 @@ def test_run_profiler_without_dynamic_args(
 @mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_with_dynamic_args(
-    mock_data_context: mock.MagicMock,
-    mock_profiler_run: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_profiler_run: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1019,8 +1019,8 @@ def test_run_profiler_with_dynamic_args(
 @mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_on_data_creates_suite_with_dict_arg(
-    mock_data_context: mock.MagicMock,
-    mock_rule_based_profiler_run: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_rule_based_profiler_run: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1047,8 +1047,8 @@ def test_run_profiler_on_data_creates_suite_with_dict_arg(
 @mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
-    mock_data_context: mock.MagicMock,
-    mock_rule_based_profiler_run: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
+    mock_rule_based_profiler_run: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1079,7 +1079,7 @@ def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_with_too_many_args_raises_error(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
 ):
     with pytest.raises(AssertionError) as e:
@@ -1096,7 +1096,7 @@ def test_get_profiler_with_too_many_args_raises_error(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_serialize_profiler_config(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     profiler = BaseRuleBasedProfiler(
@@ -1158,7 +1158,7 @@ def test_serialize_profiler_config(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_profiler(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     profiler_key: ConfigurationIdentifier,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
@@ -1182,7 +1182,7 @@ def test_add_profiler(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_profiler_with_batch_request_containing_batch_data_raises_error(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
 ):
     name = "my_profiler_config"
     config_version = 1.0
@@ -1227,7 +1227,7 @@ def test_add_profiler_with_batch_request_containing_batch_data_raises_error(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     populated_profiler_store: ProfilerStore,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
@@ -1248,7 +1248,7 @@ def test_get_profiler(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_get_profiler_non_existent_profiler_raises_error(
-    mock_data_context: mock.MagicMock, empty_profiler_store: ProfilerStore
+    mock_data_context: mock.MagicMock, empty_profiler_store: ProfilerStore  # noqa: TID251
 ):
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
         RuleBasedProfiler.get_profiler(
@@ -1310,7 +1310,7 @@ def test_delete_profiler_non_existent_profiler_raises_error(
 
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.store.ProfilerStore")
-def test_list_profilers(mock_profiler_store: mock.MagicMock):
+def test_list_profilers(mock_profiler_store: mock.MagicMock):  # noqa: TID251
     store = mock_profiler_store()
     keys = ["a", "b", "c"]
     store.list_keys.return_value = [ConfigurationIdentifier(char) for char in keys]
@@ -1322,7 +1322,7 @@ def test_list_profilers(mock_profiler_store: mock.MagicMock):
 
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.store.ProfilerStore")
-def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):
+def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):  # noqa: TID251
     store = mock_profiler_store()
     keys = ["a", "b", "c"]
     store.list_keys.return_value = keys
@@ -1339,9 +1339,9 @@ def test_list_profilers_in_cloud_mode(mock_profiler_store: mock.MagicMock):
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_single_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,
-    mock_domain_builder: mock.MagicMock,
-    mock_data_context: mock.MagicMock,
+    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
+    mock_domain_builder: mock.MagicMock,  # noqa: TID251
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1377,9 +1377,9 @@ def test_add_single_rule(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_rule_overwrite_first_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,
-    mock_domain_builder: mock.MagicMock,
-    mock_data_context: mock.MagicMock,
+    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
+    mock_domain_builder: mock.MagicMock,  # noqa: TID251
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1405,9 +1405,9 @@ def test_add_rule_overwrite_first_rule(
     "great_expectations.rule_based_profiler.expectation_configuration_builder.DefaultExpectationConfigurationBuilder"
 )
 def test_add_rule_add_second_rule(
-    mock_expectation_configuration_builder: mock.MagicMock,
-    mock_domain_builder: mock.MagicMock,
-    mock_data_context: mock.MagicMock,
+    mock_expectation_configuration_builder: mock.MagicMock,  # noqa: TID251
+    mock_domain_builder: mock.MagicMock,  # noqa: TID251
+    mock_data_context: mock.MagicMock,  # noqa: TID251
     sample_rule_dict: dict,
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
@@ -1439,7 +1439,7 @@ def test_add_rule_add_second_rule(
 @pytest.mark.unit
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
 def test_add_rule_bad_rule(
-    mock_data_context: mock.MagicMock,
+    mock_data_context: mock.MagicMock,  # noqa: TID251
 ):
     profiler: RuleBasedProfiler = RuleBasedProfiler(
         name="my_rbp",


### PR DESCRIPTION
Ban the use (import) of `unittest.mock` `Mock` and `MagicMock` in tests.
Standard use of `Mock` & `MagicMock` does not automatically remove its mocks and so can affect unrelated tests.

To continue using `MagicMock` or `Mock` make use of the `mocker` fixture which automatically removes mocks after each test.
```python
import unittest.mock

def test_old_way():
  my_mock = unttest.mock.Mock()
  my_mock()
  my_mock.assert_called()

def test_new_way(mocker):
  my_mock = mocker.Mock()
  my_mock()
  my_mock.assert_called()

```

https://pytest-mock.readthedocs.io/en/latest/index.html
