### PR TITLE
[DOCS] remove extraneous expectation docs

### DIFF
--- a/great_expectations/expectations/__init__.py
+++ b/great_expectations/expectations/__init__.py
@@ -1,1 +1,2 @@
 from great_expectations.expectations.core import *
+from great_expectations.expectations.expectation import Expectation

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -252,6 +252,8 @@ class MetaExpectation(ModelMetaclass):
 class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
     """Base class for all Expectations.
 
+    For a list of all available expectation types, see the `Expectation Gallery <https://greatexpectations.io/expectations/>`_.
+
     Expectation classes *must* have the following attributes set:
         1. `domain_keys`: a tuple of the *keys* used to determine the domain of the
            expectation

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -110,7 +110,6 @@ P = ParamSpec("P")
 T = TypeVar("T", List[RenderedStringTemplateContent], RenderedAtomicContent)
 
 
-@public_api
 def render_evaluation_parameter_string(render_func: Callable[P, T]) -> Callable[P, T]:
     """Decorator for Expectation classes that renders evaluation parameters as strings.
 
@@ -1492,7 +1491,6 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         )
 
 
-@public_api
 class BatchExpectation(Expectation, ABC):
     """Base class for BatchExpectations.
 
@@ -1683,7 +1681,6 @@ class UnexpectedRowsExpectation(BatchExpectation, ABC):
         }
 
 
-@public_api
 class QueryExpectation(BatchExpectation, ABC):
     """Base class for QueryExpectations.
 
@@ -1782,7 +1779,6 @@ class QueryExpectation(BatchExpectation, ABC):
             warnings.warn(str(e), UserWarning)
 
 
-@public_api
 class ColumnAggregateExpectation(BatchExpectation, ABC):
     """Base class for column aggregate Expectations.
 
@@ -1810,7 +1806,6 @@ class ColumnAggregateExpectation(BatchExpectation, ABC):
     domain_type = MetricDomainTypes.COLUMN
 
 
-@public_api
 class ColumnMapExpectation(BatchExpectation, ABC):
     """Base class for ColumnMapExpectations.
 
@@ -2065,7 +2060,6 @@ class ColumnMapExpectation(BatchExpectation, ABC):
         )
 
 
-@public_api
 class ColumnPairMapExpectation(BatchExpectation, ABC):
     """Base class for ColumnPairMapExpectations.
 
@@ -2308,7 +2302,6 @@ class ColumnPairMapExpectation(BatchExpectation, ABC):
         )
 
 
-@public_api
 class MulticolumnMapExpectation(BatchExpectation, ABC):
     """Base class for MulticolumnMapExpectations.
 

--- a/great_expectations/expectations/expectation_configuration.py
+++ b/great_expectations/expectations/expectation_configuration.py
@@ -19,7 +19,6 @@ from typing import (
 from marshmallow import Schema, ValidationError, fields, post_dump, post_load, pre_dump
 from typing_extensions import TypedDict
 
-from great_expectations._docs_decorators import new_argument, public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.evaluation_parameters import (
     _deduplicate_evaluation_parameter_dependencies,
@@ -108,17 +107,6 @@ class KWargDetailsDict(TypedDict):
     default_kwarg_values: dict[str, str | bool | float | RuleBasedProfilerConfig | None]
 
 
-@public_api
-@new_argument(
-    argument_name="rendered_content",
-    version="0.15.14",
-    message="Used to include rendered content dictionary in expectation configuration.",
-)
-@new_argument(
-    argument_name="expectation_context",
-    version="0.13.44",
-    message="Used to support column descriptions in GX Cloud.",
-)
 class ExpectationConfiguration(SerializableDictDot):
     """Defines the parameters and name of a specific Expectation.
 
@@ -305,7 +293,6 @@ class ExpectationConfiguration(SerializableDictDot):
 
         return domain_kwargs
 
-    @public_api
     def get_success_kwargs(self) -> dict:
         """Gets the success and domain kwargs for this ExpectationConfiguration.
 
@@ -460,7 +447,6 @@ class ExpectationConfiguration(SerializableDictDot):
     def __str__(self):
         return json.dumps(self.to_json_dict(), indent=2)
 
-    @public_api
     @override
     def to_json_dict(self) -> Dict[str, JSONValues]:
         """Returns a JSON-serializable dict representation of this ExpectationConfiguration.

--- a/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
@@ -4,7 +4,6 @@ import logging
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type, Union
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.metric_domain_types import MetricDomainTypes
@@ -38,7 +37,6 @@ if TYPE_CHECKING:
     )
 
 
-@public_api
 def column_aggregate_value(
     engine: Type[ExecutionEngine],
     **kwargs,
@@ -108,7 +106,6 @@ def column_aggregate_value(
         )
 
 
-@public_api
 def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):
     """Provides engine-specific support for authoring a metric_fn with a simplified signature.
 
@@ -260,7 +257,6 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):
         raise ValueError("Unsupported engine for column_aggregate_partial")
 
 
-@public_api
 class ColumnAggregateMetricProvider(TableMetricProvider):
     """Base class for all Column Aggregate Metrics,
     which define metrics to be calculated in aggregate from a given column.

--- a/great_expectations/expectations/metrics/map_metric_provider/column_condition_partial.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_condition_partial.py
@@ -12,7 +12,6 @@ from typing import (
     Union,
 )
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
@@ -39,7 +38,6 @@ if TYPE_CHECKING:
     from great_expectations.compatibility import sqlalchemy
 
 
-@public_api
 def column_condition_partial(  # noqa: C901, PLR0915
     engine: Type[ExecutionEngine],
     partial_fn_type: Optional[MetricPartialFunctionTypes] = None,

--- a/great_expectations/expectations/metrics/map_metric_provider/column_map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_map_metric_provider.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.metrics.map_metric_provider.map_metric_provider import (
     MapMetricProvider,
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class ColumnMapMetricProvider(MapMetricProvider):
     """Defines metrics that are evaluated for every row for a single column. An example of a column map
     metric is `column_values.null` (which is implemented as a `ColumnMapMetricProvider`, a subclass of

--- a/great_expectations/expectations/metrics/map_metric_provider/column_pair_function_partial.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_pair_function_partial.py
@@ -9,7 +9,6 @@ from typing import (
     Type,
 )
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import (
@@ -31,7 +30,6 @@ from great_expectations.expectations.metrics.util import (
 logger = logging.getLogger(__name__)
 
 
-@public_api
 def column_pair_function_partial(  # noqa: C901 - 16
     engine: Type[ExecutionEngine],
     partial_fn_type: MetricPartialFunctionTypes | None = None,

--- a/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/column_pair_map_metric_provider.py
@@ -7,7 +7,6 @@ from typing import (
     Tuple,
 )
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.metrics.map_metric_provider.map_metric_provider import (
     MapMetricProvider,
@@ -23,7 +22,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class ColumnPairMapMetricProvider(MapMetricProvider):
     """Defines metrics that are evaluated for every row for a column pair. All column pair metrics require domain
     keys of `column_A` and `column_B`.

--- a/great_expectations/expectations/metrics/map_metric_provider/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_metric_provider.py
@@ -6,7 +6,6 @@ import warnings
 from typing import TYPE_CHECKING
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import (
@@ -82,7 +81,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class MapMetricProvider(MetricProvider):
     """The base class for defining metrics that are evaluated for every row. An example of a map metric is
     `column_values.null` (which is implemented as a `ColumnMapMetricProvider`, a subclass of `MapMetricProvider`).

--- a/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_metric_provider.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.expectations.metrics.map_metric_provider import (
     MapMetricProvider,
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class MulticolumnMapMetricProvider(MapMetricProvider):
     """Defines metrics that are evaluated for every row for a set of columns. All multi-column metrics require the
     domain key `column_list`.

--- a/great_expectations/expectations/metrics/metric_provider.py
+++ b/great_expectations/expectations/metrics/metric_provider.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Type, TypeVar
 from typing_extensions import ParamSpec
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import (
     MetricFunctionTypes,
@@ -34,7 +33,6 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-@public_api
 def metric_value(
     engine: Type[ExecutionEngine],
     metric_fn_type: Union[str, MetricFunctionTypes] = MetricFunctionTypes.VALUE,
@@ -69,7 +67,6 @@ def metric_value(
     return wrapper
 
 
-@public_api
 def metric_partial(
     engine: Type[ExecutionEngine],
     partial_fn_type: MetricPartialFunctionTypes,
@@ -112,7 +109,6 @@ def metric_partial(
     return wrapper
 
 
-@public_api
 class MetricProvider(metaclass=MetaMetricProvider):
     """Base class for all metric providers.
 

--- a/great_expectations/expectations/metrics/query_metric_provider.py
+++ b/great_expectations/expectations/metrics/query_metric_provider.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import logging
 from typing import ClassVar
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.expectations.metrics.metric_provider import MetricProvider
 
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class QueryMetricProvider(MetricProvider):
     """Base class for all Query Metrics, which define metrics to construct SQL queries.
 

--- a/great_expectations/expectations/metrics/table_metric_provider.py
+++ b/great_expectations/expectations/metrics/table_metric_provider.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import logging
 from typing import Tuple
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.expectations.metrics.metric_provider import MetricProvider
 
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class TableMetricProvider(MetricProvider):
     """Base class for all Table Metrics, which define metrics to be calculated across a complete table.
 

--- a/great_expectations/expectations/regex_based_column_map_expectation.py
+++ b/great_expectations/expectations/regex_based_column_map_expectation.py
@@ -4,7 +4,6 @@ import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Optional
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
@@ -48,7 +47,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class RegexColumnMapMetricProvider(ColumnMapMetricProvider):
     """Base class for all RegexColumnMapMetrics.
 
@@ -101,7 +99,6 @@ class RegexColumnMapMetricProvider(ColumnMapMetricProvider):
         return column.rlike(cls.regex)
 
 
-@public_api
 class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
     """Base class for RegexBasedColumnMapExpectations.
 
@@ -157,7 +154,6 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
         return map_metric
 
     @override
-    @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations._docs_decorators import public_api
 from great_expectations.core.id_dict import IDDict
 
 if TYPE_CHECKING:
@@ -229,7 +228,6 @@ def _add_response_key(res, key, value):
     return res
 
 
-@public_api
 def register_metric(  # noqa: PLR0913
     metric_name: str,
     metric_domain_keys: Tuple[str, ...],

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -4,7 +4,6 @@ import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Optional
 
-from great_expectations._docs_decorators import public_api
 from great_expectations.exceptions.exceptions import (
     InvalidExpectationConfigurationError,
 )
@@ -46,7 +45,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@public_api
 class SetColumnMapMetricProvider(ColumnMapMetricProvider):
     """Base class for all SetColumnMapMetrics.
 
@@ -88,7 +86,6 @@ class SetColumnMapMetricProvider(ColumnMapMetricProvider):
         return column.isin(cls.set_)
 
 
-@public_api
 class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
     """Base class for SetBasedColumnMapExpectations.
 


### PR DESCRIPTION
The only thing in 1.0 we want documented under expectations is `Expectation` itself.

![Screenshot 2024-03-14 at 4 31 17 PM](https://github.com/great-expectations/great_expectations/assets/5400974/005f3e22-1185-4d57-b949-98b11882896d)

Also added a link to the gallery.

![Screenshot 2024-03-14 at 4 41 31 PM](https://github.com/great-expectations/great_expectations/assets/5400974/5e25af00-cabe-4df3-b437-6f3ed2a9f633)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
