### PR TITLE
[MAINTENANCE] Update git-blame-ignore-revs file to ignore changes in #9684

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -47,3 +47,6 @@ edf5dbdc77b418d659dc9d87462cd6df9a85436c
 # Change line-length from 88 -> 100
 # https://github.com/great-expectations/great_expectations/pull/9584
 d170c89167a96b702edc02b16dbf5984619d0e8f
+# enable TRYceratops linting; add noqa comments
+# https://github.com/great-expectations/great_expectations/pull/9684
+2bbfb50a6458f09ef197ee1174666a4c4726a850


### PR DESCRIPTION
Update `.git-blame-ignore-revs` to ignore TRYceratops-related noqa comments added in https://github.com/great-expectations/great_expectations/pull/9684.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
