### PR TITLE
[MAINTENANCE] Rename legacy batch definitions

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.17/reference/expectations/result_format.py
+++ b/docs/docusaurus/versioned_docs/version-0.17/reference/expectations/result_format.py
@@ -9,7 +9,7 @@ from great_expectations.core import (
     IDDict,
 )
 from great_expectations.checkpoint import Checkpoint
-from great_expectations.core.batch import Batch, LegacyBatchDefinition
+from great_expectations.core.batch import Batch
 from great_expectations.execution_engine import PandasExecutionEngine
 from great_expectations.util import filter_properties_dict
 from great_expectations.validator.validator import Validator

--- a/docs/docusaurus/versioned_docs/version-0.17/reference/expectations/result_format.py
+++ b/docs/docusaurus/versioned_docs/version-0.17/reference/expectations/result_format.py
@@ -9,7 +9,7 @@ from great_expectations.core import (
     IDDict,
 )
 from great_expectations.checkpoint import Checkpoint
-from great_expectations.core.batch import Batch, BatchDefinition
+from great_expectations.core.batch import Batch, LegacyBatchDefinition
 from great_expectations.execution_engine import PandasExecutionEngine
 from great_expectations.util import filter_properties_dict
 from great_expectations.validator.validator import Validator

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -78,7 +78,7 @@ def _get_metrics_calculator_class() -> Type[MetricsCalculator]:
 
 
 @public_api
-class BatchDefinition(SerializableDictDot):
+class LegacyBatchDefinition(SerializableDictDot):
     """Precisely identifies a set of data from a data source.
 
     More concretely, a BatchDefinition includes all the information required to precisely
@@ -739,7 +739,7 @@ class Batch(SerializableDictDot):
         self,
         data: BatchDataType | None = None,
         batch_request: BatchRequestBase | dict | None = None,
-        batch_definition: BatchDefinition | None = None,
+        batch_definition: LegacyBatchDefinition | None = None,
         batch_spec: BatchSpec | None = None,
         batch_markers: BatchMarkers | None = None,
         # The remaining parameters are for backward compatibility.
@@ -838,7 +838,7 @@ class Batch(SerializableDictDot):
             "data": str(self.data),
             "batch_request": self.batch_request.to_dict(),
             "batch_definition": self.batch_definition.to_json_dict()
-            if isinstance(self.batch_definition, BatchDefinition)
+            if isinstance(self.batch_definition, LegacyBatchDefinition)
             else {},
             "batch_spec": self.batch_spec,
             "batch_markers": self.batch_markers,
@@ -863,7 +863,7 @@ class Batch(SerializableDictDot):
     @property
     def id(self):
         batch_definition = self._batch_definition
-        if isinstance(batch_definition, BatchDefinition):
+        if isinstance(batch_definition, LegacyBatchDefinition):
             return batch_definition.id
 
         if isinstance(batch_definition, IDDict):

--- a/great_expectations/core/batch_manager.py
+++ b/great_expectations/core/batch_manager.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 from great_expectations.core.batch import (
     Batch,
     BatchDataUnion,
-    BatchDefinition,
     BatchMarkers,
+    LegacyBatchDefinition,
     _get_fluent_batch_class,
 )
 
@@ -131,7 +131,7 @@ class BatchManager:
         return self.active_batch.batch_markers
 
     @property
-    def active_batch_definition(self) -> Optional[BatchDefinition]:
+    def active_batch_definition(self) -> Optional[LegacyBatchDefinition]:
         """Getter for the active batch's batch definition"""
         if not self.active_batch:
             return None

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -14,7 +14,10 @@ from great_expectations import __version__ as ge_version
 from great_expectations._docs_decorators import public_api
 from great_expectations.alias_types import JSONValues  # noqa: TCH001
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.batch import BatchDefinition, BatchMarkers  # noqa: TCH001
+from great_expectations.core.batch import (  # noqa: TCH001
+    BatchMarkers,
+    LegacyBatchDefinition,
+)
 from great_expectations.core.id_dict import BatchSpec  # noqa: TCH001
 from great_expectations.core.run_identifier import RunIdentifier  # noqa: TCH001
 from great_expectations.core.util import (
@@ -457,7 +460,7 @@ class ExpectationValidationResultSchema(Schema):
 
 
 class ExpectationSuiteValidationResultMeta(TypedDict):
-    active_batch_definition: BatchDefinition
+    active_batch_definition: LegacyBatchDefinition
     batch_markers: BatchMarkers
     batch_spec: BatchSpec
     checkpoint_id: Optional[str]

--- a/great_expectations/datasource/data_connector/batch_filter.py
+++ b/great_expectations/datasource/data_connector/batch_filter.py
@@ -12,7 +12,7 @@ from great_expectations.core.id_dict import IDDict
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -299,8 +299,8 @@ class BatchFilter:
         return str(doc_fields_dict)
 
     def select_from_data_connector_query(
-        self, batch_definition_list: Optional[List[BatchDefinition]] = None
-    ) -> List[BatchDefinition]:
+        self, batch_definition_list: Optional[List[LegacyBatchDefinition]] = None
+    ) -> List[LegacyBatchDefinition]:
         if batch_definition_list is None:
             return []
         filter_function: Callable
@@ -308,7 +308,7 @@ class BatchFilter:
             filter_function = self.custom_filter_function
         else:
             filter_function = self.best_effort_batch_definition_matcher()
-        selected_batch_definitions: List[BatchDefinition]
+        selected_batch_definitions: List[LegacyBatchDefinition]
         selected_batch_definitions = list(
             filter(
                 lambda batch_definition: filter_function(

--- a/great_expectations/datasource/data_connector/configured_asset_aws_glue_data_catalog_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_aws_glue_data_catalog_data_connector.py
@@ -8,10 +8,10 @@ from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility import aws
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequestBase,
     BatchSpec,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.batch_spec import GlueDataCatalogBatchSpec
 from great_expectations.datasource.data_connector import DataConnector
@@ -112,13 +112,13 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
 
     @override
     def build_batch_spec(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> GlueDataCatalogBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition
@@ -192,7 +192,7 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
         if len(self._data_references_cache) == 0:
             self._refresh_data_references_cache()
 
-        batch_definition_list: List[BatchDefinition] = []
+        batch_definition_list: List[LegacyBatchDefinition] = []
         try:
             sub_cache = self._get_data_reference_list_from_cache_by_data_asset_name(
                 data_asset_name=batch_request.data_asset_name
@@ -203,7 +203,7 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
             )
 
         for batch_identifiers in sub_cache:
-            batch_definition = BatchDefinition(
+            batch_definition = LegacyBatchDefinition(
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=batch_request.data_asset_name,
@@ -359,10 +359,10 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
     @override
     def _map_data_reference_to_batch_definition_list(
         self, data_reference, data_asset_name: Optional[str] = None
-    ) -> Optional[List[BatchDefinition]]:
+    ) -> Optional[List[LegacyBatchDefinition]]:
         # Note: data references *are* dictionaries, allowing us to invoke `IDDict(data_reference)`
         return [
-            BatchDefinition(
+            LegacyBatchDefinition(
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=data_asset_name,  # type: ignore[arg-type]
@@ -372,7 +372,7 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
 
     @override
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         """
         Build BatchSpec parameters from batch_definition with the following components:
@@ -381,7 +381,7 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
             3. data_asset from data_connector
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             dict built from batch_definition

--- a/great_expectations/datasource/data_connector/configured_asset_azure_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_azure_data_connector.py
@@ -17,7 +17,7 @@ from great_expectations.datasource.data_connector.util import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.data_connector.asset import Asset
     from great_expectations.execution_engine import ExecutionEngine
 
@@ -109,12 +109,14 @@ class ConfiguredAssetAzureDataConnector(ConfiguredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> AzureBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> AzureBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -12,7 +12,7 @@ from great_expectations.datasource.data_connector.file_path_data_connector impor
 from great_expectations.datasource.data_connector.util import _build_asset_from_config
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.core.batch_spec import PathBatchSpec
     from great_expectations.datasource.data_connector.asset.asset import (
         Asset,
@@ -108,7 +108,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
             for data_reference in self._get_data_reference_list(
                 data_asset_name=data_asset_name
             ):
-                mapped_batch_definition_list: List[BatchDefinition] = (
+                mapped_batch_definition_list: List[LegacyBatchDefinition] = (
                     self._map_data_reference_to_batch_definition_list(  # type: ignore[assignment]
                         data_reference=data_reference,
                         data_asset_name=data_asset_name,
@@ -167,8 +167,8 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         return unmatched_data_references
 
     @override
-    def _get_batch_definition_list_from_cache(self) -> List[BatchDefinition]:
-        batch_definition_list: List[BatchDefinition] = [
+    def _get_batch_definition_list_from_cache(self) -> List[LegacyBatchDefinition]:
+        batch_definition_list: List[LegacyBatchDefinition] = [
             batch_definitions[0]
             for data_reference_sub_cache in self._data_references_cache.values()
             for batch_definitions in data_reference_sub_cache.values()
@@ -222,12 +222,14 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         raise NotImplementedError
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> PathBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> PathBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/configured_asset_gcs_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_gcs_data_connector.py
@@ -13,7 +13,7 @@ from great_expectations.datasource.data_connector.configured_asset_file_path_dat
 from great_expectations.datasource.data_connector.util import list_gcs_keys
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.data_connector.asset import Asset
     from great_expectations.execution_engine import ExecutionEngine
 
@@ -108,12 +108,12 @@ class ConfiguredAssetGCSDataConnector(ConfiguredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> GCSBatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> GCSBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
@@ -16,7 +16,7 @@ from great_expectations.datasource.data_connector.util import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.data_connector.asset import Asset
     from great_expectations.execution_engine import ExecutionEngine
 
@@ -90,12 +90,12 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> S3BatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> S3BatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -7,10 +7,10 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchSpec,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource.data_connector.batch_filter import (
@@ -182,7 +182,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         if len(self._data_references_cache) == 0:
             self._refresh_data_references_cache()
 
-        batch_definition_list: List[BatchDefinition] = []
+        batch_definition_list: List[LegacyBatchDefinition] = []
         try:
             sub_cache = self._get_data_reference_list_from_cache_by_data_asset_name(
                 data_asset_name=batch_request.data_asset_name
@@ -193,7 +193,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             )
 
         for batch_identifiers in sub_cache:
-            batch_definition = BatchDefinition(
+            batch_definition = LegacyBatchDefinition(
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=batch_request.data_asset_name,
@@ -277,13 +277,13 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         return [(asset["table_name"], asset["type"]) for asset in self.assets.values()]
 
     def build_batch_spec(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> SqlAlchemyDatasourceBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition
@@ -424,11 +424,11 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
 
     def _sort_batch_definition_list(
         self,
-        batch_definition_list: List[BatchDefinition],
+        batch_definition_list: List[LegacyBatchDefinition],
         partitioner_method_name: Optional[str],
         partitioner_kwargs: Optional[Dict[str, Union[str, dict, None]]],
         sorters: Optional[dict],
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """Sort a list of batch definitions given the partitioner method used to define them.
 
         Args:
@@ -550,7 +550,7 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
             )
 
             batch_definition_list = [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     batch_identifiers=IDDict(batch_identifiers),
                     datasource_name=self.datasource_name,
                     data_connector_name=self.name,
@@ -625,7 +625,7 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
         return self._data_references_cache[data_asset_name]
 
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         """
         Build BatchSpec parameters from batch_definition with the following components:
@@ -634,7 +634,7 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
             3. data_asset from data_connector
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             dict built from batch_definition
@@ -649,7 +649,7 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
         }
 
     def _get_table_name_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> str:
         """
         Helper method called by _generate_batch_spec_parameters_from_batch_definition() to parse table_name from
@@ -675,11 +675,11 @@ this is fewer than number of sorters specified, which is {len(sorters)}.
         self,
         data_reference,
         data_asset_name: Optional[str] = None,  #: Any,
-    ) -> Optional[List[BatchDefinition]]:
+    ) -> Optional[List[LegacyBatchDefinition]]:
         # Note: This is a bit hacky, but it works. In sql_data_connectors, data references *are* dictionaries,
         # allowing us to invoke `IDDict(data_reference)`
         return [
-            BatchDefinition(
+            LegacyBatchDefinition(
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=data_asset_name,

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.core.batch import (
-    BatchDefinition,  # noqa: TCH001
     BatchMarkers,  # noqa: TCH001
     BatchRequestBase,  # noqa: TCH001
+    LegacyBatchDefinition,  # noqa: TCH001
 )
 from great_expectations.core.id_dict import BatchSpec
 
@@ -103,14 +103,14 @@ class DataConnector:
 
     def get_batch_data_and_metadata(
         self,
-        batch_definition: BatchDefinition,
+        batch_definition: LegacyBatchDefinition,
     ) -> Tuple[Any, BatchSpec, BatchMarkers]:  # batch_data
         """
         Uses batch_definition to retrieve batch_data and batch_markers by building a batch_spec from batch_definition,
         then using execution_engine to return batch_data and batch_markers
 
         Args:
-            batch_definition (BatchDefinition): required batch_definition parameter for retrieval
+            batch_definition (LegacyBatchDefinition): required batch_definition parameter for retrieval
 
         """
         batch_spec: BatchSpec = self.build_batch_spec(batch_definition=batch_definition)
@@ -124,12 +124,12 @@ class DataConnector:
             batch_markers,
         )
 
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> BatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> BatchSpec:
         """
         Builds batch_spec from batch_definition by generating batch_spec params and adding any pass_through params
 
         Args:
-            batch_definition (BatchDefinition): required batch_definition parameter for retrieval
+            batch_definition (LegacyBatchDefinition): required batch_definition parameter for retrieval
         Returns:
             BatchSpec object built from BatchDefinition
 
@@ -204,21 +204,21 @@ class DataConnector:
     def get_batch_definition_list_from_batch_request(
         self,
         batch_request: BatchRequestBase,
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         raise NotImplementedError
 
     def _map_data_reference_to_batch_definition_list(
         self, data_reference: Any, data_asset_name: Optional[str] = None
-    ) -> Optional[List[BatchDefinition]]:
+    ) -> Optional[List[LegacyBatchDefinition]]:
         raise NotImplementedError
 
     def _map_batch_definition_to_data_reference(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> Any:
         raise NotImplementedError
 
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         raise NotImplementedError
 

--- a/great_expectations/datasource/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/file_path_data_connector.py
@@ -8,10 +8,10 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
     BatchSpec,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.batch_spec import PathBatchSpec
 from great_expectations.core.util import AzureUrl, DBFSPath, GCSUrl, S3Url
@@ -207,7 +207,7 @@ class FilePathDataConnector(DataConnector):
     def get_batch_definition_list_from_batch_request(  # type: ignore[override] # BaseBatchRequest
         self,
         batch_request: BatchRequest,
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         Retrieve batch_definitions and that match batch_request.
 
@@ -230,7 +230,7 @@ class FilePathDataConnector(DataConnector):
     def _get_batch_definition_list_from_batch_request(
         self,
         batch_request: BatchRequestBase,
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         Retrieve batch_definitions that match batch_request.
 
@@ -251,7 +251,7 @@ class FilePathDataConnector(DataConnector):
             self._refresh_data_references_cache()
 
         # Use a combination of a list and set to preserve iteration order
-        batch_definition_list: List[BatchDefinition] = list()
+        batch_definition_list: List[LegacyBatchDefinition] = list()
         batch_definition_set = set()
         for batch_definition in self._get_batch_definition_list_from_cache():
             if (
@@ -286,8 +286,8 @@ class FilePathDataConnector(DataConnector):
         return batch_definition_list
 
     def _sort_batch_definition_list(
-        self, batch_definition_list: List[BatchDefinition]
-    ) -> List[BatchDefinition]:
+        self, batch_definition_list: List[LegacyBatchDefinition]
+    ) -> List[LegacyBatchDefinition]:
         """
         Use configured sorters to sort batch_definition
 
@@ -309,7 +309,7 @@ class FilePathDataConnector(DataConnector):
     @override
     def _map_data_reference_to_batch_definition_list(
         self, data_reference: str, data_asset_name: Optional[str] = None
-    ) -> Optional[List[BatchDefinition]]:
+    ) -> Optional[List[LegacyBatchDefinition]]:
         regex_config: dict = self._get_regex_config(data_asset_name=data_asset_name)
         pattern: str = regex_config["pattern"]
         group_names: List[str] = regex_config["group_names"]
@@ -324,7 +324,7 @@ class FilePathDataConnector(DataConnector):
 
     @override
     def _map_batch_definition_to_data_reference(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> str:
         data_asset_name: str = batch_definition.data_asset_name
         regex_config: dict = self._get_regex_config(data_asset_name=data_asset_name)
@@ -337,12 +337,14 @@ class FilePathDataConnector(DataConnector):
         )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> PathBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> PathBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition
@@ -362,7 +364,7 @@ class FilePathDataConnector(DataConnector):
 
     @override
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         path: str = self._map_batch_definition_to_data_reference(
             batch_definition=batch_definition
@@ -410,7 +412,7 @@ this is fewer than number of sorters specified, which is {len(self.sorters)}.
                     """
                 )
 
-    def _get_batch_definition_list_from_cache(self) -> List[BatchDefinition]:
+    def _get_batch_definition_list_from_cache(self) -> List[LegacyBatchDefinition]:
         raise NotImplementedError
 
     def _get_regex_config(self, data_asset_name: Optional[str] = None) -> dict:

--- a/great_expectations/datasource/data_connector/inferred_asset_azure_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_azure_data_connector.py
@@ -17,7 +17,7 @@ from great_expectations.datasource.data_connector.util import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
@@ -111,12 +111,14 @@ class InferredAssetAzureDataConnector(InferredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> AzureBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> AzureBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.batch import BatchDefinition, BatchRequestBase
+from great_expectations.core.batch import BatchRequestBase, LegacyBatchDefinition
 from great_expectations.core.batch_spec import BatchSpec, PathBatchSpec
 from great_expectations.datasource.data_connector.file_path_data_connector import (
     FilePathDataConnector,
@@ -64,7 +64,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
         self._data_references_cache = {}
 
         for data_reference in self._get_data_reference_list():
-            mapped_batch_definition_list: List[BatchDefinition] = (
+            mapped_batch_definition_list: List[LegacyBatchDefinition] = (
                 self._map_data_reference_to_batch_definition_list(  # type: ignore[assignment]
                     data_reference=data_reference, data_asset_name=None
                 )
@@ -105,7 +105,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             self._refresh_data_references_cache()
 
         # This will fetch ALL batch_definitions in the cache
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             self._get_batch_definition_list_from_batch_request(
                 batch_request=BatchRequestBase(
                     datasource_name=self.datasource_name,
@@ -123,12 +123,14 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
         return list(set(data_asset_names))
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> PathBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> PathBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition
@@ -140,8 +142,8 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
         return PathBatchSpec(batch_spec)
 
     @override
-    def _get_batch_definition_list_from_cache(self) -> List[BatchDefinition]:
-        batch_definition_list: List[BatchDefinition] = [
+    def _get_batch_definition_list_from_cache(self) -> List[LegacyBatchDefinition]:
+        batch_definition_list: List[LegacyBatchDefinition] = [
             batch_definitions[0]
             for batch_definitions in self._data_references_cache.values()
             if batch_definitions is not None

--- a/great_expectations/datasource/data_connector/inferred_asset_gcs_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_gcs_data_connector.py
@@ -13,7 +13,7 @@ from great_expectations.datasource.data_connector.inferred_asset_file_path_data_
 from great_expectations.datasource.data_connector.util import list_gcs_keys
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
@@ -111,12 +111,12 @@ class InferredAssetGCSDataConnector(InferredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> GCSBatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> GCSBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
@@ -17,7 +17,7 @@ from great_expectations.datasource.data_connector.util import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
@@ -95,12 +95,12 @@ class InferredAssetS3DataConnector(InferredAssetFilePathDataConnector):
             )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> S3BatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> S3BatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.batch import BatchDefinition, RuntimeBatchRequest
+from great_expectations.core.batch import LegacyBatchDefinition, RuntimeBatchRequest
 from great_expectations.core.batch_spec import (
     AzureBatchSpec,
     BatchMarkers,
@@ -214,7 +214,7 @@ class RuntimeDataConnector(DataConnector):
     @override
     def get_batch_data_and_metadata(  # type: ignore[override]
         self,
-        batch_definition: BatchDefinition,
+        batch_definition: LegacyBatchDefinition,
         runtime_parameters: dict,
     ) -> Tuple[Any, BatchSpec, BatchMarkers]:  # batch_data
         batch_spec: RuntimeDataBatchSpec = self.build_batch_spec(  # type: ignore[assignment]
@@ -235,7 +235,7 @@ class RuntimeDataConnector(DataConnector):
     def get_batch_definition_list_from_batch_request(  # type: ignore[override] # BatchRequestBase
         self,
         batch_request: RuntimeBatchRequest,
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         return self._get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
@@ -243,7 +243,7 @@ class RuntimeDataConnector(DataConnector):
     def _get_batch_definition_list_from_batch_request(
         self,
         batch_request: RuntimeBatchRequest,
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         <Will> 202103. The following behavior of the _data_references_cache follows a pattern that we are using for
         other data_connectors, including variations of FilePathDataConnector. When BatchRequest contains batch_data
@@ -269,8 +269,8 @@ class RuntimeDataConnector(DataConnector):
                 "Passed in a RuntimeBatchRequest with no batch_identifiers"
             )
 
-        batch_definition_list: List[BatchDefinition]
-        batch_definition = BatchDefinition(
+        batch_definition_list: List[LegacyBatchDefinition]
+        batch_definition = LegacyBatchDefinition(
             datasource_name=self.datasource_name,
             data_connector_name=self.name,
             data_asset_name=batch_request.data_asset_name,
@@ -313,7 +313,7 @@ class RuntimeDataConnector(DataConnector):
 
     @override
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         data_asset_name: str = batch_definition.data_asset_name
         return {"data_asset_name": data_asset_name}
@@ -323,7 +323,7 @@ class RuntimeDataConnector(DataConnector):
     @override
     def build_batch_spec(  # type: ignore[return,override]
         self,
-        batch_definition: BatchDefinition,
+        batch_definition: LegacyBatchDefinition,
         runtime_parameters: dict,
     ) -> Union[RuntimeDataBatchSpec, RuntimeQueryBatchSpec, PathBatchSpec]:
         self._validate_runtime_parameters(runtime_parameters=runtime_parameters)

--- a/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
@@ -9,7 +9,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.data_connector.sorter import Sorter
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class CustomListSorter(Sorter):
         return reference_list
 
     @override
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         batch_identifiers: dict = batch_definition.batch_identifiers
         batch_value: Any = batch_identifiers[self.name]
         if batch_value in self._reference_list:

--- a/great_expectations/datasource/data_connector/sorter/date_time_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/date_time_sorter.py
@@ -11,7 +11,7 @@ from great_expectations.core.util import datetime_to_int, parse_string_to_dateti
 from great_expectations.datasource.data_connector.sorter import Sorter
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class DateTimeSorter(Sorter):
         self._datetime_format = datetime_format
 
     @override
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         batch_identifiers: dict = batch_definition.batch_identifiers
         partition_value: Any = batch_identifiers[self.name]
         dt: datetime.date = parse_string_to_datetime(

--- a/great_expectations/datasource/data_connector/sorter/dictionary_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/dictionary_sorter.py
@@ -9,7 +9,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.data_connector.sorter import Sorter
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class DictionarySorter(Sorter):
         self._key_reference_list = key_reference_list
 
     @override
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         batch_identifiers: dict = batch_definition.batch_identifiers
         batch_keys: list[Any] | None
         if self._key_reference_list is None:

--- a/great_expectations/datasource/data_connector/sorter/lexicographic_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/lexicographic_sorter.py
@@ -8,14 +8,14 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.data_connector.sorter import Sorter
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
 
 class LexicographicSorter(Sorter):
     @override
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         batch_identifiers: dict = batch_definition.batch_identifiers
         batch_value: Any = batch_identifiers[self.name]
         return batch_value

--- a/great_expectations/datasource/data_connector/sorter/numeric_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/numeric_sorter.py
@@ -10,14 +10,14 @@ from great_expectations.datasource.data_connector.sorter import Sorter
 from great_expectations.util import is_int, is_numeric
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
 
 class NumericSorter(Sorter):
     @override
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         batch_identifiers: dict = batch_definition.batch_identifiers
         batch_value: Any = batch_identifiers[self.name]
         if not is_numeric(value=batch_value):

--- a/great_expectations/datasource/data_connector/sorter/sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/sorter.py
@@ -8,7 +8,7 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility.typing_extensions import override
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,8 @@ class Sorter:
         self._reverse = reverse
 
     def get_sorted_batch_definitions(
-        self, batch_definitions: List[BatchDefinition]
-    ) -> List[BatchDefinition]:
+        self, batch_definitions: List[LegacyBatchDefinition]
+    ) -> List[LegacyBatchDefinition]:
         none_batches: List[int] = []
         value_batches: List[int] = []
         for idx, batch_definition in enumerate(batch_definitions):
@@ -49,10 +49,10 @@ class Sorter:
             else:
                 value_batches.append(idx)
 
-        none_batch_definitions: List[BatchDefinition] = [
+        none_batch_definitions: List[LegacyBatchDefinition] = [
             batch_definitions[idx] for idx in none_batches
         ]
-        value_batch_definitions: List[BatchDefinition] = sorted(
+        value_batch_definitions: List[LegacyBatchDefinition] = sorted(
             [batch_definitions[idx] for idx in value_batches],
             key=self.get_batch_key,
             reverse=self.reverse,
@@ -64,7 +64,7 @@ class Sorter:
             return value_batch_definitions + none_batch_definitions
         return none_batch_definitions + value_batch_definitions
 
-    def get_batch_key(self, batch_definition: BatchDefinition) -> Any:
+    def get_batch_key(self, batch_definition: LegacyBatchDefinition) -> Any:
         raise NotImplementedError
 
     @property

--- a/great_expectations/datasource/data_connector/util.py
+++ b/great_expectations/datasource/data_connector/util.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, U
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import azure
-from great_expectations.core.batch import BatchDefinition, BatchRequestBase
+from great_expectations.core.batch import BatchRequestBase, LegacyBatchDefinition
 from great_expectations.core.id_dict import IDDict
 from great_expectations.data_context.types.base import assetConfigSchema
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -30,10 +30,10 @@ DEFAULT_DATA_ASSET_NAME: str = "DEFAULT_ASSET_NAME"
 
 
 def batch_definition_matches_batch_request(  # noqa: C901, PLR0911
-    batch_definition: BatchDefinition,
+    batch_definition: LegacyBatchDefinition,
     batch_request: BatchRequestBase,
 ) -> bool:
-    assert isinstance(batch_definition, BatchDefinition)
+    assert isinstance(batch_definition, LegacyBatchDefinition)
     assert isinstance(batch_request, BatchRequestBase)
 
     if (
@@ -92,7 +92,7 @@ def map_data_reference_string_to_batch_definition_list_using_regex(  # noqa: PLR
     regex_pattern: str,
     group_names: List[str],
     data_asset_name: Optional[str] = None,
-) -> Optional[List[BatchDefinition]]:
+) -> Optional[List[LegacyBatchDefinition]]:
     processed_data_reference: Optional[Tuple[str, IDDict]] = (
         convert_data_reference_string_to_batch_identifiers_using_regex(
             data_reference=data_reference,
@@ -110,7 +110,7 @@ def map_data_reference_string_to_batch_definition_list_using_regex(  # noqa: PLR
         data_asset_name = data_asset_name_from_batch_identifiers
 
     return [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name=datasource_name,
             data_connector_name=data_connector_name,
             data_asset_name=data_asset_name,
@@ -165,11 +165,11 @@ def _determine_batch_identifiers_using_named_groups(
 
 
 def map_batch_definition_to_data_reference_string_using_regex(
-    batch_definition: BatchDefinition,
+    batch_definition: LegacyBatchDefinition,
     regex_pattern: re.Pattern,
     group_names: List[str],
 ) -> str:
-    if not isinstance(batch_definition, BatchDefinition):
+    if not isinstance(batch_definition, LegacyBatchDefinition):
         raise TypeError(
             "batch_definition is not of an instance of type BatchDefinition"
         )

--- a/great_expectations/datasource/fluent/data_asset/data_connector/azure_blob_storage_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/azure_blob_storage_data_connector.py
@@ -17,7 +17,7 @@ from great_expectations.datasource.fluent.data_asset.data_connector import (
 
 if TYPE_CHECKING:
     from great_expectations.compatibility import azure
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 
 logger = logging.getLogger(__name__)
@@ -195,12 +195,14 @@ class AzureBlobStorageDataConnector(FilePathDataConnector):
         )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> AzureBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> AzureBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/fluent/data_asset/data_connector/data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/data_connector.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, List, Type
 from great_expectations.core.id_dict import BatchSpec
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.fluent import BatchRequest
 
 
@@ -63,7 +63,7 @@ class DataConnector(ABC):
     @abstractmethod
     def get_batch_definition_list(
         self, batch_request: BatchRequest
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         This interface method, implemented by subclasses, examines "BatchRequest" and converts it to one or more
         "BatchDefinition" objects, each of which can be later converted to ExecutionEngine-specific "BatchSpec" object
@@ -77,12 +77,12 @@ class DataConnector(ABC):
         """
         pass
 
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> BatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> BatchSpec:
         """
         Builds batch_spec from batch_definition by generating batch_spec params and adding any pass_through params
 
         Args:
-            batch_definition (BatchDefinition): required batch_definition parameter for retrieval
+            batch_definition (LegacyBatchDefinition): required batch_definition parameter for retrieval
         Returns:
             BatchSpec object built from BatchDefinition
         """
@@ -163,7 +163,7 @@ class DataConnector(ABC):
 
     @abstractmethod
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         """
         This interface method, implemented by subclasses, examines "BatchDefinition" and converts it to
@@ -180,7 +180,7 @@ class DataConnector(ABC):
 
     @staticmethod
     def _batch_definition_matches_batch_request(
-        batch_definition: BatchDefinition, batch_request: BatchRequest
+        batch_definition: LegacyBatchDefinition, batch_request: BatchRequest
     ) -> bool:
         if not (
             batch_request.datasource_name == batch_definition.datasource_name

--- a/great_expectations/datasource/fluent/data_asset/data_connector/dbfs_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/dbfs_data_connector.py
@@ -15,7 +15,7 @@ from great_expectations.datasource.fluent.data_asset.data_connector.file_path_da
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.fluent import BatchRequest
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class DBFSDataConnector(FilesystemDataConnector):
         # TODO: <Alex>ALEX</Alex>
         file_path_template_map_fn: Optional[Callable] = None,
         get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[BatchDefinition]
+            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
         ] = file_get_unfiltered_batch_definition_list_fn,
     ) -> None:
         super().__init__(
@@ -87,7 +87,7 @@ class DBFSDataConnector(FilesystemDataConnector):
         # TODO: <Alex>ALEX</Alex>
         file_path_template_map_fn: Optional[Callable] = None,
         get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[BatchDefinition]
+            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
         ] = file_get_unfiltered_batch_definition_list_fn,
     ) -> DBFSDataConnector:
         """Builds "DBFSDataConnector", which links named DataAsset to DBFS.

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Un
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.batch_spec import BatchSpec, PathBatchSpec
 from great_expectations.datasource.data_connector.batch_filter import (
     BatchFilter,
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 def file_get_unfiltered_batch_definition_list_fn(
     data_connector: FilePathDataConnector, batch_request: BatchRequest
-) -> list[BatchDefinition]:
+) -> list[LegacyBatchDefinition]:
     """Get all batch definitions for all files from a data connector using the supplied batch request.
 
     Args:
@@ -51,7 +51,7 @@ def file_get_unfiltered_batch_definition_list_fn(
     """
 
     # Use a combination of a list and set to preserve iteration order
-    batch_definition_list: list[BatchDefinition] = list()
+    batch_definition_list: list[LegacyBatchDefinition] = list()
     batch_definition_set = set()
     for (
         batch_definition
@@ -70,11 +70,11 @@ def file_get_unfiltered_batch_definition_list_fn(
 
 def make_directory_get_unfiltered_batch_definition_list_fn(
     data_directory: PathStr,
-) -> Callable[[FilePathDataConnector, BatchRequest], list[BatchDefinition]]:
+) -> Callable[[FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]]:
     def directory_get_unfiltered_batch_definition_list_fn(
         data_connector: FilePathDataConnector,
         batch_request: BatchRequest,
-    ) -> list[BatchDefinition]:
+    ) -> list[LegacyBatchDefinition]:
         """Get a single batch definition for the directory supplied in data_directory.
 
         Args:
@@ -85,7 +85,7 @@ def make_directory_get_unfiltered_batch_definition_list_fn(
         Returns:
             List containing a single batch definition referencing the directory of interest.
         """
-        batch_definition = BatchDefinition(
+        batch_definition = LegacyBatchDefinition(
             datasource_name=data_connector.datasource_name,
             data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=data_connector.data_asset_name,
@@ -134,7 +134,7 @@ class FilePathDataConnector(DataConnector):
         # TODO: <Alex>ALEX</Alex>
         file_path_template_map_fn: Optional[Callable] = None,
         get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[BatchDefinition]
+            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
         ] = file_get_unfiltered_batch_definition_list_fn,
     ) -> None:
         super().__init__(
@@ -158,7 +158,7 @@ class FilePathDataConnector(DataConnector):
         )
 
         # This is a dictionary which maps data_references onto batch_requests.
-        self._data_references_cache: Dict[str, List[BatchDefinition] | None] = {}
+        self._data_references_cache: Dict[str, List[LegacyBatchDefinition] | None] = {}
 
     # TODO: <Alex>ALEX_INCLUDE_SORTERS_FUNCTIONALITY_UNDER_PYDANTIC-MAKE_SURE_SORTER_CONFIGURATIONS_ARE_VALIDATED</Alex>
     # TODO: <Alex>ALEX</Alex>
@@ -171,7 +171,7 @@ class FilePathDataConnector(DataConnector):
     @override
     def get_batch_definition_list(
         self, batch_request: BatchRequest
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         Retrieve batch_definitions and that match batch_request.
 
@@ -189,7 +189,7 @@ class FilePathDataConnector(DataConnector):
             A list of BatchDefinition objects that match BatchRequest
 
         """
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             self._get_unfiltered_batch_definition_list_fn(self, batch_request)
         )
 
@@ -225,12 +225,14 @@ class FilePathDataConnector(DataConnector):
         return batch_definition_list
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> PathBatchSpec:
+    def build_batch_spec(
+        self, batch_definition: LegacyBatchDefinition
+    ) -> PathBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition
@@ -308,7 +310,7 @@ class FilePathDataConnector(DataConnector):
         """
 
         def _matching_criterion(
-            batch_definition_list: Union[List[BatchDefinition], None],
+            batch_definition_list: Union[List[LegacyBatchDefinition], None],
         ) -> bool:
             return (
                 (batch_definition_list is not None)
@@ -316,7 +318,9 @@ class FilePathDataConnector(DataConnector):
                 else (batch_definition_list is None)
             )
 
-        data_reference_mapped_element: Tuple[str, Union[List[BatchDefinition], None]]
+        data_reference_mapped_element: Tuple[
+            str, Union[List[LegacyBatchDefinition], None]
+        ]
         # noinspection PyTypeChecker
         unmatched_data_references: List[str] = list(
             dict(
@@ -333,7 +337,7 @@ class FilePathDataConnector(DataConnector):
     # Interface Method
     @override
     def _generate_batch_spec_parameters_from_batch_definition(
-        self, batch_definition: BatchDefinition
+        self, batch_definition: LegacyBatchDefinition
     ) -> dict:
         """
         This interface method examines "BatchDefinition" object and converts it to exactly one "data_reference" handle,
@@ -387,7 +391,9 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
 
         return regex
 
-    def _get_data_references_cache(self) -> Dict[str, List[BatchDefinition] | None]:
+    def _get_data_references_cache(
+        self,
+    ) -> Dict[str, List[LegacyBatchDefinition] | None]:
         """
         This prototypical method populates cache, whose keys are data references and values are "BatchDefinition"
         objects.  Subsequently, "BatchDefinition" objects generated are amenable to flexible querying and sorting.
@@ -399,7 +405,7 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         if len(self._data_references_cache) == 0:
             # Map data_references to batch_definitions.
             for data_reference in self.get_data_references():
-                mapped_batch_definition_list: List[BatchDefinition] | None = (
+                mapped_batch_definition_list: List[LegacyBatchDefinition] | None = (
                     self._map_data_reference_string_to_batch_definition_list_using_regex(
                         data_reference=data_reference
                     )
@@ -436,8 +442,8 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
 
     def _get_batch_definition_list_from_data_references_cache(
         self,
-    ) -> List[BatchDefinition]:
-        batch_definition_list: List[BatchDefinition] = [
+    ) -> List[LegacyBatchDefinition]:
+        batch_definition_list: List[LegacyBatchDefinition] = [
             batch_definitions[0]
             for batch_definitions in self._get_data_references_cache().values()
             if batch_definitions is not None
@@ -446,7 +452,7 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
 
     def _map_data_reference_string_to_batch_definition_list_using_regex(
         self, data_reference: str
-    ) -> List[BatchDefinition] | None:
+    ) -> List[LegacyBatchDefinition] | None:
         batch_identifiers: Optional[IDDict] = (
             self._convert_data_reference_string_to_batch_identifiers_using_regex(
                 data_reference=data_reference
@@ -456,10 +462,10 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
             return None
 
         # Importing at module level causes circular dependencies.
-        from great_expectations.core.batch import BatchDefinition
+        from great_expectations.core.batch import LegacyBatchDefinition
 
         return [
-            BatchDefinition(
+            LegacyBatchDefinition(
                 datasource_name=self._datasource_name,
                 data_connector_name=_DATA_CONNECTOR_NAME,
                 data_asset_name=self._data_asset_name,

--- a/great_expectations/datasource/fluent/data_asset/data_connector/filesystem_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/filesystem_data_connector.py
@@ -19,7 +19,7 @@ from great_expectations.datasource.fluent.data_asset.data_connector.file_path_da
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
     from great_expectations.datasource.fluent import BatchRequest
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         # TODO: <Alex>ALEX</Alex>
         file_path_template_map_fn: Optional[Callable] = None,
         get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[BatchDefinition]
+            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
         ] = file_get_unfiltered_batch_definition_list_fn,
     ) -> None:
         self._base_directory = base_directory
@@ -110,7 +110,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         # TODO: <Alex>ALEX</Alex>
         file_path_template_map_fn: Optional[Callable] = None,
         get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[BatchDefinition]
+            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
         ] = file_get_unfiltered_batch_definition_list_fn,
     ) -> FilesystemDataConnector:
         """Builds "FilesystemDataConnector", which links named DataAsset to filesystem.

--- a/great_expectations/datasource/fluent/data_asset/data_connector/google_cloud_storage_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/google_cloud_storage_data_connector.py
@@ -17,7 +17,7 @@ from great_expectations.datasource.fluent.data_asset.data_connector import (
 
 if TYPE_CHECKING:
     from great_expectations.compatibility import google
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 
 logger = logging.getLogger(__name__)
@@ -193,12 +193,12 @@ class GoogleCloudStorageDataConnector(FilePathDataConnector):
         )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> GCSBatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> GCSBatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/fluent/data_asset/data_connector/s3_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/s3_data_connector.py
@@ -18,7 +18,7 @@ from great_expectations.datasource.fluent.data_asset.data_connector import (
 if TYPE_CHECKING:
     from botocore.client import BaseClient
 
-    from great_expectations.core.batch import BatchDefinition
+    from great_expectations.core.batch import LegacyBatchDefinition
 
 
 logger = logging.getLogger(__name__)
@@ -194,12 +194,12 @@ class S3DataConnector(FilePathDataConnector):
         )
 
     @override
-    def build_batch_spec(self, batch_definition: BatchDefinition) -> S3BatchSpec:
+    def build_batch_spec(self, batch_definition: LegacyBatchDefinition) -> S3BatchSpec:
         """
         Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
 
         Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
+            batch_definition (LegacyBatchDefinition): to be used to build batch_spec
 
         Returns:
             BatchSpec built from batch_definition

--- a/great_expectations/datasource/fluent/directory_data_asset.py
+++ b/great_expectations/datasource/fluent/directory_data_asset.py
@@ -5,7 +5,7 @@ import pathlib
 from typing import TYPE_CHECKING, Callable
 
 from great_expectations.compatibility.typing_extensions import override
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.id_dict import IDDict
 from great_expectations.datasource.fluent.constants import (
     _DATA_CONNECTOR_NAME,
@@ -32,7 +32,7 @@ class _DirectoryDataAssetMixin(_FilePathDataAsset):
     @override
     def _get_batch_definition_list(
         self, batch_request: BatchRequest
-    ) -> list[BatchDefinition]:
+    ) -> list[LegacyBatchDefinition]:
         """Generate a batch definition list from a given batch request, handling a partitioner config if present.
 
         Args:
@@ -48,7 +48,7 @@ class _DirectoryDataAssetMixin(_FilePathDataAsset):
             if not batch_identifiers.get("path"):
                 batch_identifiers["path"] = self.data_directory
 
-            batch_definition = BatchDefinition(
+            batch_definition = LegacyBatchDefinition(
                 datasource_name=self._data_connector.datasource_name,
                 data_connector_name=_DATA_CONNECTOR_NAME,
                 data_asset_name=self._data_connector.data_asset_name,
@@ -64,7 +64,7 @@ class _DirectoryDataAssetMixin(_FilePathDataAsset):
     @override
     def get_unfiltered_batch_definition_list_fn(
         self,
-    ) -> Callable[[FilePathDataConnector, BatchRequest], list[BatchDefinition]]:
+    ) -> Callable[[FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]]:
         """Get the asset specific function for retrieving the unfiltered list of batch definitions."""
         return make_directory_get_unfiltered_batch_definition_list_fn(
             self.data_directory

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -65,7 +65,7 @@ from great_expectations.datasource.fluent.spark_generic_partitioners import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import BatchDefinition, BatchMarkers
+    from great_expectations.core.batch import BatchMarkers, LegacyBatchDefinition
     from great_expectations.core.id_dict import BatchSpec
     from great_expectations.core.partitioners import Partitioner
     from great_expectations.datasource.fluent.data_asset.data_connector import (
@@ -337,7 +337,7 @@ class _FilePathDataAsset(DataAsset):
 
     def _get_batch_definition_list(
         self, batch_request: BatchRequest
-    ) -> list[BatchDefinition]:
+    ) -> list[LegacyBatchDefinition]:
         """Generate a batch definition list from a given batch request, handling a partitioner config if present.
 
         Args:
@@ -434,7 +434,7 @@ class _FilePathDataAsset(DataAsset):
 
     def get_unfiltered_batch_definition_list_fn(
         self,
-    ) -> Callable[[FilePathDataConnector, BatchRequest], list[BatchDefinition]]:
+    ) -> Callable[[FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]]:
         """Get the asset specific function for retrieving the unfiltered list of batch definitions."""
         return file_get_unfiltered_batch_definition_list_fn
 

--- a/great_expectations/datasource/fluent/interfaces.py
+++ b/great_expectations/datasource/fluent/interfaces.py
@@ -69,8 +69,8 @@ if TYPE_CHECKING:
     )
     from great_expectations.core.batch import (
         BatchData,
-        BatchDefinition,
         BatchMarkers,
+        LegacyBatchDefinition,
     )
     from great_expectations.core.config_provider import _ConfigurationProvider
     from great_expectations.core.id_dict import BatchSpec
@@ -889,7 +889,7 @@ class Batch:
         data: BatchData,
         batch_markers: BatchMarkers,
         batch_spec: BatchSpec,
-        batch_definition: BatchDefinition,
+        batch_definition: LegacyBatchDefinition,
         metadata: Dict[str, Any] | None = None,
     ):
         # Immutable attributes
@@ -944,7 +944,7 @@ class Batch:
         return self._batch_spec
 
     @property
-    def batch_definition(self) -> BatchDefinition:
+    def batch_definition(self) -> LegacyBatchDefinition:
         return self._batch_definition
 
     @property

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -146,9 +146,9 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
         # it in the future.
         # imports are done inline to prevent a circular dependency with core/batch.py
         from great_expectations.core import IDDict
-        from great_expectations.core.batch import BatchDefinition
+        from great_expectations.core.batch import LegacyBatchDefinition
 
-        batch_definition = BatchDefinition(
+        batch_definition = LegacyBatchDefinition(
             datasource_name=self.datasource.name,
             data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,
@@ -468,9 +468,9 @@ class DataFrameAsset(_PandasDataAsset, Generic[_PandasDataFrameT]):
         # it in the future.
         # imports are done inline to prevent a circular dependency with core/batch.py
         from great_expectations.core import IDDict
-        from great_expectations.core.batch import BatchDefinition
+        from great_expectations.core.batch import LegacyBatchDefinition
 
-        batch_definition = BatchDefinition(
+        batch_definition = LegacyBatchDefinition(
             datasource_name=self.datasource.name,
             data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,

--- a/great_expectations/datasource/fluent/spark_datasource.py
+++ b/great_expectations/datasource/fluent/spark_datasource.py
@@ -308,9 +308,9 @@ class DataFrameAsset(DataAsset, Generic[_SparkDataFrameT]):
         # it in the future.
         # imports are done inline to prevent a circular dependency with core/batch.py
         from great_expectations.core import IDDict
-        from great_expectations.core.batch import BatchDefinition
+        from great_expectations.core.batch import LegacyBatchDefinition
 
-        batch_definition = BatchDefinition(
+        batch_definition = LegacyBatchDefinition(
             datasource_name=self.datasource.name,
             data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -645,9 +645,9 @@ class _SQLAsset(DataAsset):
             # it in the future.
             # imports are done inline to prevent a circular dependency with core/batch.py
             from great_expectations.core import IDDict
-            from great_expectations.core.batch import BatchDefinition
+            from great_expectations.core.batch import LegacyBatchDefinition
 
-            batch_definition = BatchDefinition(
+            batch_definition = LegacyBatchDefinition(
                 datasource_name=self.datasource.name,
                 data_connector_name=_DATA_CONNECTOR_NAME,
                 data_asset_name=self.name,

--- a/great_expectations/datasource/new_datasource.py
+++ b/great_expectations/datasource/new_datasource.py
@@ -8,9 +8,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     BatchMarkers,
     BatchRequest,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -86,7 +86,7 @@ class BaseDatasource:
 
     def get_batch_from_batch_definition(
         self,
-        batch_definition: BatchDefinition,
+        batch_definition: LegacyBatchDefinition,
         batch_data: Any = None,
     ) -> Batch:
         """
@@ -129,7 +129,7 @@ class BaseDatasource:
 
     def get_batch_definition_list_from_batch_request(
         self, batch_request: Union[BatchRequest, RuntimeBatchRequest]
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         """
         Validates batch request and utilizes the classes'
         Data Connectors' property to get a list of batch definition given a batch request
@@ -162,7 +162,7 @@ class BaseDatasource:
             batch_request.data_connector_name
         ]
 
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             data_connector.get_batch_definition_list_from_batch_request(
                 batch_request=batch_request
             )
@@ -330,7 +330,7 @@ class BaseDatasource:
 
     def get_available_batch_definitions(
         self, batch_request: Union[BatchRequest, RuntimeBatchRequest]
-    ) -> List[BatchDefinition]:
+    ) -> List[LegacyBatchDefinition]:
         self._validate_batch_request(batch_request=batch_request)
 
         data_connector: DataConnector = self.data_connectors[

--- a/great_expectations/experimental/datasource/fabric.py
+++ b/great_expectations/experimental/datasource/fabric.py
@@ -108,9 +108,9 @@ class _PowerBIAsset(DataAsset):
         # it in the future.
         # imports are done inline to prevent a circular dependency with core/batch.py
         from great_expectations.core import IDDict
-        from great_expectations.core.batch import BatchDefinition
+        from great_expectations.core.batch import LegacyBatchDefinition
 
-        batch_definition = BatchDefinition(
+        batch_definition = LegacyBatchDefinition(
             datasource_name=self.datasource.name,
             data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -53,7 +53,7 @@ from great_expectations.core import (
     ExpectationValidationResultSchema,
     IDDict,
 )
-from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest
+from great_expectations.core.batch import Batch, BatchRequest, LegacyBatchDefinition
 from great_expectations.core.util import (
     get_sql_dialect_floating_point_infinity_value,
 )
@@ -698,7 +698,7 @@ def _get_test_validator_with_data_pandas(
         # noinspection PyUnusedLocal
         table_name = generate_test_table_name()
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="pandas_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -855,7 +855,7 @@ def _get_test_validator_with_data_spark(  # noqa: C901, PLR0912, PLR0915
         columns = list(data.keys())
         spark_df = spark.createDataFrame(data_reshaped, columns)
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -872,7 +872,7 @@ def _get_test_validator_with_data_spark(  # noqa: C901, PLR0912, PLR0915
 
 def build_pandas_validator_with_data(
     df: pd.DataFrame,
-    batch_definition: Optional[BatchDefinition] = None,
+    batch_definition: Optional[LegacyBatchDefinition] = None,
     context: Optional[AbstractDataContext] = None,
 ) -> Validator:
     batch = Batch(data=df, batch_definition=batch_definition)  # type: ignore[arg-type]
@@ -897,7 +897,7 @@ def build_sa_validator_with_data(  # noqa: C901, PLR0912, PLR0913, PLR0915
     caching=True,
     sqlite_db_path=None,
     extra_debug_info="",
-    batch_definition: Optional[BatchDefinition] = None,
+    batch_definition: Optional[LegacyBatchDefinition] = None,
     debug_logger: Optional[logging.Logger] = None,
     context: Optional[AbstractDataContext] = None,
     pk_column: bool = False,
@@ -1175,7 +1175,7 @@ def modify_locale(func: Callable[P, None]) -> Callable[P, None]:
 def build_spark_validator_with_data(
     df: Union[pd.DataFrame, pyspark.DataFrame],
     spark: pyspark.SparkSession,
-    batch_definition: Optional[BatchDefinition] = None,
+    batch_definition: Optional[LegacyBatchDefinition] = None,
     context: Optional[AbstractDataContext] = None,
 ) -> Validator:
     if isinstance(df, pd.DataFrame):
@@ -1263,7 +1263,7 @@ def build_spark_engine(
     df: Union[pd.DataFrame, pyspark.DataFrame],
     schema: Optional[pyspark.types.StructType] = None,
     batch_id: Optional[str] = None,
-    batch_definition: Optional[BatchDefinition] = None,
+    batch_definition: Optional[LegacyBatchDefinition] = None,
 ) -> SparkDFExecutionEngine:
     if (
         sum(
@@ -1280,7 +1280,7 @@ def build_spark_engine(
         )
 
     if batch_id is None:
-        batch_id = cast(BatchDefinition, batch_definition).id
+        batch_id = cast(LegacyBatchDefinition, batch_definition).id
 
     if isinstance(df, pd.DataFrame):
         if schema is None:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -93,8 +93,8 @@ if TYPE_CHECKING:
         AnyBatch,
         Batch,
         BatchDataUnion,
-        BatchDefinition,
         BatchMarkers,
+        LegacyBatchDefinition,
     )
     from great_expectations.core.id_dict import BatchSpec
     from great_expectations.data_context.data_context import AbstractDataContext
@@ -283,7 +283,7 @@ class Validator:
         return self._execution_engine.batch_manager.active_batch_markers
 
     @property
-    def active_batch_definition(self) -> Optional[BatchDefinition]:
+    def active_batch_definition(self) -> Optional[LegacyBatchDefinition]:
         """Getter for batch_definition of active Batch (convenience property)"""
         return self._execution_engine.batch_manager.active_batch_definition
 

--- a/tests/core/test_batch_related_objects.py
+++ b/tests/core/test_batch_related_objects.py
@@ -3,11 +3,11 @@ import pytest
 
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     BatchMarkers,
     BatchRequest,
     BatchSpec,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.batch_spec import RuntimeDataBatchSpec
 from great_expectations.core.id_dict import deep_convert_properties_iterable_to_id_dict
@@ -99,11 +99,11 @@ def test_iddict_is_hashable():
 @pytest.mark.unit
 def test_batch_definition_id():
     # noinspection PyUnusedLocal,PyPep8Naming
-    A = BatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
+    A = LegacyBatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
     print(A.id)
 
     # noinspection PyUnusedLocal,PyPep8Naming
-    B = BatchDefinition("B", "b", "bbb", batch_identifiers=IDDict({"id": "B"}))
+    B = LegacyBatchDefinition("B", "b", "bbb", batch_identifiers=IDDict({"id": "B"}))
     print(B.id)
 
     assert A.id != B.id
@@ -113,10 +113,10 @@ def test_batch_definition_id():
 def test_batch_definition_instantiation():
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker,PyUnusedLocal,PyPep8Naming
-        A = BatchDefinition("A", "a", "aaa", {"id": "A"})
+        A = LegacyBatchDefinition("A", "a", "aaa", {"id": "A"})
 
     # noinspection PyPep8Naming
-    A = BatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
+    A = LegacyBatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
 
     print(A.id)
 
@@ -124,15 +124,15 @@ def test_batch_definition_instantiation():
 @pytest.mark.unit
 def test_batch_definition_equality():
     # noinspection PyUnusedLocal,PyPep8Naming
-    A = BatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
+    A = LegacyBatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
 
     # noinspection PyUnusedLocal,PyPep8Naming
-    B = BatchDefinition("B", "b", "bbb", batch_identifiers=IDDict({"id": "B"}))
+    B = LegacyBatchDefinition("B", "b", "bbb", batch_identifiers=IDDict({"id": "B"}))
 
     assert A != B
 
     # noinspection PyUnusedLocal,PyPep8Naming
-    A2 = BatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
+    A2 = LegacyBatchDefinition("A", "a", "aaa", batch_identifiers=IDDict({"id": "A"}))
 
     assert A == A2
 
@@ -146,7 +146,7 @@ def test_batch__str__method():
             data_connector_name="my_data_connector",
             data_asset_name="my_data_asset_name",
         ),
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="my_data_connector",
             data_asset_name="my_data_asset_name",

--- a/tests/datasource/data_connector/sorters/test_sorters.py
+++ b/tests/datasource/data_connector/sorters/test_sorters.py
@@ -1,7 +1,7 @@
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.id_dict import IDDict
 from great_expectations.datasource.data_connector.sorter import (
     CustomListSorter,
@@ -110,7 +110,7 @@ def test_sorter_instantiation_custom_list_with_periodic_table(
     # noinspection PyProtectedMember
     assert my_custom_sorter._reference_list == periodic_table_of_elements
     # This element exists : Hydrogen
-    test_batch_def = BatchDefinition(
+    test_batch_def = LegacyBatchDefinition(
         datasource_name="test",
         data_connector_name="fake",
         data_asset_name="nowhere",
@@ -120,7 +120,7 @@ def test_sorter_instantiation_custom_list_with_periodic_table(
     assert returned_partition_key == 0
 
     # This element does not : Vibranium
-    test_batch_def = BatchDefinition(
+    test_batch_def = LegacyBatchDefinition(
         datasource_name="test",
         data_connector_name="fake",
         data_asset_name="nowhere",

--- a/tests/datasource/data_connector/sorters/test_sorting.py
+++ b/tests/datasource/data_connector/sorters/test_sorting.py
@@ -3,7 +3,7 @@ from typing import Iterator
 import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition, IDDict
+from great_expectations.core.batch import IDDict, LegacyBatchDefinition
 from great_expectations.datasource.data_connector.sorter import (
     CustomListSorter,
     DateTimeSorter,
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture()
 def example_batch_def_list():
-    a = BatchDefinition(
+    a = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="james_20200810_1003",
@@ -27,7 +27,7 @@ def example_batch_def_list():
             {"name": "james", "timestamp": "20200810", "price": "1003"}
         ),
     )
-    b = BatchDefinition(
+    b = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="b",
         data_asset_name="abe_20200809_1040",
@@ -35,7 +35,7 @@ def example_batch_def_list():
             {"name": "abe", "timestamp": "20200809", "price": "1040"}
         ),
     )
-    c = BatchDefinition(
+    c = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="c",
         data_asset_name="eugene_20200809_1500",
@@ -43,7 +43,7 @@ def example_batch_def_list():
             {"name": "eugene", "timestamp": "20200809", "price": "1500"}
         ),
     )
-    d = BatchDefinition(
+    d = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="d",
         data_asset_name="alex_20200819_1300",
@@ -51,7 +51,7 @@ def example_batch_def_list():
             {"name": "alex", "timestamp": "20200819", "price": "1300"}
         ),
     )
-    e = BatchDefinition(
+    e = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="e",
         data_asset_name="alex_20200809_1000",
@@ -59,7 +59,7 @@ def example_batch_def_list():
             {"name": "alex", "timestamp": "20200809", "price": "1000"}
         ),
     )
-    f = BatchDefinition(
+    f = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="f",
         data_asset_name="will_20200810_1001",
@@ -67,7 +67,7 @@ def example_batch_def_list():
             {"name": "will", "timestamp": "20200810", "price": "1001"}
         ),
     )
-    g = BatchDefinition(
+    g = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="g",
         data_asset_name="eugene_20201129_1900",
@@ -75,7 +75,7 @@ def example_batch_def_list():
             {"name": "eugene", "timestamp": "20201129", "price": "1900"}
         ),
     )
-    h = BatchDefinition(
+    h = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="h",
         data_asset_name="will_20200809_1002",
@@ -83,7 +83,7 @@ def example_batch_def_list():
             {"name": "will", "timestamp": "20200809", "price": "1002"}
         ),
     )
-    i = BatchDefinition(
+    i = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="i",
         data_asset_name="james_20200811_1009",
@@ -91,7 +91,7 @@ def example_batch_def_list():
             {"name": "james", "timestamp": "20200811", "price": "1009"}
         ),
     )
-    j = BatchDefinition(
+    j = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="j",
         data_asset_name="james_20200713_1567",
@@ -104,61 +104,61 @@ def example_batch_def_list():
 
 @pytest.fixture()
 def example_hierarchical_batch_def_list():
-    a = BatchDefinition(
+    a = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="alex_20220913_1000",
         batch_identifiers=IDDict({"date": {"month": 1, "year": 2022}}),
     )
-    b = BatchDefinition(
+    b = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="b",
         data_asset_name="will_20220913_1002",
         batch_identifiers=IDDict({"date": {"year": 2022, "month": 4}}),
     )
-    c = BatchDefinition(
+    c = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="c",
         data_asset_name="anthony_20220913_1003",
         batch_identifiers=IDDict({"date": {"month": 1, "year": 2021}}),
     )
-    d = BatchDefinition(
+    d = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="d",
         data_asset_name="chetan_20220913_1567",
         batch_identifiers=IDDict({"date": {"month": 6, "year": 2022}}),
     )
-    e = BatchDefinition(
+    e = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="e",
         data_asset_name="nathan_20220913_1500",
         batch_identifiers=IDDict({"date": {"year": 2021, "month": 3}}),
     )
-    f = BatchDefinition(
+    f = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="f",
         data_asset_name="gabriel_20220913_1040",
         batch_identifiers=IDDict({"date": {"month": 2, "year": 2021}}),
     )
-    g = BatchDefinition(
+    g = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="g",
         data_asset_name="bill_20220913_1300",
         batch_identifiers=IDDict({"date": {"year": 2021, "month": 4}}),
     )
-    h = BatchDefinition(
+    h = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="h",
         data_asset_name="tal_20220913_1009",
         batch_identifiers=IDDict({"date": {"month": 5, "year": 2022}}),
     )
-    i = BatchDefinition(
+    i = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="i",
         data_asset_name="don_20220913_1900",
         batch_identifiers=IDDict({"date": {"year": 2022, "month": 3}}),
     )
-    j = BatchDefinition(
+    j = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="j",
         data_asset_name="ken_20220913_1001",
@@ -168,19 +168,19 @@ def example_hierarchical_batch_def_list():
 
 
 def test_create_three_batch_definitions_sort_lexicographically():
-    a = BatchDefinition(
+    a = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="aaa",
         batch_identifiers=IDDict({"id": "A"}),
     )
-    b = BatchDefinition(
+    b = LegacyBatchDefinition(
         datasource_name="B",
         data_connector_name="b",
         data_asset_name="bbb",
         batch_identifiers=IDDict({"id": "B"}),
     )
-    c = BatchDefinition(
+    c = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",
@@ -205,19 +205,19 @@ def test_create_three_batch_definitions_sort_lexicographically():
 
 
 def test_create_three_batch_definitions_sort_numerically():
-    one = BatchDefinition(
+    one = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="aaa",
         batch_identifiers=IDDict({"id": 1}),
     )
-    two = BatchDefinition(
+    two = LegacyBatchDefinition(
         datasource_name="B",
         data_connector_name="b",
         data_asset_name="bbb",
         batch_identifiers=IDDict({"id": 2}),
     )
-    three = BatchDefinition(
+    three = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",
@@ -234,7 +234,7 @@ def test_create_three_batch_definitions_sort_numerically():
     assert sorted_batch_list == [one, two, three]
 
     # testing a non-numeric, which should throw an error
-    i_should_not_work = BatchDefinition(
+    i_should_not_work = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",
@@ -247,19 +247,19 @@ def test_create_three_batch_definitions_sort_numerically():
 
 
 def test_date_time():
-    first = BatchDefinition(
+    first = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="aaa",
         batch_identifiers=IDDict({"date": "20210101"}),
     )
-    second = BatchDefinition(
+    second = LegacyBatchDefinition(
         datasource_name="B",
         data_connector_name="b",
         data_asset_name="bbb",
         batch_identifiers=IDDict({"date": "20210102"}),
     )
-    third = BatchDefinition(
+    third = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",
@@ -281,7 +281,7 @@ def test_date_time():
             name="date", datetime_format=12345, orderby="desc"
         )
 
-    my_date_is_not_a_string = BatchDefinition(
+    my_date_is_not_a_string = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",
@@ -296,19 +296,19 @@ def test_date_time():
 
 
 def test_custom_list(periodic_table_of_elements):
-    Hydrogen = BatchDefinition(
+    Hydrogen = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="aaa",
         batch_identifiers=IDDict({"element": "Hydrogen"}),
     )
-    Helium = BatchDefinition(
+    Helium = LegacyBatchDefinition(
         datasource_name="B",
         data_connector_name="b",
         data_asset_name="bbb",
         batch_identifiers=IDDict({"element": "Helium"}),
     )
-    Lithium = BatchDefinition(
+    Lithium = LegacyBatchDefinition(
         datasource_name="C",
         data_connector_name="c",
         data_asset_name="ccc",

--- a/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
@@ -6,9 +6,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import azure
 from great_expectations.core import IDDict
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -63,7 +63,7 @@ def expected_batch_definitions_unsorted():
     Input and output should maintain the same order (henced "unsorted")
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -71,7 +71,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -79,7 +79,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -87,7 +87,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -95,7 +95,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -103,7 +103,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200809", "price": "1002"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -111,7 +111,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -119,7 +119,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -127,7 +127,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -135,7 +135,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -155,7 +155,7 @@ def expected_batch_definitions_sorted():
     between input and output.
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -163,7 +163,7 @@ def expected_batch_definitions_sorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -171,7 +171,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -179,7 +179,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -187,7 +187,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -195,7 +195,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -203,7 +203,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -211,7 +211,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -219,7 +219,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -227,7 +227,7 @@ def expected_batch_definitions_sorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="TestFiles",
@@ -901,7 +901,7 @@ def test_return_all_batch_definitions_returns_specified_partition(
 
     assert len(my_batch_definition_list) == 1
     my_batch_definition = my_batch_definition_list[0]
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_azure_data_connector",
         data_asset_name="TestFiles",

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -8,7 +8,7 @@ import boto3
 import botocore
 import pytest
 
-from great_expectations.core.batch import BatchDefinition, BatchRequest
+from great_expectations.core.batch import BatchRequest, LegacyBatchDefinition
 from great_expectations.core.batch_spec import PathBatchSpec
 from great_expectations.core.id_dict import BatchSpec
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -100,8 +100,8 @@ def test__get_full_file_path_for_asset_pandas(fs: FakeFilesystem):
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
     my_batch_request = BatchRequest(
         datasource_name="BASE",
         data_connector_name="my_configured_asset_filesystem_data_connector",
@@ -189,8 +189,8 @@ def test__get_full_file_path_for_asset_spark(basic_spark_df_execution_engine, fs
         == f"{base_directory_colon}/test_dir_0/A/B/C/bigfile_1.csv"
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
     my_batch_request = BatchRequest(
         datasource_name="BASE",
         data_connector_name="my_configured_asset_filesystem_data_connector",

--- a/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
@@ -4,10 +4,10 @@ import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -140,7 +140,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
         )
     )
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -148,7 +148,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -156,7 +156,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -164,7 +164,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -172,7 +172,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -180,7 +180,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -188,7 +188,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -196,7 +196,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -204,7 +204,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -212,7 +212,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 {"name": "will", "timestamp": "20200809", "price": "1002"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -309,7 +309,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -317,7 +317,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -325,7 +325,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -333,7 +333,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -341,7 +341,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -349,7 +349,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -357,7 +357,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -365,7 +365,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -373,7 +373,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -381,7 +381,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -409,8 +409,8 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
         ),
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     # TEST 2: Should only return the specified partition
     my_batch_definition_list = (
@@ -421,7 +421,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
 
     assert len(my_batch_definition_list) == 1
     my_batch_definition = my_batch_definition_list[0]
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_filesystem_data_connector",
         data_asset_name="TestFiles",
@@ -494,13 +494,13 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
             batch_identifiers=IDDict({"name": "A"}),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -574,8 +574,8 @@ def test_alpha(tmp_path_factory):
         )
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     # Try to fetch a batch from a nonexistent asset
     my_batch_request: BatchRequest = BatchRequest(
@@ -675,7 +675,7 @@ def test_foxtrot(tmp_path_factory):
         data_asset_name="A",
         data_connector_query=None,
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=my_batch_request
         )
@@ -746,7 +746,7 @@ def test_relative_asset_base_directory_path(tmp_path_factory):
         data_asset_name="A",
         data_connector_query=None,
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=my_batch_request
         )
@@ -815,8 +815,8 @@ def test_relative_default_and_relative_asset_base_directory_paths(tmp_path_facto
         == f"{base_directory}/test_dir_0/A/B/C/bigfile_1.csv"
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
     my_batch_request = BatchRequest(
         datasource_name="BASE",
         data_connector_name="my_configured_asset_filesystem_data_connector",

--- a/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
@@ -6,9 +6,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import google
 from great_expectations.core import IDDict
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -60,7 +60,7 @@ def expected_batch_definitions_unsorted():
     Input and output should maintain the same order (henced "unsorted")
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -68,7 +68,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -76,7 +76,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -84,7 +84,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -92,7 +92,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -100,7 +100,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200809", "price": "1002"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -108,7 +108,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -116,7 +116,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -124,7 +124,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -132,7 +132,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -152,7 +152,7 @@ def expected_batch_definitions_sorted():
     between input and output.
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -160,7 +160,7 @@ def expected_batch_definitions_sorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -168,7 +168,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -176,7 +176,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -184,7 +184,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -192,7 +192,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -200,7 +200,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -208,7 +208,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -216,7 +216,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -224,7 +224,7 @@ def expected_batch_definitions_sorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_gcs_data_connector",
             data_asset_name="TestFiles",
@@ -769,7 +769,7 @@ def test_return_all_batch_definitions_returns_specified_partition(
 
     assert len(my_batch_definition_list) == 1
     my_batch_definition = my_batch_definition_list[0]
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_gcs_data_connector",
         data_asset_name="TestFiles",

--- a/tests/datasource/data_connector/test_configured_asset_glue_catalog_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_glue_catalog_data_connector.py
@@ -1,7 +1,7 @@
 import pytest
 from moto import mock_glue
 
-from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest
+from great_expectations.core.batch import Batch, BatchRequest, LegacyBatchDefinition
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -317,7 +317,7 @@ def test_instantiation_with_batch_spec_passthrough(
     )
 
     batch_data, _, __ = my_data_connector.get_batch_data_and_metadata(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="FAKE_Datasource_NAME",
             data_connector_name="my_glue_catalog_data_connector",
             data_asset_name="titanic_asset",
@@ -418,7 +418,7 @@ def test_build_batch_spec_with_all_options(
             },
         },
     )
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="prefix__asset_titanic__suffix",
@@ -459,7 +459,7 @@ def test_build_batch_spec_with_minimal_options(glue_titanic_catalog):
             },
         },
     )
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -530,7 +530,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__random_in_asset_confi
     )
 
     batch_data, _, __ = my_data_connector.get_batch_data_and_metadata(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="FAKE_Datasource_NAME",
             data_connector_name="my_glue_catalog_data_connector",
             data_asset_name="titanic_asset",
@@ -567,7 +567,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__random_in_batch_spec_
     )
 
     batch_data, _, __ = my_data_connector.get_batch_data_and_metadata(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="FAKE_Datasource_NAME",
             data_connector_name="my_glue_catalog_data_connector",
             data_asset_name="titanic_asset",
@@ -618,7 +618,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__mod(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -673,7 +673,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__list(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -728,7 +728,7 @@ def test_get_batch_data_and_metadata_with_sampling_method__hash(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -787,7 +787,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__whole_table(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -840,7 +840,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__column_value(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -898,7 +898,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__divided_integer(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -959,7 +959,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__mod_integer(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -1018,7 +1018,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__multi_column_valu
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -1077,7 +1077,7 @@ def test_get_batch_data_and_metadata_with_partitioning_method__hashed_column(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",
@@ -1135,7 +1135,7 @@ def test_get_batch_data_and_metadata_with_partitions(
         "FAKE_Datasource_NAME"
     ]._execution_engine = execution_engine  # type: ignore[union-attr]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_glue_catalog_data_connector",
         data_asset_name="db_test.tb_titanic",

--- a/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
@@ -8,10 +8,10 @@ from moto import mock_s3
 
 import great_expectations.exceptions.exceptions as gx_exceptions
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -157,7 +157,7 @@ def test_return_all_batch_definitions_unsorted():
         )
     )
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -165,7 +165,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -173,7 +173,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -181,7 +181,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -189,7 +189,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -197,7 +197,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -205,7 +205,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -213,7 +213,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -221,7 +221,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -229,7 +229,7 @@ def test_return_all_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200809", "price": "1002"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -329,7 +329,7 @@ def test_return_all_batch_definitions_sorted():
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -337,7 +337,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -345,7 +345,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -353,7 +353,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -361,7 +361,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -369,7 +369,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -377,7 +377,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -385,7 +385,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -393,7 +393,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -401,7 +401,7 @@ def test_return_all_batch_definitions_sorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_s3_data_connector",
             data_asset_name="TestFiles",
@@ -429,8 +429,8 @@ def test_return_all_batch_definitions_sorted():
         ),
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     # TEST 2: Should only return the specified partition
     my_batch_definition_list = (
@@ -441,7 +441,7 @@ def test_return_all_batch_definitions_sorted():
 
     assert len(my_batch_definition_list) == 1
     my_batch_definition = my_batch_definition_list[0]
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_s3_data_connector",
         data_asset_name="TestFiles",
@@ -517,8 +517,8 @@ def test_alpha():
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},
     )
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     # Try to fetch a batch from a nonexistent asset
     my_batch_request: BatchRequest = BatchRequest(
@@ -616,8 +616,8 @@ def test_foxtrot():
         },
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},
     )
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
     my_batch_request = BatchRequest(
         datasource_name="BASE",
         data_connector_name="general_s3_data_connector",

--- a/tests/datasource/data_connector/test_data_connector.py
+++ b/tests/datasource/data_connector/test_data_connector.py
@@ -2,10 +2,10 @@
 import pytest
 
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
     IDDict,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -52,7 +52,7 @@ assets:
 @pytest.mark.unit
 def test__batch_definition_matches_batch_request():
     # TODO: <Alex>We need to cleanup PyCharm warnings.</Alex>
-    A = BatchDefinition(
+    A = LegacyBatchDefinition(
         datasource_name="A",
         data_connector_name="a",
         data_asset_name="aaa",
@@ -123,7 +123,7 @@ def test__batch_definition_matches_batch_request():
     )
 
     assert batch_definition_matches_batch_request(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             **{
                 "datasource_name": "FAKE_DATASOURCE",
                 "data_connector_name": "TEST_DATA_CONNECTOR",

--- a/tests/datasource/data_connector/test_data_connector_query_filesystem.py
+++ b/tests/datasource/data_connector/test_data_connector_query_filesystem.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.data_connector import DataConnector
@@ -225,8 +225,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
         )
     )
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -234,7 +234,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -242,7 +242,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -250,7 +250,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -258,7 +258,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -299,8 +299,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_limit(
         )
     )
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -308,7 +308,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_limit(
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -316,7 +316,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_limit(
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -324,7 +324,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_limit(
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -366,8 +366,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_int
     )
     assert len(returned_batch_definition_list) == 1
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -411,8 +411,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
 
     assert len(returned_batch_definition_list) == 2
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -420,7 +420,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -462,8 +462,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
     )
     assert len(returned_batch_definition_list) == 2
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -471,7 +471,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -512,8 +512,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_str
         )
     )
     assert len(returned_batch_definition_list) == 1
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -554,8 +554,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 5
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -563,7 +563,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -571,7 +571,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -579,7 +579,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -587,7 +587,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -628,8 +628,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 3
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -637,7 +637,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -645,7 +645,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -686,8 +686,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 5
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -695,7 +695,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -703,7 +703,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -711,7 +711,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -719,7 +719,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -760,8 +760,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 3
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -769,7 +769,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -777,7 +777,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -818,8 +818,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 2
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -827,7 +827,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -870,8 +870,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
     )
     assert len(returned_batch_definition_list) == 2
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -879,7 +879,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -920,8 +920,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 2
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -929,7 +929,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -972,8 +972,8 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
     )
     assert len(returned_batch_definition_list) == 2
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -981,7 +981,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1012,8 +1012,8 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
     )
     assert len(returned_batch_definition_list) == 4
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1021,7 +1021,7 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1029,7 +1029,7 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1037,7 +1037,7 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1069,8 +1069,8 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key_and_i
     )
     assert len(returned_batch_definition_list) == 1
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1104,8 +1104,8 @@ def test_data_connector_query_data_connector_query_batch_identifiers_2_key_name_
     )
     assert len(returned_batch_definition_list) == 1
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1133,8 +1133,8 @@ def test_data_connector_query_for_data_asset_name(
     )
     assert len(returned_batch_definition_list) == 10
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1142,7 +1142,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1150,7 +1150,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1158,7 +1158,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1166,7 +1166,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1174,7 +1174,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1182,7 +1182,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1190,7 +1190,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1198,7 +1198,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",
@@ -1206,7 +1206,7 @@ def test_data_connector_query_for_data_asset_name(
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_filesystem_data_connector",
             data_asset_name="TestFiles",

--- a/tests/datasource/data_connector/test_data_connector_query_sql.py
+++ b/tests/datasource/data_connector/test_data_connector_query_sql.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 from great_expectations.data_context.util import (
     file_relative_path,
     instantiate_class_from_config,
@@ -134,7 +134,7 @@ def test_data_connector_query_limit(create_db_and_instantiate_simple_sql_datasou
     )
 
     # no limit
-    batch_definition_list: List[BatchDefinition] = (
+    batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -146,7 +146,7 @@ def test_data_connector_query_limit(create_db_and_instantiate_simple_sql_datasou
     )
     assert len(batch_definition_list) == 3
     # proper limit
-    batch_definition_list: List[BatchDefinition] = (
+    batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -161,7 +161,7 @@ def test_data_connector_query_limit(create_db_and_instantiate_simple_sql_datasou
     # illegal limit
     with pytest.raises(gx_exceptions.BatchFilterError):
         # noinspection PyUnusedLocal
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             my_sql_datasource.get_batch_definition_list_from_batch_request(
                 batch_request=BatchRequest(
                     datasource_name="taxi_multi_batch_sql_datasource",
@@ -182,7 +182,7 @@ def test_data_connector_query_illegal_index_and_limit_combination(
     with pytest.raises(gx_exceptions.BatchFilterError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -209,7 +209,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
             == datetime.datetime(2020, 1, 1).date()
         )
 
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -222,7 +222,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter(
         )
     )
     assert len(returned_batch_definition_list) == 24
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="taxi_multi_batch_sql_datasource",
         data_connector_name="by_pickup_date_time",
         data_asset_name="yellow_tripdata_sample_2020_01",
@@ -247,7 +247,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index(
             == datetime.datetime(2020, 1, 1).date()
         )
 
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -262,7 +262,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index(
     )
     assert len(returned_batch_definition_list) == 1
 
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="taxi_multi_batch_sql_datasource",
         data_connector_name="by_pickup_date_time",
         data_asset_name="yellow_tripdata_sample_2020_01",
@@ -287,7 +287,7 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
             == datetime.datetime(2020, 1, 1).date()
         )
 
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -301,14 +301,14 @@ def test_data_connector_query_sorted_filtered_by_custom_filter_with_index_as_sli
         )
     )
     assert len(returned_batch_definition_list) == 2
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="taxi_multi_batch_sql_datasource",
             data_connector_name="by_pickup_date_time",
             data_asset_name="yellow_tripdata_sample_2020_01",
             batch_identifiers=IDDict({"pickup_datetime": "2020-01-01 00"}),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="taxi_multi_batch_sql_datasource",
             data_connector_name="by_pickup_date_time",
             data_asset_name="yellow_tripdata_sample_2020_01",
@@ -325,7 +325,7 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
         create_db_and_instantiate_simple_sql_datasource
     )
     # no limit
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -338,8 +338,8 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key(
         )
     )
     assert len(returned_batch_definition_list) == 1
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="taxi_multi_batch_sql_datasource",
             data_connector_name="by_vendor_id",
             data_asset_name="yellow_tripdata_sample_2020_01",
@@ -356,7 +356,7 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key_and_i
         create_db_and_instantiate_simple_sql_datasource
     )
     # no limit
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",
@@ -371,8 +371,8 @@ def test_data_connector_query_data_connector_query_batch_identifiers_1_key_and_i
     )
     assert len(returned_batch_definition_list) == 1
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="taxi_multi_batch_sql_datasource",
             data_connector_name="by_vendor_id",
             data_asset_name="yellow_tripdata_sample_2020_01",
@@ -389,7 +389,7 @@ def test_data_connector_query_for_data_asset_name(
         create_db_and_instantiate_simple_sql_datasource
     )
     # no limit
-    returned_batch_definition_list: List[BatchDefinition] = (
+    returned_batch_definition_list: List[LegacyBatchDefinition] = (
         my_sql_datasource.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="taxi_multi_batch_sql_datasource",

--- a/tests/datasource/data_connector/test_data_connector_util.py
+++ b/tests/datasource/data_connector/test_data_connector_util.py
@@ -4,7 +4,7 @@ import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
 from great_expectations.compatibility import google
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 
 # noinspection PyProtectedMember
 from great_expectations.datasource.data_connector.util import (
@@ -21,7 +21,7 @@ from great_expectations.datasource.data_connector.util import (
 
 @pytest.mark.unit
 def test_batch_definition_matches_batch_request():
-    my_batch_definition = BatchDefinition(
+    my_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_filesystem_data_connector",
         data_asset_name="TestFiles",
@@ -136,7 +136,7 @@ def test_map_data_reference_string_to_batch_definition_list_using_regex():
         )
     )
     assert returned_batch_def_list == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_datasource",
             data_connector_name="test_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -162,7 +162,7 @@ def test_map_data_reference_string_to_batch_definition_list_using_regex():
         )
     )
     assert returned_batch_def_list == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_datasource",
             data_connector_name="test_data_connector",
             data_asset_name="test_data_asset",
@@ -286,7 +286,7 @@ def test_map_batch_definition_to_data_reference_string_using_regex():
         )
 
     # group names do not match
-    my_batch_definition = BatchDefinition(
+    my_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_filesystem_data_connector",
         data_asset_name="TestFiles",
@@ -305,7 +305,7 @@ def test_map_batch_definition_to_data_reference_string_using_regex():
         )
 
     # success
-    my_batch_definition = BatchDefinition(
+    my_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_filesystem_data_connector",
         data_asset_name="TestFiles",

--- a/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
@@ -6,9 +6,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import azure
 from great_expectations.core import IDDict
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchRequest,
     BatchRequestBase,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -38,7 +38,7 @@ def expected_batch_definitions_unsorted():
     Input and output should maintain the same order (henced "unsorted")
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -46,7 +46,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -54,7 +54,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -62,7 +62,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -70,7 +70,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -78,7 +78,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200809", "price": "1002"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -86,7 +86,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -94,7 +94,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -102,7 +102,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -110,7 +110,7 @@ def expected_batch_definitions_unsorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -130,7 +130,7 @@ def expected_batch_definitions_sorted():
     between input and output.
     """
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -138,7 +138,7 @@ def expected_batch_definitions_sorted():
                 {"name": "abe", "timestamp": "20200809", "price": "1040"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -146,7 +146,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200819", "price": "1300"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -154,7 +154,7 @@ def expected_batch_definitions_sorted():
                 {"name": "alex", "timestamp": "20200809", "price": "1000"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -162,7 +162,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20201129", "price": "1900"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -170,7 +170,7 @@ def expected_batch_definitions_sorted():
                 {"name": "eugene", "timestamp": "20200809", "price": "1500"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -178,7 +178,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200811", "price": "1009"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -186,7 +186,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200810", "price": "1003"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -194,7 +194,7 @@ def expected_batch_definitions_sorted():
                 {"name": "james", "timestamp": "20200713", "price": "1567"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -202,7 +202,7 @@ def expected_batch_definitions_sorted():
                 {"name": "will", "timestamp": "20200810", "price": "1001"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="general_azure_data_connector",
             data_asset_name="DEFAULT_ASSET_NAME",
@@ -834,7 +834,7 @@ def test_return_all_batch_definitions_returns_specified_partition(
 
     assert len(my_batch_definition_list) == 1
     my_batch_definition = my_batch_definition_list[0]
-    expected_batch_definition = BatchDefinition(
+    expected_batch_definition = LegacyBatchDefinition(
         datasource_name="test_environment",
         data_connector_name="general_azure_data_connector",
         data_asset_name="DEFAULT_ASSET_NAME",

--- a/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
@@ -8,7 +8,7 @@ import boto3
 import botocore
 import pytest
 
-from great_expectations.core.batch import BatchDefinition, BatchRequest
+from great_expectations.core.batch import BatchRequest, LegacyBatchDefinition
 from great_expectations.core.batch_spec import PathBatchSpec
 from great_expectations.core.id_dict import BatchSpec
 from great_expectations.datasource.data_connector import InferredAssetDBFSDataConnector
@@ -74,7 +74,7 @@ def test__get_full_file_path_pandas(fs: FakeFilesystem):
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
 
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="FAKE_DATASOURCE_NAME",
@@ -85,7 +85,7 @@ def test__get_full_file_path_pandas(fs: FakeFilesystem):
     )
     assert len(my_batch_definition_list) == 2
 
-    my_batch_definition: BatchDefinition = my_batch_definition_list[0]
+    my_batch_definition: LegacyBatchDefinition = my_batch_definition_list[0]
     batch_spec: BatchSpec = my_data_connector.build_batch_spec(
         batch_definition=my_batch_definition
     )
@@ -137,7 +137,7 @@ def test__get_full_file_path_spark(basic_spark_df_execution_engine, fs):
     assert my_data_connector.get_data_reference_count() == 4
     assert my_data_connector.get_unmatched_data_references() == []
 
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="FAKE_DATASOURCE_NAME",
@@ -148,7 +148,7 @@ def test__get_full_file_path_spark(basic_spark_df_execution_engine, fs):
     )
     assert len(my_batch_definition_list) == 2
 
-    my_batch_definition: BatchDefinition = my_batch_definition_list[0]
+    my_batch_definition: LegacyBatchDefinition = my_batch_definition_list[0]
     batch_spec: BatchSpec = my_data_connector.build_batch_spec(
         batch_definition=my_batch_definition
     )

--- a/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource import Datasource
@@ -103,7 +103,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(tmp_path_factory):
     # Test for an unknown execution environment
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             my_data_connector.get_batch_definition_list_from_batch_request(
                 batch_request=BatchRequest(
                     datasource_name="non_existent_datasource",
@@ -117,7 +117,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(tmp_path_factory):
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="FAKE_DATASOURCE_NAME",
@@ -165,7 +165,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(tmp_path_factory):
             },
         )
     ) == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="FAKE_DATASOURCE_NAME",
             data_connector_name="my_data_connector",
             data_asset_name="alpha",
@@ -241,7 +241,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -249,7 +249,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "07", "full_date": "20210107"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -257,7 +257,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "06", "full_date": "20210106"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -265,7 +265,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "05", "full_date": "20210105"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -273,7 +273,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "04", "full_date": "20210104"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -281,7 +281,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "03", "full_date": "20210103"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -289,7 +289,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
                 {"year": "2021", "month": "01", "day": "02", "full_date": "20210102"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",

--- a/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
@@ -4,7 +4,7 @@ import pytest
 
 import great_expectations.exceptions.exceptions as gx_exceptions
 from great_expectations.compatibility import google
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.data_connector import InferredAssetGCSDataConnector
@@ -308,7 +308,7 @@ def test_complex_regex_example_with_implicit_data_asset_names(
             },
         )
     ) == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="FAKE_DATASOURCE_NAME",
             data_connector_name="my_data_connector",
             data_asset_name="alpha",
@@ -382,7 +382,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -390,7 +390,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "07", "full_date": "20210107"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -398,7 +398,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "06", "full_date": "20210106"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -406,7 +406,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "05", "full_date": "20210105"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -414,7 +414,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "04", "full_date": "20210104"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -422,7 +422,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "03", "full_date": "20210103"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -430,7 +430,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
                 {"year": "2021", "month": "01", "day": "02", "full_date": "20210102"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",

--- a/tests/datasource/data_connector/test_inferred_asset_glue_catalog_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_glue_catalog_data_connector.py
@@ -3,7 +3,7 @@ import random
 import pytest
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.core.batch import Batch, BatchDefinition
+from great_expectations.core.batch import Batch, LegacyBatchDefinition
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.datasource import Datasource
@@ -100,7 +100,7 @@ def test_get_batch_data_and_metadata_without_partitions(
         data_asset_name_suffix="__suffix",
     )
     batch_data, _, __ = my_data_connector.get_batch_data_and_metadata(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="FAKE_Datasource_NAME",
             data_connector_name="my_data_connector",
             data_asset_name="prefix__db_test.tb_titanic_without_partitions__suffix",
@@ -154,7 +154,7 @@ def test_get_batch_data_and_metadata_with_partitions(
         "FAKE_Datasource_NAME"
     ].data_connectors["my_data_connector"]
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="FAKE_Datasource_NAME",
         data_connector_name="my_data_connector",
         data_asset_name="prefix__db_test.tb_titanic_with_partitions__suffix",

--- a/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
@@ -8,7 +8,7 @@ import pytest
 from moto import mock_s3
 
 import great_expectations.exceptions.exceptions as gx_exceptions
-from great_expectations.core.batch import BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import BatchRequest, IDDict, LegacyBatchDefinition
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.data_connector import InferredAssetS3DataConnector
@@ -120,7 +120,7 @@ def test_complex_regex_example_with_implicit_data_asset_names():
     # Test for an unknown execution environment
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             my_data_connector.get_batch_definition_list_from_batch_request(
                 batch_request=BatchRequest(
                     datasource_name="non_existent_datasource",
@@ -134,7 +134,7 @@ def test_complex_regex_example_with_implicit_data_asset_names():
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = my_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=BatchRequest(
                 datasource_name="FAKE_DATASOURCE_NAME",
@@ -182,7 +182,7 @@ def test_complex_regex_example_with_implicit_data_asset_names():
             },
         )
     ) == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="FAKE_DATASOURCE_NAME",
             data_connector_name="my_data_connector",
             data_asset_name="alpha",
@@ -262,7 +262,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -270,7 +270,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "07", "full_date": "20210107"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -278,7 +278,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "06", "full_date": "20210106"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -286,7 +286,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "05", "full_date": "20210105"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -294,7 +294,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "04", "full_date": "20210104"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -302,7 +302,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "03", "full_date": "20210103"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",
@@ -310,7 +310,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
                 {"year": "2021", "month": "01", "day": "02", "full_date": "20210102"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="test_environment",
             data_connector_name="my_inferred_asset_filesystem_data_connector",
             data_asset_name="some_bucket",

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -7,8 +7,8 @@ import pytest
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     BatchSpec,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.core.batch_spec import (
@@ -148,7 +148,7 @@ def test_error_checking_unknown_datasource(basic_datasource):
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name="non_existent_datasource",
@@ -172,7 +172,7 @@ def test_error_checking_unknown_data_connector(basic_datasource):
     with pytest.raises(ValueError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource.name,
@@ -194,7 +194,7 @@ def test_error_checking_missing_runtime_parameters(basic_datasource):
     with pytest.raises(TypeError):
         # noinspection PyUnusedLocal, PyArgumentList
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource.name,
@@ -215,7 +215,7 @@ def test_asset_is_name_batch_identifier_correctly_used(
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    res: List[BatchDefinition] = (
+    res: List[LegacyBatchDefinition] = (
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -227,7 +227,7 @@ def test_asset_is_name_batch_identifier_correctly_used(
         )
     )
     assert len(res) == 1
-    assert res[0] == BatchDefinition(
+    assert res[0] == LegacyBatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="runtime",
         data_asset_name="asset_a",
@@ -367,7 +367,7 @@ def test_error_checking_too_many_runtime_parameters(basic_datasource):
     with pytest.raises(gx_exceptions.InvalidBatchRequestError):
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource.name,
@@ -407,7 +407,7 @@ def test_batch_identifiers_and_batch_identifiers_success_all_keys_present(
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
-    batch_definition_list: List[BatchDefinition] = (
+    batch_definition_list: List[LegacyBatchDefinition] = (
         test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
@@ -448,7 +448,7 @@ def test_batch_identifiers_and_batch_identifiers_error_illegal_keys(
 
     with pytest.raises(gx_exceptions.DataConnectorError) as data_connector_error:
         # noinspection PyUnusedLocal
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             test_runtime_data_connector.get_batch_definition_list_from_batch_request(
                 batch_request=batch_request
             )
@@ -482,7 +482,7 @@ def test_batch_identifiers_and_batch_identifiers_error_illegal_keys(
     with pytest.raises(gx_exceptions.DataConnectorError) as data_connector_error:
         # noinspection PyUnusedLocal
         batch_definition_list: List[  # noqa: F841
-            BatchDefinition
+            LegacyBatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
@@ -626,7 +626,7 @@ def test_data_references_cache_updating_after_batch_request(
     assert test_runtime_data_connector._data_references_cache == {
         "my_data_asset_1": {
             "1234567890": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_1",
@@ -661,7 +661,7 @@ def test_data_references_cache_updating_after_batch_request(
     assert test_runtime_data_connector._data_references_cache == {
         "my_data_asset_1": {
             "1234567890": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_1",
@@ -669,7 +669,7 @@ def test_data_references_cache_updating_after_batch_request(
                 )
             ],
             "987654321": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_1",
@@ -706,7 +706,7 @@ def test_data_references_cache_updating_after_batch_request(
     assert test_runtime_data_connector._data_references_cache == {
         "my_data_asset_1": {
             "1234567890": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_1",
@@ -714,7 +714,7 @@ def test_data_references_cache_updating_after_batch_request(
                 )
             ],
             "987654321": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_1",
@@ -724,7 +724,7 @@ def test_data_references_cache_updating_after_batch_request(
         },
         "my_data_asset_2": {
             "5555555": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="test_runtime_data_connector",
                     data_asset_name="my_data_asset_2",
@@ -772,13 +772,13 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
     # run with my_data_asset_1
-    batch_definitions: List[BatchDefinition] = (
+    batch_definitions: List[LegacyBatchDefinition] = (
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
     )
     assert batch_definitions == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="runtime",
             data_asset_name="asset_a",
@@ -788,7 +788,7 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
     assert runtime_data_connector._data_references_cache == {
         "asset_a": {
             "1-1": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="runtime",
                     data_asset_name="asset_a",
@@ -810,13 +810,13 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
     # run with another batch under asset_a
-    batch_definitions: List[BatchDefinition] = (
+    batch_definitions: List[LegacyBatchDefinition] = (
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
     )
     assert batch_definitions == [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="runtime",
             data_asset_name="asset_a",
@@ -826,7 +826,7 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
     assert runtime_data_connector._data_references_cache == {
         "asset_a": {
             "1-1": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="runtime",
                     data_asset_name="asset_a",
@@ -834,7 +834,7 @@ def test_data_references_cache_updating_after_batch_request_named_assets(
                 )
             ],
             "1-2": [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name="my_datasource",
                     data_connector_name="runtime",
                     data_asset_name="asset_a",
@@ -868,8 +868,8 @@ def test_get_batch_definition_list_from_batch_request_length_one(
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
-    expected_batch_definition_list: List[BatchDefinition] = [
-        BatchDefinition(
+    expected_batch_definition_list: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="test_runtime_data_connector",
             data_asset_name="my_data_asset",
@@ -877,7 +877,7 @@ def test_get_batch_definition_list_from_batch_request_length_one(
         )
     ]
 
-    batch_definition_list: List[BatchDefinition] = (
+    batch_definition_list: List[LegacyBatchDefinition] = (
         test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
@@ -924,7 +924,7 @@ def test_get_batch_definition_list_from_batch_request_with_and_without_data_asse
         "batch_identifiers": batch_identifiers,
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
-    batch_definition_list: List[BatchDefinition] = (
+    batch_definition_list: List[LegacyBatchDefinition] = (
         test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
@@ -975,7 +975,7 @@ def test__generate_batch_spec_parameters_from_batch_definition(
 
     # noinspection PyProtectedMember
     batch_spec_parameters: dict = test_runtime_data_connector._generate_batch_spec_parameters_from_batch_definition(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="test_runtime_data_connector",
             data_asset_name="my_data_asset",
@@ -997,7 +997,7 @@ def test__build_batch_spec(basic_datasource):
         basic_datasource.data_connectors["test_runtime_data_connector"]
     )
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="test_runtime_data_connector",
         data_asset_name="my_data_asset",
@@ -1131,7 +1131,7 @@ def test_temp_table_schema_name_included_in_batch_spec(basic_datasource):
         basic_datasource.data_connectors["test_runtime_data_connector"]
     )
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="test_runtime_data_connector",
         data_asset_name="my_data_asset",

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -3,7 +3,12 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest, IDDict
+from great_expectations.core.batch import (
+    Batch,
+    BatchRequest,
+    IDDict,
+    LegacyBatchDefinition,
+)
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import AbstractDataContext
@@ -190,7 +195,7 @@ def test_get_batch_data_and_markers_sampling_method__limit(
         )
     )
 
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="my_test_datasource",
         data_connector_name="my_sql_data_connector",
         data_asset_name="my_asset",
@@ -1548,7 +1553,7 @@ def test_ConfiguredAssetSqlDataConnector_return_all_batch_definitions_sorted(
     )
 
     expected = [
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_test_datasource",
             data_connector_name="my_sql_data_connector",
             data_asset_name="table_partitioned_by_date_column__A",

--- a/tests/datasource/fluent/data_asset/data_connector/test_azure_blob_storage_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_azure_blob_storage_data_connector.py
@@ -7,7 +7,7 @@ import pytest
 
 from great_expectations.compatibility import azure
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.util import AzureUrl
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.data_asset.data_connector import (
@@ -157,7 +157,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
         my_data_connector.get_batch_definition_list()
 
     # with empty options
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -166,8 +166,8 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
             )
         )
     )
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -180,7 +180,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -193,7 +193,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -206,7 +206,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -219,7 +219,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -232,7 +232,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -245,7 +245,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -258,7 +258,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -271,7 +271,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -284,7 +284,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -502,14 +502,14 @@ def test_return_only_unique_batch_definitions(mock_list_keys):
         "B/file_2.csv",
     ]
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
             batch_identifiers=IDDict({"path": "B/file_1.csv", "filename": "file_1"}),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_azure_blob_storage_data_asset",
@@ -528,7 +528,7 @@ def test_return_only_unique_batch_definitions(mock_list_keys):
         file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_HTTPS_URL_TEMPLATE.format,
     )
 
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -580,8 +580,8 @@ def test_alpha(mock_list_keys):
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert my_data_connector.get_unmatched_data_reference_count() == 0
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     my_batch_request: BatchRequest
 
@@ -742,7 +742,7 @@ def test_foxtrot(mock_list_keys):
         data_asset_name="my_azure_blob_storage_data_asset",
         options={},
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(batch_request=my_batch_request)
     )
     assert len(my_batch_definition_list) == 3

--- a/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_filesystem_data_connector.py
@@ -6,7 +6,7 @@ import pytest
 
 from great_expectations.compatibility import pydantic
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector,
@@ -140,7 +140,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
         my_data_connector.get_batch_definition_list()
 
     # with empty options
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -149,8 +149,8 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
             )
         )
     )
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -163,7 +163,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -176,7 +176,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -189,7 +189,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -202,7 +202,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -215,7 +215,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -228,7 +228,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -241,7 +241,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -254,7 +254,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -267,7 +267,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -527,8 +527,8 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
     ]
     assert my_data_connector.get_unmatched_data_reference_count() == 2
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -536,7 +536,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
                 {"path": "A/file_1.csv", "directory": "A", "filename": "file_1.csv"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -544,7 +544,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
                 {"path": "A/file_2.csv", "directory": "A", "filename": "file_2.csv"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -552,7 +552,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
                 {"path": "A/file_3.csv", "directory": "A", "filename": "file_3.csv"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -560,7 +560,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
                 {"path": "B/file_1.csv", "directory": "B", "filename": "file_1.csv"}
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_filesystem_data_asset",
@@ -578,7 +578,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
         # glob_directive="*.csv",  # omitting for purposes of this test
     )
 
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -626,8 +626,8 @@ def test_alpha(tmp_path_factory):
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert my_data_connector.get_unmatched_data_reference_count() == 0
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     my_batch_request: BatchRequest
 
@@ -763,7 +763,7 @@ def test_foxtrot(tmp_path_factory):
         data_asset_name="my_filesystem_data_asset",
         options={},
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(batch_request=my_batch_request)
     )
     assert len(my_batch_definition_list) == 3
@@ -834,7 +834,7 @@ def test_relative_base_directory_path(tmp_path_factory):
         data_asset_name="my_filesystem_data_asset",
         options={},
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(batch_request=my_batch_request)
     )
     assert len(my_batch_definition_list) == 1

--- a/tests/datasource/fluent/data_asset/data_connector/test_google_cloud_storage_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_google_cloud_storage_data_connector.py
@@ -7,7 +7,7 @@ import pytest
 
 from great_expectations.compatibility import google
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.util import GCSUrl
 from great_expectations.datasource.fluent import BatchRequest
 from great_expectations.datasource.fluent.data_asset.data_connector import (
@@ -151,7 +151,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
         my_data_connector.get_batch_definition_list()
 
     # with empty options
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -160,8 +160,8 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
             )
         )
     )
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -174,7 +174,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -187,7 +187,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -200,7 +200,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -213,7 +213,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -226,7 +226,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -239,7 +239,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -252,7 +252,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -265,7 +265,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -278,7 +278,7 @@ def test_return_all_batch_definitions_unsorted(mock_list_keys):
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -492,14 +492,14 @@ def test_return_only_unique_batch_definitions(mock_list_keys):
         "B/file_2.csv",
     ]
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
             batch_identifiers=IDDict({"path": "B/file_1.csv", "filename": "file_1"}),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_google_cloud_storage_data_asset",
@@ -517,7 +517,7 @@ def test_return_only_unique_batch_definitions(mock_list_keys):
         file_path_template_map_fn=GCSUrl.OBJECT_URL_TEMPLATE.format,
     )
 
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -566,8 +566,8 @@ def test_alpha(mock_list_keys):
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert my_data_connector.get_unmatched_data_reference_count() == 0
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     my_batch_request: BatchRequest
 
@@ -722,7 +722,7 @@ def test_foxtrot(mock_list_keys):
         data_asset_name="my_google_cloud_storage_data_asset",
         options={},
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(batch_request=my_batch_request)
     )
     assert len(my_batch_definition_list) == 3

--- a/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/datasource/fluent/data_asset/data_connector/test_s3_data_connector.py
@@ -10,7 +10,7 @@ from moto import mock_s3
 import great_expectations as gx
 from great_expectations import set_context
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.util import S3Url
 from great_expectations.data_context.store.tuple_store_backend import (
     TupleS3StoreBackend,
@@ -174,7 +174,7 @@ def test_return_all_batch_definitions_unsorted():
         my_data_connector.get_batch_definition_list()
 
     # with empty options
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -183,8 +183,8 @@ def test_return_all_batch_definitions_unsorted():
             )
         )
     )
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -197,7 +197,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -210,7 +210,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -223,7 +223,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -236,7 +236,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -249,7 +249,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -262,7 +262,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -275,7 +275,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -288,7 +288,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -301,7 +301,7 @@ def test_return_all_batch_definitions_unsorted():
                 }
             ),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -577,14 +577,14 @@ def test_return_only_unique_batch_definitions():
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert my_data_connector.get_unmatched_data_reference_count() == 0
 
-    expected: List[BatchDefinition] = [
-        BatchDefinition(
+    expected: List[LegacyBatchDefinition] = [
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
             batch_identifiers=IDDict({"path": "B/file_1.csv", "filename": "file_1"}),
         ),
-        BatchDefinition(
+        LegacyBatchDefinition(
             datasource_name="my_file_path_datasource",
             data_connector_name="fluent",
             data_asset_name="my_s3_data_asset",
@@ -602,7 +602,7 @@ def test_return_only_unique_batch_definitions():
         file_path_template_map_fn=S3Url.OBJECT_URL_TEMPLATE.format,
     )
 
-    unsorted_batch_definition_list: List[BatchDefinition] = (
+    unsorted_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(
             BatchRequest(
                 datasource_name="my_file_path_datasource",
@@ -660,8 +660,8 @@ def test_alpha():
     assert my_data_connector.get_unmatched_data_references()[:3] == []
     assert my_data_connector.get_unmatched_data_reference_count() == 0
 
-    my_batch_definition_list: List[BatchDefinition]
-    my_batch_definition: BatchDefinition
+    my_batch_definition_list: List[LegacyBatchDefinition]
+    my_batch_definition: LegacyBatchDefinition
 
     my_batch_request: BatchRequest
 
@@ -812,7 +812,7 @@ def test_foxtrot():
         data_asset_name="my_s3_data_asset",
         options={},
     )
-    my_batch_definition_list: List[BatchDefinition] = (
+    my_batch_definition_list: List[LegacyBatchDefinition] = (
         my_data_connector.get_batch_definition_list(batch_request=my_batch_request)
     )
     assert len(my_batch_definition_list) == 3

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -9,9 +9,9 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations.compatibility import pyspark
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     BatchRequest,
     IDDict,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -207,7 +207,7 @@ def test_get_batch_definitions_and_get_batch_basics(basic_pandas_datasource_v013
     )
 
     batch: Batch = basic_pandas_datasource_v013.get_batch_from_batch_definition(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             datasource_name="my_datasource",
             data_connector_name="my_filesystem_data_connector",
             data_asset_name="B1",
@@ -223,7 +223,7 @@ def test_get_batch_definitions_and_get_batch_basics(basic_pandas_datasource_v013
     # TODO Abe 20201104: Make sure this is what we truly want to do.
     assert batch.batch_request == {}
     assert isinstance(batch.data.dataframe, pd.DataFrame)
-    assert batch.batch_definition == BatchDefinition(
+    assert batch.batch_definition == LegacyBatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="my_filesystem_data_connector",
         data_asset_name="B1",
@@ -272,7 +272,7 @@ def test_get_batch_definitions_and_get_batch_basics(basic_pandas_datasource_v013
 
     my_df: pd.DataFrame = pd.DataFrame({"x": range(10), "y": range(10)})
     batch: Batch = basic_pandas_datasource_v013.get_batch_from_batch_definition(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             "my_datasource",
             "_pipeline",
             "_pipeline",

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector_pandas_execution_engine.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector_pandas_execution_engine.py
@@ -13,8 +13,8 @@ except ImportError:
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     IDDict,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -362,7 +362,7 @@ def test_batch_data_pandas_execution_engine_get_batch_definitions_and_get_batch_
 
     my_df: pd.DataFrame = pd.DataFrame({"x": range(10), "y": range(10)})
     batch: Batch = datasource_with_runtime_data_connector_and_pandas_execution_engine.get_batch_from_batch_definition(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             "my_datasource",
             "_pipeline",
             "_pipeline",

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector_sparkdf_execution_engine.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector_sparkdf_execution_engine.py
@@ -13,8 +13,8 @@ except ImportError:
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     IDDict,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
@@ -372,7 +372,7 @@ def test_batch_data_sparkdf_execution_engine_get_batch_definitions_and_get_batch
         spark_session.createDataFrame(pd.DataFrame({"x": range(10), "y": range(10)}))
     )
     batch: Batch = datasource_with_runtime_data_connector_and_sparkdf_execution_engine.get_batch_from_batch_definition(
-        batch_definition=BatchDefinition(
+        batch_definition=LegacyBatchDefinition(
             "my_datasource",
             "_pipeline",
             "_pipeline",

--- a/tests/execution_engine/partition_and_sample/test_pandas_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_pandas_execution_engine_partitioning.py
@@ -9,7 +9,7 @@ import pytest
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.core.batch_spec import (
     PathBatchSpec,
     RuntimeDataBatchSpec,
@@ -362,7 +362,7 @@ def test_get_batch_with_partition_on_whole_table_s3_with_configured_asset_s3_dat
             "group_names": ["index"],
         },
     )
-    batch_def = BatchDefinition(
+    batch_def = LegacyBatchDefinition(
         datasource_name="FAKE_DATASOURCE_NAME",
         data_connector_name="my_data_connector",
         data_asset_name="alpha",
@@ -378,7 +378,7 @@ def test_get_batch_with_partition_on_whole_table_s3_with_configured_asset_s3_dat
     assert test_df.dataframe.shape == expected_df.shape
 
     # if key does not exist
-    batch_def_no_key = BatchDefinition(
+    batch_def_no_key = LegacyBatchDefinition(
         datasource_name="FAKE_DATASOURCE_NAME",
         data_connector_name="my_data_connector",
         data_asset_name="alpha",

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -11,7 +11,7 @@ from great_expectations.core import (
     ExpectationValidationResult,
     IDDict,
 )
-from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest
+from great_expectations.core.batch import Batch, BatchRequest, LegacyBatchDefinition
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.metric_function_types import (
     MetricPartialFunctionTypes,
@@ -144,7 +144,7 @@ def _expecation_configuration_to_validation_result_pandas(
 
     """
     expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="pandas_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -795,7 +795,7 @@ def test_spark_single_column_complete_result_format(
         },
     )
     expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -852,7 +852,7 @@ def test_spark_single_column_complete_result_format_with_id_pk(
         },
     )
     expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -923,7 +923,7 @@ def test_spark_single_column_summary_result_format(
         },
     )
     expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",
@@ -976,7 +976,7 @@ def test_spark_single_column_basic_result_format(
         },
     )
     expectation = gxe.ExpectColumnValuesToBeInSet(**expectation_configuration.kwargs)
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="spark_datasource",
         data_connector_name="runtime_data_connector",
         data_asset_name="my_asset",

--- a/tests/integration/db/taxi_data_utils.py
+++ b/tests/integration/db/taxi_data_utils.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 
 import great_expectations as gx
 from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchDefinition, BatchRequest
+from great_expectations.core.batch import BatchRequest, LegacyBatchDefinition
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource import BaseDatasource
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
@@ -156,7 +156,7 @@ def _execute_taxi_partitioning_test_cases(
             data_connector_name=data_connector_name,
             data_asset_name=data_asset_name,
         )
-        batch_definition_list: List[BatchDefinition] = (
+        batch_definition_list: List[LegacyBatchDefinition] = (
             data_connector.get_batch_definition_list_from_batch_request(
                 batch_request=batch_request
             )
@@ -165,10 +165,10 @@ def _execute_taxi_partitioning_test_cases(
         print(test_case.num_expected_batch_definitions, "expected batch definitions")
         assert len(batch_definition_list) == test_case.num_expected_batch_definitions
 
-        expected_batch_definition_list: List[BatchDefinition]
+        expected_batch_definition_list: List[LegacyBatchDefinition]
         if test_case.table_domain_test_case:
             expected_batch_definition_list = [
-                BatchDefinition(
+                LegacyBatchDefinition(
                     datasource_name=datasource_name,
                     data_connector_name=data_connector_name,
                     data_asset_name=data_asset_name,
@@ -179,7 +179,7 @@ def _execute_taxi_partitioning_test_cases(
             column_value: Any
             if column_name:
                 expected_batch_definition_list = [
-                    BatchDefinition(
+                    LegacyBatchDefinition(
                         datasource_name=datasource_name,
                         data_connector_name=data_connector_name,
                         data_asset_name=data_asset_name,
@@ -190,7 +190,7 @@ def _execute_taxi_partitioning_test_cases(
             elif column_names:
                 dictionary_element: dict
                 expected_batch_definition_list = [
-                    BatchDefinition(
+                    LegacyBatchDefinition(
                         datasource_name=datasource_name,
                         data_connector_name=data_connector_name,
                         data_asset_name=data_asset_name,

--- a/tests/integration/db/test_sql_data_sampling.py
+++ b/tests/integration/db/test_sql_data_sampling.py
@@ -4,7 +4,7 @@ import pandas as pd
 import sqlalchemy as sa
 
 import great_expectations as gx
-from great_expectations.core.batch import BatchDefinition, BatchRequest
+from great_expectations.core.batch import BatchRequest, LegacyBatchDefinition
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource import BaseDatasource
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
@@ -87,7 +87,7 @@ if __name__ == "test_script_module":
                 data_connector_name=data_connector_name,
                 data_asset_name=data_asset_name,
             )
-            batch_definition_list: List[BatchDefinition] = (
+            batch_definition_list: List[LegacyBatchDefinition] = (
                 data_connector.get_batch_definition_list_from_batch_request(
                     batch_request
                 )

--- a/tests/render/test_EmailRenderer.py
+++ b/tests/render/test_EmailRenderer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from great_expectations.core.batch import BatchDefinition, IDDict
+from great_expectations.core.batch import IDDict, LegacyBatchDefinition
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
@@ -68,7 +68,7 @@ def test_EmailRenderer_validation_results_with_datadocs():
 
 
 def test_EmailRenderer_checkpoint_validation_results_with_datadocs():
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
         data_asset_name="test_data_asset",

--- a/tests/render/test_OpsgenieRenderer.py
+++ b/tests/render/test_OpsgenieRenderer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from great_expectations.core.batch import BatchDefinition, IDDict
+from great_expectations.core.batch import IDDict, LegacyBatchDefinition
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
@@ -41,7 +41,7 @@ def test_OpsgenieRenderer_validation_results_success():
 
 
 def test_OpsgenieRenderer_checkpoint_validation_results_success():
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
         data_asset_name="test_data_asset",

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from great_expectations.core.batch import BatchDefinition, IDDict
+from great_expectations.core.batch import IDDict, LegacyBatchDefinition
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
@@ -202,7 +202,7 @@ def test_SlackRenderer_validation_results_with_datadocs(
 
 
 def test_SlackRenderer_checkpoint_validation_results_with_datadocs():
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
         data_asset_name="test_data_asset",

--- a/tests/render/test_microsoft_teams_renderer.py
+++ b/tests/render/test_microsoft_teams_renderer.py
@@ -6,7 +6,7 @@ from great_expectations.core import (
     ExpectationSuiteValidationResult,
     RunIdentifier,
 )
-from great_expectations.core.batch import BatchDefinition
+from great_expectations.core.batch import LegacyBatchDefinition
 from great_expectations.data_context.types.resource_identifiers import (
     BatchIdentifier,
     ExpectationSuiteIdentifier,
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.big
                 "expectation_suite_name": "asset.default",
                 "run_id": "test_100",
                 "active_batch_definition": Mock(
-                    BatchDefinition, data_asset_name="expected_asset_name"
+                    LegacyBatchDefinition, data_asset_name="expected_asset_name"
                 ),
             },
             "1234",

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -7,9 +7,9 @@ import pytest
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchDefinition,
     BatchMarkers,
     BatchRequest,
+    LegacyBatchDefinition,
 )
 from great_expectations.core.domain import Domain
 from great_expectations.core.id_dict import BatchSpec, IDDict
@@ -46,7 +46,7 @@ def batch_fixture() -> Batch:
         data_connector_name="my_data_connector",
         data_asset_name="my_data_asset_name",
     )
-    batch_definition = BatchDefinition(
+    batch_definition = LegacyBatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="my_data_connector",
         data_asset_name="my_data_asset_name",

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -13,9 +13,9 @@ import great_expectations.exceptions as gx_exceptions
 import great_expectations.expectations as gxe
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import (
-    BatchDefinition,
     BatchMarkers,
     BatchRequest,
+    LegacyBatchDefinition,
     RuntimeBatchRequest,
 )
 from great_expectations.core.expectation_validation_result import (
@@ -452,7 +452,7 @@ def test_validator_with_bad_batchrequest(
 def test_validator_batch_filter(
     multi_batch_taxi_validator,
 ):
-    total_batch_definition_list: List[BatchDefinition] = [
+    total_batch_definition_list: List[LegacyBatchDefinition] = [
         v.batch_definition for k, v in multi_batch_taxi_validator.batches.items()
     ]
 
@@ -460,7 +460,7 @@ def test_validator_batch_filter(
         data_connector_query_dict={"batch_filter_parameters": {"month": "01"}}
     )
 
-    jan_batch_definition_list: List[BatchDefinition] = (
+    jan_batch_definition_list: List[LegacyBatchDefinition] = (
         jan_batch_filter.select_from_data_connector_query(
             batch_definition_list=total_batch_definition_list
         )
@@ -474,7 +474,7 @@ def test_validator_batch_filter(
         data_connector_query_dict={"index": slice(-1, 0, -1)}
     )
 
-    feb_march_batch_definition_list: List[BatchDefinition] = (
+    feb_march_batch_definition_list: List[LegacyBatchDefinition] = (
         feb_march_batch_filter.select_from_data_connector_query(
             batch_definition_list=total_batch_definition_list
         )
@@ -499,7 +499,7 @@ def test_validator_batch_filter(
         }
     )
 
-    jan_march_batch_definition_list: List[BatchDefinition] = (
+    jan_march_batch_definition_list: List[LegacyBatchDefinition] = (
         jan_march_batch_filter.select_from_data_connector_query(
             batch_definition_list=total_batch_definition_list
         )
@@ -519,7 +519,7 @@ def test_validator_batch_filter(
         data_connector_query_dict={"limit": 2}
     )
 
-    limit_batch_filter_definition_list: List[BatchDefinition] = (
+    limit_batch_filter_definition_list: List[LegacyBatchDefinition] = (
         limit_batch_filter.select_from_data_connector_query(
             batch_definition_list=total_batch_definition_list
         )
@@ -542,7 +542,7 @@ def test_validator_batch_filter(
 def test_custom_filter_function(
     multi_batch_taxi_validator,
 ):
-    total_batch_definition_list: List[BatchDefinition] = [
+    total_batch_definition_list: List[LegacyBatchDefinition] = [
         v.batch_definition for k, v in multi_batch_taxi_validator.batches.items()
     ]
     assert len(total_batch_definition_list) == 3


### PR DESCRIPTION
See title. Rename `BatchDefinition` -> `LegacyBatchDefinition` to make room for the next PR, which renames `BatchConfig` -> `BatchDefinition`. Note that this only renames the class, not any variable or attribute names.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
