### PR TITLE
[DOCS] Corrects broken import for prerequisites in v0.18 connect to Filesystem Data Assets page

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
@@ -189,7 +189,7 @@ Connect to a Microsoft Azure Blob Storage Data Source.
 
 <Prerequisites>
 
-- <PrereqInstallGxWithDependencies />
+- [An installation of GX set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
 - Access to data in Azure Blob Storage
 
 </Prerequisites> 
@@ -243,7 +243,7 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 <Prerequisites>
 
-- <PrereqInstallGxWithDependencies />
+- [An installation of GX set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
 - Access to data in Azure Blob Storage
 
 </Prerequisites> 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
@@ -243,7 +243,7 @@ The following information is required when you create a Microsoft Azure Blob Sto
 
 <Prerequisites>
 
-- [An installation of GX set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
+- [GX installed and set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
 - Access to data in Azure Blob Storage
 
 </Prerequisites> 

--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/connecting_to_your_data/fluent/filesystem/connect_filesystem_source_data.md
@@ -189,7 +189,7 @@ Connect to a Microsoft Azure Blob Storage Data Source.
 
 <Prerequisites>
 
-- [An installation of GX set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
+- [GX installed and set up to work with Azure Blob Storage](/oss/guides/setup/installation/install_gx.md)
 - Access to data in Azure Blob Storage
 
 </Prerequisites> 


### PR DESCRIPTION
## Description
- Replaces a broken import in the Connect to Filesystem Data Assets topic with a direct link.

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated