### PR TITLE
[BUGFIX] Issue 5627: unexpected_rows not included in result of is_null and is_not_null column map expectations

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -250,4 +250,7 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
             unexpected_index_query=metrics.get(
                 f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_INDEX_QUERY.value}"
             ),
+            unexpected_rows=metrics.get(
+                f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}"
+            ),
         )

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -289,4 +289,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             unexpected_index_query=metrics.get(
                 f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_INDEX_QUERY.value}"
             ),
+            unexpected_rows=metrics.get(
+                f"{self.map_metric}.{SummarizationMetricNameSuffixes.UNEXPECTED_ROWS.value}"
+            ),
         )


### PR DESCRIPTION
This is a fix to address the problem where unexpected_rows was omitted from the results of two expectations: expect_column_values_to_be_null and expect_column_values_to_not_be_null. https://github.com/great-expectations/great_expectations/issues/5627

- [X] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [X] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
