### PR TITLE
[DOCS] Posthog Instance

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -3,13 +3,14 @@
 const remarkNamedSnippets = require('./scripts/remark-named-snippets/index');
 const remarkCodeImport = require('remark-code-import');
 
-require('dotenv').config()
+const config = require('dotenv').config()
 
 module.exports = {
   title: 'Great Expectations',
   tagline: 'Always know what to expect from your data.',
   url: 'https://docs.greatexpectations.io', // Url to your site with no trailing slash
   baseUrl: '/',
+  customFields: {posthogApiKey: config.parsed.POSTHOG_API_KEY},
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: '/img/gx-mark.png',
@@ -23,15 +24,6 @@ module.exports = {
       require.resolve('docusaurus-gtm-plugin'),
       {
         id: 'GTM-K63L45F', // GTM Container ID
-      },
-    ],
-    [
-      'posthog-docusaurus',
-      {
-        apiKey: process.env.POSTHOG_API_KEY,
-        enableInDevelopment: true
-        // for more information on how to set up this value go to
-        // https://greatexpectations.atlassian.net/wiki/spaces/DVRL/pages/956334083/Manage+the+feedback+survey
       },
     ],
   ],

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -33,7 +33,6 @@
     "docusaurus-plugin-sass": "0.2.2",
     "dotenv": "^16.4.1",
     "plugin-image-zoom": "ataft/plugin-image-zoom",
-    "posthog-docusaurus": "^2.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-loadable": "5.5.0",
@@ -57,7 +56,8 @@
     "babel-jest": "^29.7.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "posthog-js": "^1.111.3"
   },
   "browserslist": {
     "production": [

--- a/docs/docusaurus/src/components/WasThisHelpful/index.js
+++ b/docs/docusaurus/src/components/WasThisHelpful/index.js
@@ -2,8 +2,20 @@ import React, {useState} from 'react';
 import styles from './styles.module.scss';
 import {useLocation} from "@docusaurus/router";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import { posthog as posthogJS } from 'posthog-js';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 export default function WasThisHelpful(){
+
+    const posthog = window.posthog
+    const config = useDocusaurusContext()
+
+    if (!posthog ) {
+        // Checking if Posthog is already initialized
+        posthogJS.init(config.siteConfig.customFields.posthogApiKey)
+        window.posthog = posthogJS
+    }
+
 
     const { pathname } = useLocation();
     const [feedbackSent, setFeedbackSent] = useState(false)

--- a/docs/docusaurus/src/components/WasThisHelpful/index.js
+++ b/docs/docusaurus/src/components/WasThisHelpful/index.js
@@ -4,7 +4,6 @@ import {useLocation} from "@docusaurus/router";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { posthog as posthogJS } from 'posthog-js';
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function WasThisHelpful(){
     const { pathname } = useLocation();
@@ -70,7 +69,7 @@ export default function WasThisHelpful(){
 
     const closeImg = useBaseUrl(`img/close_icon.svg`);
 
-    return <BrowserOnly>
+    return <>
             <hr className={styles.feedbackDivider}/>
             <section className={styles.feedbackCard}>
                 <h3 className={styles.feedbackCardTitle}>Was this helpful?</h3>
@@ -136,5 +135,5 @@ export default function WasThisHelpful(){
                     </form>
                 </dialog>
             </>}
-    </BrowserOnly>
+    </>
 }

--- a/docs/docusaurus/src/components/WasThisHelpful/index.js
+++ b/docs/docusaurus/src/components/WasThisHelpful/index.js
@@ -1,13 +1,25 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import styles from './styles.module.scss';
 import {useLocation} from "@docusaurus/router";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import { posthog as posthogJS } from 'posthog-js';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function WasThisHelpful(){
-
     const { pathname } = useLocation();
     const [feedbackSent, setFeedbackSent] = useState(false)
     const [isOpen, setIsOpen] = useState(false);
+    const config = useDocusaurusContext()
+
+    useEffect(() => {
+        const posthog = window.posthog
+        if (!posthog ) {
+            // Checking if Posthog is already initialized
+            posthogJS.init(config.siteConfig.customFields.posthogApiKey)
+            window.posthog = posthogJS
+        }
+    }, []);
 
     const [formData, setFormData] = useState({
         name: '',
@@ -58,7 +70,7 @@ export default function WasThisHelpful(){
 
     const closeImg = useBaseUrl(`img/close_icon.svg`);
 
-    return <>
+    return <BrowserOnly>
             <hr className={styles.feedbackDivider}/>
             <section className={styles.feedbackCard}>
                 <h3 className={styles.feedbackCardTitle}>Was this helpful?</h3>
@@ -124,5 +136,5 @@ export default function WasThisHelpful(){
                     </form>
                 </dialog>
             </>}
-    </>
+    </BrowserOnly>
 }

--- a/docs/docusaurus/src/components/WasThisHelpful/index.js
+++ b/docs/docusaurus/src/components/WasThisHelpful/index.js
@@ -12,8 +12,7 @@ export default function WasThisHelpful(){
     const config = useDocusaurusContext()
 
     useEffect(() => {
-        const posthog = window.posthog
-        if (!posthog ) {
+        if (window && !window.posthog) {
             // Checking if Posthog is already initialized
             posthogJS.init(config.siteConfig.customFields.posthogApiKey)
             window.posthog = posthogJS

--- a/docs/docusaurus/src/theme/MDXContent/index.js
+++ b/docs/docusaurus/src/theme/MDXContent/index.js
@@ -9,6 +9,6 @@ export default function MDXContent({children}) {
   } = children.type;
   return <MDXProvider components={MDXComponents}>
       {children}
-    { !frontMatter.hide_feedback_survey && <WasThisHelpful/> }
+    { !frontMatter.hide_feedback_survey && <BrowserOnly><WasThisHelpful/></BrowserOnly> }
   </MDXProvider>;
 }

--- a/docs/docusaurus/src/theme/MDXContent/index.js
+++ b/docs/docusaurus/src/theme/MDXContent/index.js
@@ -10,6 +10,6 @@ export default function MDXContent({children}) {
   } = children.type;
   return <MDXProvider components={MDXComponents}>
       {children}
-    { !frontMatter.hide_feedback_survey && <BrowserOnly><WasThisHelpful/></BrowserOnly> }
+    { !frontMatter.hide_feedback_survey && <BrowserOnly>{() => <WasThisHelpful/>}</BrowserOnly> }
   </MDXProvider>;
 }

--- a/docs/docusaurus/src/theme/MDXContent/index.js
+++ b/docs/docusaurus/src/theme/MDXContent/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {MDXProvider} from '@mdx-js/react';
 import MDXComponents from '@theme/MDXComponents';
 import WasThisHelpful from "../../components/WasThisHelpful";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function MDXContent({children}) {
   const {

--- a/docs/docusaurus/yarn.lock
+++ b/docs/docusaurus/yarn.lock
@@ -5830,9 +5830,9 @@ dot-prop@^5.2.0:
     is-obj "^2.0.0"
 
 dotenv@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.1.tgz#1d9931f1d3e5d2959350d1250efab299561f7f11"
-  integrity sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 duplexer3@^0.1.4:
   version "0.1.5"
@@ -6509,6 +6509,11 @@ feed@^4.2.2:
   integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
   dependencies:
     xml-js "^1.6.11"
+
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -9787,15 +9792,23 @@ postcss@^8.3.11, postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4.21:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-docusaurus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/posthog-docusaurus/-/posthog-docusaurus-2.0.0.tgz#8b8ac890a2d780c8097a1a9766a3d24d2a1f1177"
-  integrity sha512-nDSTIhmH/Fexv347Gx6wBCE97Z+fZTj0p/gqVYAaolMwSdVuzwyFWcFA+aW9uzA5Y5hjzRwwKJJOrIv8smkYkA==
+posthog-js@^1.111.3:
+  version "1.111.3"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.111.3.tgz#5f4524dd2c6757e141029a7b5be71a703796b04c"
+  integrity sha512-Ie04OWI4dzYoPbPXv8mgwEoklexA8RqwH0kYTZdMxY0T78Rym/yj9jwhYK+2NGgDATAVp9KMsz9MbdkchGWoHA==
+  dependencies:
+    fflate "^0.4.8"
+    preact "^10.19.3"
 
 preact@^10.13.2:
   version "10.18.1"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.18.1.tgz#3b84bb305f0b05f4ad5784b981d15fcec4e105da"
   integrity sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==
+
+preact@^10.19.3:
+  version "10.19.6"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.19.6.tgz#66007b67aad4d11899f583df1b0116d94a89b8f5"
+  integrity sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
# Description

[Deploy Preview](https://deploy-preview-9592.docs.greatexpectations.io)

To integrate Posthog with Docusaurus we were having a recursion issue because posthog was being initialized twice. When working locally it needs to be initialized, otherwise its already being set up elsewhere. 
Some browsers could handle the error, but Firefox crashed because of it:
![image](https://github.com/great-expectations/great_expectations/assets/38264052/4da3cfc2-1c9b-426e-8f93-445dce343926)
JS script twice in the HTML:
![image](https://github.com/great-expectations/great_expectations/assets/38264052/b6b97304-5091-4c47-a0d3-69eba842c393)

This PR contemplates the posibility of Posthog already being initialized and refactors the way it is set up and _when_ it set up to cover more border cases.


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
