### PR TITLE
[MAINTENANCE] Fix cloud e2e test

### DIFF
--- a/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
+++ b/tests/integration/cloud/end_to_end/test_snowflake_datasource.py
@@ -49,17 +49,19 @@ def datasource(
         connection_string=connection_string,
         create_temp_table=False,
     )
-    datasource.create_temp_table = True
+    updated_connection_string = f"{connection_string}&foo=bar"
+
+    datasource.connection_string = updated_connection_string  # type: ignore[assignment] # is a str
     datasource = context.sources.add_or_update_snowflake(datasource=datasource)
     assert (
-        datasource.create_temp_table is True
+        datasource.connection_string == updated_connection_string
     ), "The datasource was not updated in the previous method call."
-    datasource.create_temp_table = False
+    datasource.connection_string = connection_string  # type: ignore[assignment] # is a str
     datasource = context.add_or_update_datasource(datasource=datasource)  # type: ignore[assignment]
     assert (
-        datasource.create_temp_table is False
+        datasource.connection_string == connection_string
     ), "The datasource was not updated in the previous method call."
-    datasource.create_temp_table = True
+    datasource.connection_string = updated_connection_string  # type: ignore[assignment] # is a str
     datasource_dict = datasource.dict()
     # this is a bug - LATIKU-448
     # call to datasource.dict() results in a ConfigStr that fails pydantic
@@ -67,17 +69,18 @@ def datasource(
     datasource_dict["connection_string"] = str(datasource_dict["connection_string"])
     datasource = context.sources.add_or_update_snowflake(**datasource_dict)
     assert (
-        datasource.create_temp_table is True
+        datasource.connection_string == updated_connection_string
     ), "The datasource was not updated in the previous method call."
-    datasource.create_temp_table = False
+    datasource.connection_string = connection_string  # type: ignore[assignment] # is a str
     datasource_dict = datasource.dict()
     # this is a bug - LATIKU-448
     # call to datasource.dict() results in a ConfigStr that fails pydantic
     # validation on SnowflakeDatasource
     datasource_dict["connection_string"] = str(datasource_dict["connection_string"])
-    datasource = context.add_or_update_datasource(**datasource_dict)  # type: ignore[assignment]
+    _ = context.add_or_update_datasource(**datasource_dict)
+    datasource = context.get_datasource(datasource_name=datasource_name)  # type: ignore[assignment]
     assert (
-        datasource.create_temp_table is False
+        datasource.connection_string == connection_string
     ), "The datasource was not updated in the previous method call."
     return datasource
 


### PR DESCRIPTION
`create_temp_table` can only be `None` or `False` for `Postgres` & `Snowflake` datasources for Great Expectations Cloud due to performance issues when splitting assets.

Changed cloud e2e tests to modify a different field when testing update operations.
