### PR TITLE
[MAINTENANCE] Cloud tests - don't error on `GxInvalidDatasourceWarning` - `package_resources` deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
 
       - name: Run the tests
         run:
-          invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasources.fluent.GxInvalidDatasourceWarning
+          invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
           # upload coverage report to codecov
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
 
       - name: Run the tests
         run:
-          invoke ci-tests 'cloud' --up-services --verbose  --reports
+          invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::GxInvalidDatasourceWarning
 
           # upload coverage report to codecov
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
 
       - name: Run the tests
         run:
-          invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::GxInvalidDatasourceWarning
+          invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasources.fluent.GxInvalidDatasourceWarning
 
           # upload coverage report to codecov
       - name: Upload coverage reports to Codecov

--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -15,7 +15,7 @@ from subprocess import CalledProcessError, CompletedProcess, check_output, run
 from typing import Dict, Final, List, Optional, Tuple
 
 import click
-import pkg_resources
+import pkg_resources  # noqa: TID251 # TODO: switch to importlib.metadata or importlib.resources
 
 from great_expectations.compatibility import pydantic
 from great_expectations.core.expectation_diagnostics.expectation_doctor import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,7 +382,10 @@ filterwarnings = [
     # https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
     "default::pytest_mock.plugin.PytestMockWarning",
 
-    "default::DeprecationWarning: pkg_resources is deprecated as an API",
+    # the pkg_resources module distributed with setuptools has been deprecated
+    # we should never use it but it is used in some of our dependencies
+    # https://setuptools.pypa.io/en/latest/pkg_resources.html
+    "once::DeprecationWarning: pkg_resources is deprecated as an API",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,6 +387,7 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "once:pkg_resources is deprecated as an API:DeprecationWarning",
+    "once:Deprecated call to `pkg_resources.declare_namespace('ruamel')`:DeprecationWarning",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,7 +387,8 @@ filterwarnings = [
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
     "once:pkg_resources is deprecated as an API:DeprecationWarning",
-    "once:Deprecated call to `pkg_resources.declare_namespace('ruamel')`:DeprecationWarning",
+    # ruamel, google, etc.
+    "once:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,6 +363,7 @@ If you are working in a configuration file you may use the inline comment \
 "typing_extensions.override".msg = "Do not import typing_extensions.override directly, import `override` from great_expectations.compatibility.typing_extensions instead."
 # TODO: remove pydantic once our min version is pydantic v2
 "pydantic".msg = "Please do not import pydantic directly, import from great_expectations.compatibility.pydantic instead."
+"pkg_resources".msg = "pkg_resources module has been deprecated. Use importlib.resources or importlib.metada instead."
 
 
 # -----------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,7 +386,7 @@ filterwarnings = [
     # the pkg_resources module distributed with setuptools has been deprecated
     # we should never use it but it is used in some of our dependencies
     # https://setuptools.pypa.io/en/latest/pkg_resources.html
-    "once::DeprecationWarning: pkg_resources is deprecated as an API",
+    "once:pkg_resources is deprecated as an API:DeprecationWarning",
 
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,8 @@ filterwarnings = [
     # https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
     "default::pytest_mock.plugin.PytestMockWarning",
 
+    "default::DeprecationWarning: pkg_resources is deprecated as an API",
+
     # This warning is common during testing where we intentionally use a COMPLETE format even in cases that would
     # be potentially overly resource intensive in standard operation
     "ignore:Setting result format to COMPLETE for a SqlAlchemyDataset:UserWarning",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 
 # https://setuptools.pypa.io/en/latest/pkg_resources.html
-import pkg_resources  # noqa: TID251: TODO: switch to importlib.metadata or importlib.resources or poetry
+import pkg_resources  # noqa: TID251: TODO: switch to poetry
 from setuptools import find_packages, setup
 
 import versioneer

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import re
 from pathlib import Path
 
-import pkg_resources
+# https://setuptools.pypa.io/en/latest/pkg_resources.html
+import pkg_resources  # noqa: TID251: TODO: switch to importlib.metadata or importlib.resources or poetry
 from setuptools import find_packages, setup
 
 import versioneer

--- a/tasks.py
+++ b/tasks.py
@@ -999,7 +999,7 @@ def docs_snippet_tests(
     },
     iterable=["service_names", "up_services", "verbose"],
 )
-def ci_tests(
+def ci_tests(  # noqa: C901 - too complex (9)
     ctx: Context,
     marker: str,
     up_services: bool = False,
@@ -1042,7 +1042,7 @@ def ci_tests(
 
     if W:
         # https://docs.python.org/3/library/warnings.html#describing-warning-filters
-        pytest_options.append(f"-W={warnings}")
+        pytest_options.append(f"-W={W}")
 
     for test_deps in _get_marker_dependencies(marker):
         if restart_services or up_services:

--- a/tasks.py
+++ b/tasks.py
@@ -992,7 +992,11 @@ def docs_snippet_tests(
 
 
 @invoke.task(
-    help={"pty": _PTY_HELP_DESC, "reports": "Generate coverage reports to be uploaded to codecov"},
+    help={
+        "pty": _PTY_HELP_DESC,
+        "reports": "Generate coverage reports to be uploaded to codecov",
+        "W": "Warnings control",
+    },
     iterable=["service_names", "up_services", "verbose"],
 )
 def ci_tests(
@@ -1005,6 +1009,7 @@ def ci_tests(
     slowest: int = 5,
     timeout: float = 0.0,  # 0 indicates no timeout
     xdist: bool = False,
+    W: str | None = None,
     pty: bool = True,
 ):
     """
@@ -1034,6 +1039,10 @@ def ci_tests(
 
     if verbose:
         pytest_options.append("-vv")
+
+    if W:
+        # https://docs.python.org/3/library/warnings.html#describing-warning-filters
+        pytest_options.append(f"-W={warnings}")
 
     for test_deps in _get_marker_dependencies(marker):
         if restart_services or up_services:


### PR DESCRIPTION
Apply a `-W default::GxInvalidDatasourceWarning` filter to the cloud tests to prevent failing CI due to this warning.

In general, we want tests to fail for this warning, but the cloud tests do not control their own seed data, so we don't want to be as reactive to warnings.

### `package_resources` deprecation

Also had to deal with the deprecation of `package_resources` in newer `setuptools`.

https://setuptools.pypa.io/en/latest/pkg_resources.html

1. Prevent CI error on warning.
2. Added `banned-api` rule to prevent us from using this internally.
3. Ignored existing violations of `2` in `setup.py` & the build gallery.
  a. We should eventually make changes to the build gallery script.
  b. Should not bother making changes in `setup.py` since we want to move to `poetry` anyway.
