### PR TITLE
[DOCS] Add Snowflake Connection Syntax Example

### DIFF
--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -49,7 +49,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is: `snowflake://<user_login_name>:<password>@<accountname>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/docs/cloud/data_assets/manage_data_assets.md
@@ -49,7 +49,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. 
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/docs/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/try_gx_cloud.md
@@ -104,7 +104,7 @@ Create a Data Asset to define the data you want GX Cloud to access within Snowfl
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is: `snowflake://<user_login_name>:<password>@<accountname>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/docs/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/docs/cloud/try_gx_cloud.md
@@ -104,7 +104,7 @@ Create a Data Asset to define the data you want GX Cloud to access within Snowfl
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. 
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
@@ -49,7 +49,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is: `snowflake://<user_login_name>:<password>@<accountname>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/data_assets/manage_data_assets.md
@@ -49,7 +49,7 @@ Define the data you want GX Cloud to access within Snowflake.
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. 
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
@@ -104,7 +104,7 @@ Create a Data Asset to define the data you want GX Cloud to access within Snowfl
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is: `snowflake://<user_login_name>:<password>@<accountname>`.
 
 5. Complete the following fields:
 

--- a/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/cloud/try_gx_cloud.md
@@ -104,7 +104,7 @@ Create a Data Asset to define the data you want GX Cloud to access within Snowfl
 
 3. Enter a meaningful name for the Data Asset in the **Data Source name** field.
 
-4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. 
+4. Optional. To use a connection string to connect to a Data Source, click the **Use connection string** selector, enter a connection string, and then move to step 6. The connection string format is `snowflake://<user_login_name>:<password>@<account_identifier>`.
 
 5. Complete the following fields:
 


### PR DESCRIPTION

Currently, the syntax for Snowflake connection strings is not defined in the GX Cloud documentation. This PR adds the syntax for Snowflake connection strings.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated