### PR TITLE
[DOCS] Move expectations gallery link inside navbar

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -150,16 +150,17 @@ module.exports = {
           position: 'right',
         },
         {
+          label: 'Expectations gallery',
+          to: 'https://greatexpectations.io/expectations',
+          position: 'right'
+        },
+        {
           type: 'dropdown',
           label: 'Resources',
           items: [
             {
               label: 'Get support',
               to: '/docs/resources/get_support',
-            },
-            {
-              label: 'Expectations gallery',
-              to: 'https://greatexpectations.io/expectations',
             },
             {
               label: 'Integration support policy',

--- a/docs/docusaurus/src/css/navbar.scss
+++ b/docs/docusaurus/src/css/navbar.scss
@@ -65,7 +65,7 @@
 
     /* The number in this rule corresponds to the amount of links that
       will be positioned in the right end of the tabs in the navbar */
-    &:nth-last-child(1) {
+    &:nth-last-child(2) {
       margin-left: auto;
     }
   }


### PR DESCRIPTION
## Description
- Move expectations gallery link to be a whole item in the navbar instead of inside resources dropdown

## Screenshot
![Captura desde 2024-03-25 22-25-24](https://github.com/great-expectations/great_expectations/assets/7197057/d9da4280-ff8c-4c1c-b504-03197abcd4a5)


- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
