### PR TITLE
[FEATURE] Implement TupleS3StoreBackend::get_all

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -551,6 +551,8 @@ class TupleS3StoreBackend(TupleStoreBackend):
     def _get_all(self) -> list[Any]:
         """Get all objects from the store.
         NOTE: This is non-performant because we download each object separately.
+        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/bucket/objects.html#objects
+        for the docs.
         """
         client = self._create_client()
         keys = self.list_keys()

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -639,6 +639,15 @@ class TupleS3StoreBackend(TupleStoreBackend):
 
         return key_list
 
+    def _get_s3_objects(self):
+        s3r = self._create_resource()
+        bucket = s3r.Bucket(self.bucket)
+
+        if self.prefix:
+            return bucket.objects.filter(Prefix=self.prefix)
+        else:
+            return bucket.objects.all()
+
     def get_url_for_key(self, key, protocol=None):
         location = None
         if self.boto3_options.get("endpoint_url"):

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -549,12 +549,13 @@ class TupleS3StoreBackend(TupleStoreBackend):
 
     @override
     def _get_all(self) -> list[Any]:
+        """Get all objects from the store.
+        NOTE: This is non-performant because we download each object separately.
+        """
         client = self._create_client()
         keys = self.list_keys()
         keys = [k for k in keys if k != StoreBackend.STORE_BACKEND_ID_KEY]
-
         s3_object_keys = [self._build_s3_object_key(key) for key in keys]
-
         return [self._get_by_s3_object_key(client, key) for key in s3_object_keys]
 
     def _get_by_s3_object_key(self, s3_client, s3_object_key):

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -631,6 +631,29 @@ def test_TupleS3StoreBackend_with_prefix(aws_credentials):
 
 @mock_s3
 @pytest.mark.aws_deps
+def test_TupleS3StoreBackend_get_all(aws_credentials):
+    bucket = "leakybucket"
+
+    # create a bucket in Moto's mock AWS environment
+    conn = boto3.resource("s3", region_name="us-east-1")
+    conn.create_bucket(Bucket=bucket)
+
+    my_store = TupleS3StoreBackend(filepath_template="my_file_{0}", bucket=bucket)
+
+    val_a = "aaa"
+    val_b = "bbb"
+
+    my_store.set(("AAA",), val_a, content_type="text/html; charset=utf-8")
+    my_store.set(("BBB",), val_b, content_type="text/html; charset=utf-8")
+
+    my_store.list_keys()
+    result = my_store.get_all()
+
+    assert sorted(result) == [val_a, val_b]
+
+
+@mock_s3
+@pytest.mark.aws_deps
 def test_tuple_s3_store_backend_slash_conditions(aws_credentials):  # noqa: PLR0915
     bucket = "my_bucket"
     prefix = None

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -646,7 +646,6 @@ def test_TupleS3StoreBackend_get_all(aws_credentials):
     my_store.set(("AAA",), val_a, content_type="text/html; charset=utf-8")
     my_store.set(("BBB",), val_b, content_type="text/html; charset=utf-8")
 
-    my_store.list_keys()
     result = my_store.get_all()
 
     assert sorted(result) == [val_a, val_b]


### PR DESCRIPTION
See title. This is query is non-performant because `bucket.objects` only exposes methods to get ObjectSummaries, rather than the objects themselves. Here are the docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/bucket/objects.html#objects.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
