### PR TITLE
[MAINTENANCE] Add validation result URL support within V1 Checkpoint

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -887,13 +887,11 @@ class StoreValidationResultAction(ValidationAction):
         checkpoint_identifier: Optional[GXCloudIdentifier] = None,
     ):
         logger.debug("StoreValidationResultAction.run")
-        output = store_validation_results(
-            self._target_store,
+        output = self._target_store.store_validation_results(
             validation_result_suite,
             validation_result_suite_identifier,
             expectation_suite_identifier,
             checkpoint_identifier,
-            self._using_cloud_context,
         )
 
         if isinstance(output, GXCloudResourceRef) and isinstance(
@@ -903,33 +901,6 @@ class StoreValidationResultAction(ValidationAction):
 
         if self._using_cloud_context and isinstance(output, GXCloudResourceRef):
             return output
-
-
-def store_validation_results(  # noqa: PLR0913
-    validation_result_store: ValidationsStore,
-    suite_validation_result: ExpectationSuiteValidationResult,
-    suite_validation_result_identifier: ValidationResultIdentifier | GXCloudIdentifier,
-    expectation_suite_identifier: Optional[ExpectationSuiteIdentifier | GXCloudIdentifier] = None,
-    checkpoint_identifier: Optional[GXCloudIdentifier] = None,
-    cloud_mode: bool = False,
-) -> bool | GXCloudResourceRef:
-    """Helper function to do the heavy lifting for StoreValidationResultAction and ValidationConfigs.
-    This is broken from the ValidationAction (for now) so we don't need to pass the data_context around.
-    """  # noqa: E501
-    checkpoint_id = None
-    if cloud_mode and checkpoint_identifier:
-        checkpoint_id = checkpoint_identifier.id
-
-    expectation_suite_id = None
-    if isinstance(expectation_suite_identifier, GXCloudIdentifier):
-        expectation_suite_id = expectation_suite_identifier.id
-
-    return validation_result_store.set(
-        key=suite_validation_result_identifier,
-        value=suite_validation_result,
-        checkpoint_id=checkpoint_id,
-        expectation_suite_id=expectation_suite_id,
-    )
 
 
 @public_api

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -8,7 +8,7 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations import project_manager
 from great_expectations._docs_decorators import public_api
 from great_expectations.checkpoint.actions import ValidationAction  # noqa: TCH001
-from great_expectations.compatibility.pydantic import BaseModel, root_validator, validator
+from great_expectations.compatibility.pydantic import BaseModel, Field, root_validator, validator
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,  # noqa: TCH001
 )
@@ -150,7 +150,7 @@ class Checkpoint(BaseModel):
             run_id=run_id,
             run_results=run_results,
             checkpoint_config=self,
-            validation_result_url=None,  # TODO: Need to plumb from actions
+            validation_result_urls=[result.result_url for result in run_results.values()],
         )
 
     def _run_validation_definitions(
@@ -210,7 +210,7 @@ class CheckpointResult(BaseModel):
     run_id: RunIdentifier
     run_results: Dict[ValidationResultIdentifier, ExpectationSuiteValidationResult]
     checkpoint_config: Checkpoint
-    validation_result_url: Optional[str] = None
+    validation_result_urls: List[Optional[str]] = Field(default_factory=list)
     success: Optional[bool] = None
 
     class Config:

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -8,7 +8,7 @@ import great_expectations.exceptions as gx_exceptions
 from great_expectations import project_manager
 from great_expectations._docs_decorators import public_api
 from great_expectations.checkpoint.actions import ValidationAction  # noqa: TCH001
-from great_expectations.compatibility.pydantic import BaseModel, Field, root_validator, validator
+from great_expectations.compatibility.pydantic import BaseModel, root_validator, validator
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,  # noqa: TCH001
 )
@@ -150,7 +150,6 @@ class Checkpoint(BaseModel):
             run_id=run_id,
             run_results=run_results,
             checkpoint_config=self,
-            validation_result_urls=[result.result_url for result in run_results.values()],
         )
 
     def _run_validation_definitions(
@@ -210,7 +209,6 @@ class CheckpointResult(BaseModel):
     run_id: RunIdentifier
     run_results: Dict[ValidationResultIdentifier, ExpectationSuiteValidationResult]
     checkpoint_config: Checkpoint
-    validation_result_urls: List[Optional[str]] = Field(default_factory=list)
     success: Optional[bool] = None
 
     class Config:

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -638,11 +638,15 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         )
 
     def describe_dict(self) -> dict:
-        return {
+        data = {
             "success": self.success,
             "statistics": self.statistics,
             "expectations": [expectation.describe_dict() for expectation in self.results],
         }
+        if self.result_url:
+            data["result_url"] = self.result_url
+
+        return data
 
     @public_api
     def describe(self) -> str:

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from marshmallow import Schema, fields, post_dump, post_load, pre_dump
 from typing_extensions import TypedDict
@@ -637,7 +637,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
             meta=self.meta,
         )
 
-    def describe_dict(self) -> dict:
+    def describe_dict(self) -> dict[str, Any]:
         data = {
             "success": self.success,
             "statistics": self.statistics,

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -514,6 +514,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         statistics: Optional[dict] = None,
         meta: Optional[ExpectationSuiteValidationResult | dict] = None,
         batch_id: Optional[str] = None,
+        result_url: Optional[str] = None,
         id: Optional[str] = None,
     ) -> None:
         self.success = success
@@ -531,6 +532,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         ensure_json_serializable(meta)  # We require meta information to be serializable.
         self.meta = meta
         self.batch_id = batch_id
+        self.result_url = result_url
         self._metrics: dict = {}
 
     def __eq__(self, other):

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from marshmallow import Schema, fields, post_dump, post_load, pre_dump
 from typing_extensions import TypedDict
@@ -637,16 +637,13 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
             meta=self.meta,
         )
 
-    def describe_dict(self) -> dict[str, Any]:
-        data = {
+    def describe_dict(self) -> dict:
+        return {
             "success": self.success,
             "statistics": self.statistics,
             "expectations": [expectation.describe_dict() for expectation in self.results],
+            "result_url": self.result_url,
         }
-        if self.result_url:
-            data["result_url"] = self.result_url
-
-        return data
 
     @public_api
     def describe(self) -> str:

--- a/great_expectations/core/validation_config.py
+++ b/great_expectations/core/validation_config.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
-from great_expectations.checkpoint.actions import store_validation_results
 from great_expectations.compatibility.pydantic import (
     BaseModel,
     Field,
@@ -216,17 +215,14 @@ class ValidationConfig(BaseModel):
             validation_result_id,
         ) = self._get_expectation_suite_and_validation_result_ids(validator)
 
-        ref = store_validation_results(
-            validation_result_store=self._validation_results_store,
+        ref = self._validation_results_store.store_validation_results(
             suite_validation_result=results,
             suite_validation_result_identifier=validation_result_id,
             expectation_suite_identifier=expectation_suite_identifier,
-            cloud_mode=self._validation_results_store.cloud_mode,
         )
 
         if isinstance(ref, GXCloudResourceRef):
-            result_url = ref.response["data"]["attributes"]["validation_result"]["display_url"]
-            results.result_url = result_url
+            results.result_url = self._validation_results_store.get_result_url(ref)
 
         return results
 

--- a/great_expectations/core/validation_config.py
+++ b/great_expectations/core/validation_config.py
@@ -23,6 +23,7 @@ from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.core.serdes import _EncodedValidationData, _IdentifierBundle
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.context_factory import project_manager
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     GXCloudIdentifier,
@@ -215,13 +216,18 @@ class ValidationConfig(BaseModel):
             validation_result_id,
         ) = self._get_expectation_suite_and_validation_result_ids(validator)
 
-        store_validation_results(
+        ref = store_validation_results(
             validation_result_store=self._validation_results_store,
             suite_validation_result=results,
             suite_validation_result_identifier=validation_result_id,
             expectation_suite_identifier=expectation_suite_identifier,
             cloud_mode=self._validation_results_store.cloud_mode,
         )
+
+        # TODO(cdkini): Don't love the placement but this gets the URL from Cloud
+        if isinstance(ref, GXCloudResourceRef):
+            result_url = ref.response["data"]["attributes"]["validation_result"]["display_url"]
+            results.result_url = result_url
 
         return results
 

--- a/great_expectations/core/validation_config.py
+++ b/great_expectations/core/validation_config.py
@@ -224,7 +224,6 @@ class ValidationConfig(BaseModel):
             cloud_mode=self._validation_results_store.cloud_mode,
         )
 
-        # TODO(cdkini): Don't love the placement but this gets the URL from Cloud
         if isinstance(ref, GXCloudResourceRef):
             result_url = ref.response["data"]["attributes"]["validation_result"]["display_url"]
             results.result_url = result_url

--- a/great_expectations/core/validation_config.py
+++ b/great_expectations/core/validation_config.py
@@ -222,7 +222,9 @@ class ValidationConfig(BaseModel):
         )
 
         if isinstance(ref, GXCloudResourceRef):
-            results.result_url = self._validation_results_store.get_result_url(ref)
+            results.result_url = self._validation_results_store.parse_result_url_from_gx_cloud_ref(
+                ref
+            )
 
         return results
 

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -202,5 +202,6 @@ class ValidationsStore(Store):
             expectation_suite_id=expectation_suite_id,
         )
 
-    def parse_result_url_from_gx_cloud_ref(self, ref: GXCloudResourceRef) -> str | None:
+    @staticmethod
+    def parse_result_url_from_gx_cloud_ref(ref: GXCloudResourceRef) -> str | None:
         return ref.response["data"]["attributes"]["validation_result"]["display_url"]

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -202,5 +202,5 @@ class ValidationsStore(Store):
             expectation_suite_id=expectation_suite_id,
         )
 
-    def get_result_url(self, ref: GXCloudResourceRef) -> str | None:
+    def parse_result_url_from_gx_cloud_ref(self, ref: GXCloudResourceRef) -> str | None:
         return ref.response["data"]["attributes"]["validation_result"]["display_url"]

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import ClassVar, Dict, Type
+from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Type
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.expectation_validation_result import (
+    ExpectationSuiteValidationResult,
     ExpectationSuiteValidationResultSchema,
 )
 from great_expectations.data_context.store.database_store_backend import (
@@ -12,6 +13,8 @@ from great_expectations.data_context.store.database_store_backend import (
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
+    ExpectationSuiteIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import load_class
@@ -19,6 +22,9 @@ from great_expectations.util import (
     filter_properties_dict,
     verify_dynamic_loading_support,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.data_context.types.refs import GXCloudResourceRef
 
 
 class ValidationsStore(Store):
@@ -168,3 +174,33 @@ class ValidationsStore(Store):
     @override
     def config(self) -> dict:
         return self._config
+
+    def store_validation_results(
+        self,
+        suite_validation_result: ExpectationSuiteValidationResult,
+        suite_validation_result_identifier: ValidationResultIdentifier | GXCloudIdentifier,
+        expectation_suite_identifier: Optional[
+            ExpectationSuiteIdentifier | GXCloudIdentifier
+        ] = None,
+        checkpoint_identifier: Optional[GXCloudIdentifier] = None,
+    ) -> bool | GXCloudResourceRef:
+        """Helper function to do the heavy lifting for StoreValidationResultAction and ValidationConfigs.
+        This is broken from the ValidationAction (for now) so we don't need to pass the data_context around.
+        """  # noqa: E501
+        checkpoint_id = None
+        if self.cloud_mode and checkpoint_identifier:
+            checkpoint_id = checkpoint_identifier.id
+
+        expectation_suite_id = None
+        if isinstance(expectation_suite_identifier, GXCloudIdentifier):
+            expectation_suite_id = expectation_suite_identifier.id
+
+        return self.set(
+            key=suite_validation_result_identifier,
+            value=suite_validation_result,
+            checkpoint_id=checkpoint_id,
+            expectation_suite_id=expectation_suite_id,
+        )
+
+    def get_result_url(self, ref: GXCloudResourceRef) -> str | None:
+        return ref.response["data"]["attributes"]["validation_result"]["display_url"]

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -430,7 +430,7 @@ class TestCheckpointResult:
         assert len(validation_result.results) == 1 and validation_result.results[0].success is True
 
         assert result.checkpoint_config == checkpoint
-        assert result.validation_result_url is None
+        assert result.validation_result_urls == [None]
         assert result.success is True
 
     @pytest.mark.unit

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -635,6 +635,7 @@ class TestCheckpointResult:
                         "unsuccessful_expectations": 1,
                     },
                     "success": False,
+                    "result_url": None,
                 },
             ],
         }

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -430,7 +430,6 @@ class TestCheckpointResult:
         assert len(validation_result.results) == 1 and validation_result.results[0].success is True
 
         assert result.checkpoint_config == checkpoint
-        assert result.validation_result_urls == [None]
         assert result.success is True
 
     @pytest.mark.unit

--- a/tests/core/test_expectation_validation_result.py
+++ b/tests/core/test_expectation_validation_result.py
@@ -249,7 +249,6 @@ def test_expectation_suite_validation_result_returns_expected_shape(
     # act
     description = svr.describe()
     # assert
-
     assert description == json.dumps(
         {
             "success": True,

--- a/tests/core/test_expectation_validation_result.py
+++ b/tests/core/test_expectation_validation_result.py
@@ -249,60 +249,58 @@ def test_expectation_suite_validation_result_returns_expected_shape(
     # act
     description = svr.describe()
     # assert
-    expected = {
-        "success": True,
-        "statistics": {
-            "evaluated_expectations": 2,
-            "successful_expectations": 2,
-            "unsuccessful_expectations": 0,
-            "success_percent": 100.0,
-        },
-        "expectations": [
-            {
-                "expectation_type": "expect_column_values_to_be_between",
-                "success": True,
-                "kwargs": {
-                    "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
-                    "mostly": 0.95,
-                    "column": "passenger_count",
-                    "min_value": 0.0,
-                    "max_value": 6.0,
-                },
-                "result": {
-                    "element_count": 100000,
-                    "unexpected_count": 1,
-                    "unexpected_percent": 0.001,
-                    "partial_unexpected_list": [7.0],
-                    "missing_count": 0,
-                    "missing_percent": 0.0,
-                    "unexpected_percent_total": 0.001,
-                    "unexpected_percent_nonmissing": 0.001,
-                    "partial_unexpected_counts": [{"value": 7.0, "count": 1}],
-                    "partial_unexpected_index_list": [48422],
-                },
-            },
-            {
-                "expectation_type": "expect_column_values_to_not_be_null",
-                "success": True,
-                "kwargs": {
-                    "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
-                    "column": "trip_distance",
-                },
-                "result": {
-                    "element_count": 100000,
-                    "unexpected_count": 0,
-                    "unexpected_percent": 0.0,
-                    "partial_unexpected_list": [],
-                    "partial_unexpected_counts": [],
-                    "partial_unexpected_index_list": [],
-                },
-            },
-        ],
-    }
-    if validation_result_url:
-        expected["result_url"] = validation_result_url
 
     assert description == json.dumps(
-        expected,
+        {
+            "success": True,
+            "statistics": {
+                "evaluated_expectations": 2,
+                "successful_expectations": 2,
+                "unsuccessful_expectations": 0,
+                "success_percent": 100.0,
+            },
+            "expectations": [
+                {
+                    "expectation_type": "expect_column_values_to_be_between",
+                    "success": True,
+                    "kwargs": {
+                        "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
+                        "mostly": 0.95,
+                        "column": "passenger_count",
+                        "min_value": 0.0,
+                        "max_value": 6.0,
+                    },
+                    "result": {
+                        "element_count": 100000,
+                        "unexpected_count": 1,
+                        "unexpected_percent": 0.001,
+                        "partial_unexpected_list": [7.0],
+                        "missing_count": 0,
+                        "missing_percent": 0.0,
+                        "unexpected_percent_total": 0.001,
+                        "unexpected_percent_nonmissing": 0.001,
+                        "partial_unexpected_counts": [{"value": 7.0, "count": 1}],
+                        "partial_unexpected_index_list": [48422],
+                    },
+                },
+                {
+                    "expectation_type": "expect_column_values_to_not_be_null",
+                    "success": True,
+                    "kwargs": {
+                        "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
+                        "column": "trip_distance",
+                    },
+                    "result": {
+                        "element_count": 100000,
+                        "unexpected_count": 0,
+                        "unexpected_percent": 0.0,
+                        "partial_unexpected_list": [],
+                        "partial_unexpected_counts": [],
+                        "partial_unexpected_index_list": [],
+                    },
+                },
+            ],
+            "result_url": validation_result_url,
+        },
         indent=4,
     )

--- a/tests/core/test_expectation_validation_result.py
+++ b/tests/core/test_expectation_validation_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pytest
@@ -153,7 +155,16 @@ def test_expectation_validation_result_describe_returns_expected_description_wit
 
 
 @pytest.mark.unit
-def test_expectation_suite_validation_result_returns_expected_shape():
+@pytest.mark.parametrize(
+    "validation_result_url",
+    [
+        "https://app.greatexpectations.io/organizations/my-org/data-assets/6f6d390b-a52b-41d1-b5c0-a1d57a6b4618/validations/expectation-suites/a0af0eb5-90ab-4219-ab60-482eee0a8b32/results/e77ce5e4-b71b-4f86-9c3b-f82385aab660",
+        None,
+    ],
+)
+def test_expectation_suite_validation_result_returns_expected_shape(
+    validation_result_url: str | None,
+):
     # arrange
     svr = ExpectationSuiteValidationResult(
         success=True,
@@ -233,60 +244,65 @@ def test_expectation_suite_validation_result_returns_expected_shape():
                 }
             ),
         ],
+        result_url=validation_result_url,
     )
     # act
     description = svr.describe()
     # assert
-    assert description == json.dumps(
-        {
-            "success": True,
-            "statistics": {
-                "evaluated_expectations": 2,
-                "successful_expectations": 2,
-                "unsuccessful_expectations": 0,
-                "success_percent": 100.0,
-            },
-            "expectations": [
-                {
-                    "expectation_type": "expect_column_values_to_be_between",
-                    "success": True,
-                    "kwargs": {
-                        "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
-                        "mostly": 0.95,
-                        "column": "passenger_count",
-                        "min_value": 0.0,
-                        "max_value": 6.0,
-                    },
-                    "result": {
-                        "element_count": 100000,
-                        "unexpected_count": 1,
-                        "unexpected_percent": 0.001,
-                        "partial_unexpected_list": [7.0],
-                        "missing_count": 0,
-                        "missing_percent": 0.0,
-                        "unexpected_percent_total": 0.001,
-                        "unexpected_percent_nonmissing": 0.001,
-                        "partial_unexpected_counts": [{"value": 7.0, "count": 1}],
-                        "partial_unexpected_index_list": [48422],
-                    },
-                },
-                {
-                    "expectation_type": "expect_column_values_to_not_be_null",
-                    "success": True,
-                    "kwargs": {
-                        "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
-                        "column": "trip_distance",
-                    },
-                    "result": {
-                        "element_count": 100000,
-                        "unexpected_count": 0,
-                        "unexpected_percent": 0.0,
-                        "partial_unexpected_list": [],
-                        "partial_unexpected_counts": [],
-                        "partial_unexpected_index_list": [],
-                    },
-                },
-            ],
+    expected = {
+        "success": True,
+        "statistics": {
+            "evaluated_expectations": 2,
+            "successful_expectations": 2,
+            "unsuccessful_expectations": 0,
+            "success_percent": 100.0,
         },
+        "expectations": [
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "success": True,
+                "kwargs": {
+                    "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
+                    "mostly": 0.95,
+                    "column": "passenger_count",
+                    "min_value": 0.0,
+                    "max_value": 6.0,
+                },
+                "result": {
+                    "element_count": 100000,
+                    "unexpected_count": 1,
+                    "unexpected_percent": 0.001,
+                    "partial_unexpected_list": [7.0],
+                    "missing_count": 0,
+                    "missing_percent": 0.0,
+                    "unexpected_percent_total": 0.001,
+                    "unexpected_percent_nonmissing": 0.001,
+                    "partial_unexpected_counts": [{"value": 7.0, "count": 1}],
+                    "partial_unexpected_index_list": [48422],
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "success": True,
+                "kwargs": {
+                    "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset",
+                    "column": "trip_distance",
+                },
+                "result": {
+                    "element_count": 100000,
+                    "unexpected_count": 0,
+                    "unexpected_percent": 0.0,
+                    "partial_unexpected_list": [],
+                    "partial_unexpected_counts": [],
+                    "partial_unexpected_index_list": [],
+                },
+            },
+        ],
+    }
+    if validation_result_url:
+        expected["result_url"] = validation_result_url
+
+    assert description == json.dumps(
+        expected,
         indent=4,
     )


### PR DESCRIPTION
Ensure that Cloud URLs are passed down through to both validation definition and checkpoint results

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
