### PR TITLE
[MAINTENANCE] Typing improvements in `test_metadatasource`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ exclude = [
     'v012',                                                              # legacy code
     'tests/datasource/fluent/test_metadatasource\.py',                   # metaprogramming leads to errors
     'datasource/data_connector/configured_asset_sql_data_connector\.py', # 37 - This is legacy code and will not be typed.
-    'dataset/sparkdf_dataset\.py',                                       #  3 - This is legacy code and will not be typed.
-    'dataset/sqlalchemy_dataset\.py',                                    # 16 - This is legacy code and will not be typed.
     'core/usage_statistics/anonymizers/batch_anonymizer\.py',            # 10 - This code will be removed in 1.0
     'core/usage_statistics/anonymizers/batch_request_anonymizer\.py',    # 16 - This code will be removed in 1.0
     'core/usage_statistics/anonymizers/checkpoint_anonymizer\.py',       # 16 - This code will be removed in 1.0

--- a/tasks.py
+++ b/tasks.py
@@ -89,15 +89,16 @@ def sort(
 
 
 @invoke.task(
+    aliases=("fmt",),
     help={
         "check": _CHECK_HELP_DESC,
         "exclude": _EXCLUDE_HELP_DESC,
         "path": _PATH_HELP_DESC,
         "sort": "Disable import sorting. Runs by default.",
         "pty": _PTY_HELP_DESC,
-    }
+    },
 )
-def fmt(
+def format(
     ctx: Context,
     path: str = ".",
     sort_: bool = True,
@@ -138,7 +139,7 @@ def lint(
 ):
     """Run formatter (ruff format) and linter (ruff)"""
     if fmt_:
-        fmt(ctx, path, check=not fix, pty=pty)
+        format(ctx, path, check=not fix, pty=pty)
 
     # Run code linter (ruff)
     cmds = ["ruff", "check", path]
@@ -153,7 +154,7 @@ def lint(
 def fix(ctx: Context, path: str = "."):
     """Automatically fix all possible code issues."""
     lint(ctx, path=path, fix=True)
-    fmt(ctx, path=path, sort_=True)
+    format(ctx, path=path, sort_=True)
 
 
 @invoke.task(help={"path": _PATH_HELP_DESC})

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -10,9 +10,12 @@ from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple, Type, U
 import pytest
 
 from great_expectations.compatibility.pydantic import DirectoryPath, validate_arguments
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.partitioners import Partitioner
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import AbstractDataContext, FileDataContext
 from great_expectations.data_context import get_context as get_gx_context
+from great_expectations.datasource.data_connector.batch_filter import BatchSlice
 from great_expectations.datasource.fluent.batch_request import (
     BatchRequest,
     BatchRequestOptions,
@@ -66,21 +69,12 @@ class DataContext:
             cls._context = DataContext(context_root_dir=context_root_dir)
 
         assert cls._context
-        if cls._context.root_directory:
-            # load config and add/instantiate Datasources & Assets
-            config_path = pathlib.Path(cls._context.root_directory) / _config_file
-            cls._config = GxConfig.parse_yaml(config_path)
-            for ds_name, datasource in cls._config.datasources.items():
-                logger.info(f"Loaded '{ds_name}' from config")
-                cls._context._add_fluent_datasource(datasource)
-                # TODO: add assets?
-
         return cls._context
 
     @validate_arguments
     def __init__(self, context_root_dir: Optional[DirectoryPath] = None) -> None:
         self.root_directory = context_root_dir
-        self._sources: _SourceFactories = _SourceFactories(self)
+        self._sources: _SourceFactories = _SourceFactories(self)  # type: ignore[arg-type]
         self._datasources: Dict[str, Datasource] = {}
         self.config_provider: _ConfigurationProvider | None = None
         logger.info(f"Available Factories - {self._sources.factories}")
@@ -92,7 +86,7 @@ class DataContext:
 
     @property
     def datasources(self) -> DatasourceDict:
-        return self._datasources
+        return self._datasources  # type: ignore[return-value]
 
     def _add_fluent_datasource(self, datasource: Datasource) -> Datasource:
         self._datasources[datasource.name] = datasource
@@ -125,7 +119,13 @@ def get_context(context_root_dir: Optional[DirectoryPath] = None, **kwargs):
 class DummyDataAsset(DataAsset):
     """Minimal Concrete DataAsset Implementation"""
 
-    def build_batch_request(self, options: Optional[BatchRequestOptions]) -> BatchRequest:
+    @override
+    def build_batch_request(
+        self,
+        options: Optional[BatchRequestOptions] = None,
+        batch_slice: Optional[BatchSlice] = None,
+        partitioner: Optional[Partitioner] = None,
+    ) -> BatchRequest:
         return BatchRequest("datasource_name", "data_asset_name", options or {})
 
 


### PR DESCRIPTION
Fix some typing errors in `test_metadatasource.py`
Add alias to `invoke fmt` so users can use `invoke format` as well
Remove unused `exclude`s in `pyproject.toml`


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
