### PR TITLE
[FEATURE] TupleGCSStoreBackend::get_all

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -828,12 +828,26 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         return gcs_object_key
 
     def _get(self, key):
-        gcs_object_key = self._build_gcs_object_key(key)
-
         from great_expectations.compatibility import google
 
         gcs = google.storage.Client(project=self.project)
         bucket = gcs.bucket(self.bucket)
+        return self._get_by_gcs_object_key(bucket, key)
+
+    @override
+    def _get_all(self) -> list[Any]:
+        from great_expectations.compatibility import google
+
+        gcs = google.storage.Client(project=self.project)
+        bucket = gcs.bucket(self.bucket)
+
+        keys = self.list_keys()
+        keys = [k for k in keys if k != StoreBackend.STORE_BACKEND_ID_KEY]
+
+        return [self._get_by_gcs_object_key(bucket, key) for key in keys]
+
+    def _get_by_gcs_object_key(self, bucket, key):
+        gcs_object_key = self._build_gcs_object_key(key)
         gcs_response_object = bucket.get_blob(gcs_object_key)
         if not gcs_response_object:
             raise InvalidKeyError(  # noqa: TRY003
@@ -841,10 +855,6 @@ class TupleGCSStoreBackend(TupleStoreBackend):
             )
         else:
             return gcs_response_object.download_as_bytes().decode("utf-8")
-
-    @override
-    def _get_all(self) -> list[Any]:
-        raise NotImplementedError
 
     def _set(
         self,

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1117,6 +1117,7 @@ def test_TupleGCSStoreBackend_get_all(mocker: MockerFixture):
         return output
 
     def mock_get_blob(gcs_object_key):
+        """Test double for bucket::get_blob."""
         key_to_return_val = {
             f"{prefix}/blob_a": val_a,
             f"{prefix}/blob_b": val_b,

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1101,6 +1101,7 @@ def test_TupleGCSStoreBackend():  # noqa: PLR0915
 )
 @pytest.mark.big
 def test_TupleGCSStoreBackend_get_all(mocker: MockerFixture):
+    # Note: it would be nice to inject the gcs client so we could pass in the mock.
     bucket = "leakybucket"
     prefix = "this_is_a_test_prefix"
     project = "dummy-project"

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1045,6 +1045,48 @@ def test_TupleGCSStoreBackend():  # noqa: PLR0915
     )
 
 
+@pytest.mark.skipif(
+    not is_library_loadable(library_name="google.cloud"),
+    reason="google is not installed",
+)
+@pytest.mark.skipif(
+    not is_library_loadable(library_name="google"),
+    reason="google is not installed",
+)
+@pytest.mark.big
+def test_TupleGCSStoreBackend_get_all():
+    """
+    What does this test and why?
+
+    the base_public_path parameter allows users to point to a custom DNS when hosting Data docs.
+
+    This test will exercise the get_url_for_key method twice to see that we are getting the expected url,
+    with or without base_public_path
+    """  # noqa: E501
+    bucket = "leakybucket"
+    prefix = "this_is_a_test_prefix"
+    project = "dummy-project"
+    base_public_path = "http://www.test.com/"
+    val_a = b"aaa"
+    val_b = b"bbb"
+
+    with mock.patch("google.cloud.storage.Client", autospec=True):
+        my_store = TupleGCSStoreBackend(
+            filepath_template=None,
+            bucket=bucket,
+            prefix=prefix,
+            project=project,
+            base_public_path=base_public_path,
+        )
+
+        my_store.set(("AAA",), val_a, content_encoding=None, content_type="image/png")
+        my_store.set(("BBB",), val_b, content_encoding=None, content_type="image/png")
+
+        result = my_store.get_all()
+
+        assert sorted(result) == [val_a, val_b]
+
+
 @pytest.mark.unit
 def test_TupleAzureBlobStoreBackend_credential():
     pytest.importorskip("azure.storage.blob")


### PR DESCRIPTION
Implements `TupleGCSStoreBackend::get_all`. Note that we could improve the performance if/when we bump google-cloud-storage to 2.12, using the `transfer_manager`.

The test coverage here uses fakes to mimic what GCS does, inferred from the preexisting code, but I also did a bit of manual testing. The steps if you want to repro:
* get set up with GCS (we have it in a sandbox)
* add a bucket
* follow google's docs on getting authorization working
* follow our docs to get a validation_result store hosted in that bucket
* run a checkpoint
* run the following code and make sure things look reasonable:
```
store = context.stores["validations_store"].store_backend
all_of_them = store.get_all() # check that this looks good.

# get an individual validation result to make sure it looks like the first in the above list if you want to check
keys = store.list_keys()
first = store.get(keys[0])
```

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
