### PR TITLE
[MAINTENANCE] Add after_n_builds to codecov default rules

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
+    after_n_builds: 10
     carryforward: false
     statuses:
       - type: project


### PR DESCRIPTION
We're getting some premature comments from codecov before all the reports are in. This just adds a ballpark number to hopefully mitigate the majority of false notifications.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
