### PR TITLE
[BUGFIX] Ensure that `Checkpoint` deserializes proper action subclass

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -6,7 +6,6 @@ The only requirement from an action is for it to have a take_action method.
 
 from __future__ import annotations
 
-import importlib
 import json
 import logging
 from typing import (
@@ -46,7 +45,7 @@ from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
-from great_expectations.exceptions import ClassInstantiationError, DataContextError
+from great_expectations.exceptions import ClassInstantiationError
 from great_expectations.render.renderer import (
     EmailRenderer,
     MicrosoftTeamsRenderer,
@@ -400,15 +399,6 @@ class PagerdutyAlertAction(ValidationAction):
     routing_key: str
     notify_on: Literal["all", "failure", "success"] = "failure"
     severity: Literal["critical", "error", "warning", "info"] = "critical"
-
-    @root_validator
-    def _root_validate_deps(cls, values: dict) -> dict:
-        if not importlib.util.find_spec("pypd"):
-            raise DataContextError(  # noqa: TRY003
-                'ModuleNotFoundError: No module named "pypd". "pypd" is required for PageDuty notification actions.'  # noqa: E501
-            )
-
-        return values
 
     @override
     def _run(  # type: ignore[override] # signature does not match parent  # noqa: PLR0913

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -6,7 +6,16 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, c
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
-from great_expectations.checkpoint.actions import ValidationAction  # noqa: TCH001
+from great_expectations.checkpoint.actions import (
+    EmailAction,  # noqa: TCH001
+    MicrosoftTeamsNotificationAction,  # noqa: TCH001
+    OpsgenieAlertAction,  # noqa: TCH001
+    PagerdutyAlertAction,  # noqa: TCH001
+    SlackNotificationAction,  # noqa: TCH001
+    SNSNotificationAction,  # noqa: TCH001
+    StoreValidationResultAction,  # noqa: TCH001
+    UpdateDataDocsAction,  # noqa: TCH001
+)
 from great_expectations.compatibility.pydantic import BaseModel, root_validator, validator
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,  # noqa: TCH001
@@ -45,7 +54,18 @@ class Checkpoint(BaseModel):
 
     name: str
     validation_definitions: List[ValidationDefinition]
-    actions: List[ValidationAction]
+    actions: List[
+        Union[
+            EmailAction,
+            MicrosoftTeamsNotificationAction,
+            OpsgenieAlertAction,
+            PagerdutyAlertAction,
+            SlackNotificationAction,
+            SNSNotificationAction,
+            StoreValidationResultAction,
+            UpdateDataDocsAction,
+        ]
+    ]
     result_format: ResultFormat = ResultFormat.SUMMARY
     id: Union[str, None] = None
 

--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, c
 import great_expectations.exceptions as gx_exceptions
 from great_expectations._docs_decorators import public_api
 from great_expectations.checkpoint.actions import (
-    EmailAction,  # noqa: TCH001
-    MicrosoftTeamsNotificationAction,  # noqa: TCH001
-    OpsgenieAlertAction,  # noqa: TCH001
-    PagerdutyAlertAction,  # noqa: TCH001
-    SlackNotificationAction,  # noqa: TCH001
-    SNSNotificationAction,  # noqa: TCH001
-    StoreValidationResultAction,  # noqa: TCH001
-    UpdateDataDocsAction,  # noqa: TCH001
+    EmailAction,
+    MicrosoftTeamsNotificationAction,
+    OpsgenieAlertAction,
+    PagerdutyAlertAction,
+    SlackNotificationAction,
+    SNSNotificationAction,
+    StoreValidationResultAction,
+    UpdateDataDocsAction,
 )
 from great_expectations.compatibility.pydantic import BaseModel, root_validator, validator
 from great_expectations.core.expectation_validation_result import (
@@ -31,9 +31,22 @@ from great_expectations.data_context.types.resource_identifiers import (
 from great_expectations.render.renderer.renderer import Renderer
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from great_expectations.data_context.store.validation_definition_store import (
         ValidationDefinitionStore,
     )
+
+CheckpointAction: TypeAlias = Union[
+    EmailAction,
+    MicrosoftTeamsNotificationAction,
+    OpsgenieAlertAction,
+    PagerdutyAlertAction,
+    SlackNotificationAction,
+    SNSNotificationAction,
+    StoreValidationResultAction,
+    UpdateDataDocsAction,
+]
 
 
 class Checkpoint(BaseModel):
@@ -54,18 +67,7 @@ class Checkpoint(BaseModel):
 
     name: str
     validation_definitions: List[ValidationDefinition]
-    actions: List[
-        Union[
-            EmailAction,
-            MicrosoftTeamsNotificationAction,
-            OpsgenieAlertAction,
-            PagerdutyAlertAction,
-            SlackNotificationAction,
-            SNSNotificationAction,
-            StoreValidationResultAction,
-            UpdateDataDocsAction,
-        ]
-    ]
+    actions: List[CheckpointAction]
     result_format: ResultFormat = ResultFormat.SUMMARY
     id: Union[str, None] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,6 +381,7 @@ extend-exclude = [
 runtime-evaluated-base-classes = [
     # NOTE: ruff is unable to detect that these are subclasses of pydantic.BaseModel
     "pydantic.BaseModel",
+    "great_expectations.checkpoint.v1_checkpoint.Checkpoint",
     "great_expectations.datasource.fluent.fluent_base_model.FluentBaseModel",
     "great_expectations.datasource.fluent.interfaces.Datasource",
     "great_expectations.datasource.fluent.sql_datasource.SQLDatasource",

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Type, Union
+from typing import Type
 from unittest import mock
 
 import pytest
@@ -23,7 +23,7 @@ from great_expectations.checkpoint.actions import (
 )
 from great_expectations.checkpoint.util import smtplib
 from great_expectations.checkpoint.v1_checkpoint import Checkpoint, CheckpointResult
-from great_expectations.compatibility.pydantic import BaseModel, Field, ValidationError
+from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
@@ -37,7 +37,6 @@ from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
 )
-from great_expectations.render.renderer.renderer import Renderer
 from great_expectations.util import is_library_loadable
 
 logger = logging.getLogger(__name__)
@@ -763,52 +762,6 @@ class TestActionSerialization:
     ):
         actual = action_class.parse_obj(serialized_action)
         assert isinstance(actual, action_class)
-
-    @pytest.mark.parametrize(
-        "action_class, init_params",
-        [(k, v) for k, v in ACTION_INIT_PARAMS.items()],
-        ids=[k.__name__ for k in ACTION_INIT_PARAMS],
-    )
-    @pytest.mark.unit
-    def test_action_deserialization_within_parent_class(
-        self, action_class: ValidationAction, init_params: dict
-    ):
-        """
-        The matter of deserializing an Action into the relevant subclass is the responsibility of
-        the Checkpoint in production code.
-
-        In order to test Actions alone, we utilize a dummy class with a single field to ensure
-        properly implementation of Pydantic discriminated unions.
-
-        Ref: https://docs.pydantic.dev/1.10/usage/types/#discriminated-unions-aka-tagged-unions
-        """
-
-        # This somewhat feels like we're testing Pydantic code but it's the only way to ensure that
-        # we've properly implemented the Pydantic discriminated union feature.
-        class DummyClassWithActionChild(BaseModel):
-            class Config:
-                # Due to limitations of Pydantic V1, we need to specify the json_encoders at every level of the hierarchy  # noqa: E501
-                json_encoders = {Renderer: lambda r: r.serialize()}
-
-            action: Union[
-                APINotificationAction,
-                EmailAction,
-                MicrosoftTeamsNotificationAction,
-                OpsgenieAlertAction,
-                PagerdutyAlertAction,
-                SlackNotificationAction,
-                SNSNotificationAction,
-                StoreValidationResultAction,
-                UpdateDataDocsAction,
-            ] = Field(..., discriminator="type")
-
-        action = action_class(**init_params)
-        instance = DummyClassWithActionChild(action=action)
-
-        json_dict = instance.json()
-        parsed_action = DummyClassWithActionChild.parse_raw(json_dict)
-
-        assert isinstance(parsed_action.action, action_class)
 
 
 class TestV1ActionRun:

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import pathlib
 import uuid
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -17,7 +17,11 @@ from great_expectations.checkpoint.actions import (
     UpdateDataDocsAction,
     ValidationAction,
 )
-from great_expectations.checkpoint.v1_checkpoint import Checkpoint, CheckpointResult
+from great_expectations.checkpoint.v1_checkpoint import (
+    Checkpoint,
+    CheckpointAction,
+    CheckpointResult,
+)
 from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.expectation_suite import ExpectationSuite
@@ -212,7 +216,7 @@ class TestCheckpointSerialization:
     def test_checkpoint_filesystem_round_trip_adds_ids(
         self,
         tmp_path: pathlib.Path,
-        actions: list[Union[SlackNotificationAction, MicrosoftTeamsNotificationAction]],
+        actions: list[CheckpointAction],
     ):
         with working_directory(tmp_path):
             context = gx.get_context(mode="file")
@@ -491,7 +495,7 @@ class TestCheckpointResult:
     def test_checkpoint_run_actions(
         self,
         validation_definition: ValidationDefinition,
-        actions: list[Union[SlackNotificationAction, MicrosoftTeamsNotificationAction]],
+        actions: list[CheckpointAction],
     ):
         validation_definitions = [validation_definition]
         checkpoint = Checkpoint(

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import pathlib
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 from unittest import mock
 
 import pytest
@@ -210,7 +210,9 @@ class TestCheckpointSerialization:
 
     @pytest.mark.filesystem
     def test_checkpoint_filesystem_round_trip_adds_ids(
-        self, tmp_path: pathlib.Path, actions: list[ValidationAction]
+        self,
+        tmp_path: pathlib.Path,
+        actions: list[Union[SlackNotificationAction, MicrosoftTeamsNotificationAction]],
     ):
         with working_directory(tmp_path):
             context = gx.get_context(mode="file")
@@ -487,7 +489,9 @@ class TestCheckpointResult:
 
     @pytest.mark.unit
     def test_checkpoint_run_actions(
-        self, validation_definition: ValidationDefinition, actions: list[ValidationAction]
+        self,
+        validation_definition: ValidationDefinition,
+        actions: list[Union[SlackNotificationAction, MicrosoftTeamsNotificationAction]],
     ):
         validation_definitions = [validation_definition]
         checkpoint = Checkpoint(

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -14,6 +14,7 @@ from great_expectations import set_context
 from great_expectations.checkpoint.actions import (
     MicrosoftTeamsNotificationAction,
     SlackNotificationAction,
+    UpdateDataDocsAction,
     ValidationAction,
 )
 from great_expectations.checkpoint.v1_checkpoint import Checkpoint, CheckpointResult
@@ -366,6 +367,37 @@ class TestCheckpointSerialization:
             Checkpoint.parse_obj(serialized_checkpoint)
 
         assert expected_error in str(e.value)
+
+    @pytest.mark.unit
+    def test_checkpoint_deserialization_with_actions(self, mocker: MockerFixture):
+        # Arrange
+        context = mocker.Mock(spec=AbstractDataContext)
+        context.validation_definition_store.get.return_value = mocker.Mock(
+            spec=ValidationDefinition
+        )
+        set_context(context)
+
+        # Act
+        serialized_checkpoint = {
+            "actions": [
+                {"site_names": [], "type": "update_data_docs"},
+                {"slack_webhook": "test", "type": "slack"},
+                {"teams_webhook": "test", "type": "microsoft"},
+            ],
+            "id": "e7d1f462-821b-429c-8086-cca80eeea5e9",
+            "name": "my_checkpoint",
+            "result_format": "SUMMARY",
+            "validation_definitions": [
+                {"id": "3fb9ce09-a8fb-44d6-8abd-7d699443f6a1", "name": "my_validation_def"}
+            ],
+        }
+        checkpoint = Checkpoint.parse_obj(serialized_checkpoint)
+
+        # Assert
+        assert len(checkpoint.actions) == 3
+        assert isinstance(checkpoint.actions[0], UpdateDataDocsAction)
+        assert isinstance(checkpoint.actions[1], SlackNotificationAction)
+        assert isinstance(checkpoint.actions[2], MicrosoftTeamsNotificationAction)
 
 
 class TestCheckpointResult:


### PR DESCRIPTION
Without the specific union noted in this PR, we get a generic `ValidationAction` type when reading from disk.

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
