### PR TITLE
[FEATURE] Refactor FilePathDataConnector

### DIFF
--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -316,7 +316,7 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         return {FilePathDataConnector.FILE_PATH_BATCH_SPEC_KEY: path}
 
     def _preprocess_batching_regex(self, regex: re.Pattern) -> re.Pattern:
-        """Add the FILE_PATH_BATCH_SPEC_KEY group to regex in case it is not already present."""
+        """Add the FILE_PATH_BATCH_SPEC_KEY group to regex if not already present."""
         regex_parser = RegExParser(
             regex_pattern=regex,
             unnamed_regex_group_prefix=self._unnamed_regex_group_prefix,

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -5,7 +5,7 @@ import logging
 import re
 from abc import abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
@@ -27,6 +27,8 @@ from great_expectations.datasource.fluent.data_asset.data_connector.regex_parser
 )
 
 if TYPE_CHECKING:
+    from typing import DefaultDict
+
     from great_expectations.alias_types import PathStr
     from great_expectations.datasource.fluent import BatchRequest
 
@@ -340,21 +342,21 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         self, batching_regex: re.Pattern
     ) -> Dict[str, List[LegacyBatchDefinition] | None]:
         """Access a map where keys are data references and values are LegacyBatchDefinitions."""
-        regex_parser = RegExParser(
-            regex_pattern=batching_regex,
-            unnamed_regex_group_prefix=self._unnamed_regex_group_prefix,
-        )
-        batch_definitions = self._data_references_cache.get(batching_regex)
+
+        batch_definitions = self._data_references_cache[batching_regex]
         if batch_definitions:
             return batch_definitions
 
         # Cache was empty so we need to calculate BatchDefinitions
+        regex_parser = RegExParser(
+            regex_pattern=batching_regex,
+            unnamed_regex_group_prefix=self._unnamed_regex_group_prefix,
+        )
         for data_reference in self.get_data_references():
             batch_definition = self._build_batch_definition(
                 data_reference=data_reference, regex_parser=regex_parser
             )
             batch_definitions[data_reference] = [batch_definition]
-        self._data_references_cache[batching_regex] = batch_definitions
 
         return batch_definitions
 

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import re
 from abc import abstractmethod
+from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from great_expectations.compatibility.typing_extensions import override
@@ -48,7 +49,7 @@ def file_get_unfiltered_batch_definition_list_fn(
     # Use a combination of a list and set to preserve iteration order
     batch_definition_list: list[LegacyBatchDefinition] = list()
     batch_definition_set = set()
-    for batch_definition in data_connector._get_batch_definition_list_from_data_references_cache():
+    for batch_definition in data_connector._get_batch_definitions():
         if (
             data_connector._batch_definition_matches_batch_request(
                 batch_definition=batch_definition, batch_request=batch_request
@@ -136,7 +137,9 @@ class FilePathDataConnector(DataConnector):
         self._get_unfiltered_batch_definition_list_fn = get_unfiltered_batch_definition_list_fn
 
         # This is a dictionary which maps data_references onto batch_requests.
-        self._data_references_cache: Dict[str, List[LegacyBatchDefinition] | None] = {}
+        self._data_references_cache: Dict[
+            re.Pattern, Dict[str, List[LegacyBatchDefinition] | None]
+        ] = defaultdict(dict)
 
     # Interface Method
     @override
@@ -198,14 +201,8 @@ class FilePathDataConnector(DataConnector):
     # Interface Method
     @override
     def get_data_reference_count(self) -> int:
-        """
-        Returns the list of data_references known by this DataConnector from its _data_references_cache
-
-        Returns:
-            number of data_references known by this DataConnector.
-        """  # noqa: E501
-        total_references: int = len(self._get_data_references_cache())
-        return total_references
+        data_references = self._get_data_references_cache(batching_regex=self._batching_regex)
+        return len(data_references)
 
     # Interface Method
     @override
@@ -270,6 +267,7 @@ class FilePathDataConnector(DataConnector):
             )
 
         data_reference_mapped_element: Tuple[str, Union[List[LegacyBatchDefinition], None]]
+        data_references = self._get_data_references_cache(batching_regex=self._batching_regex)
         # noinspection PyTypeChecker
         unmatched_data_references: List[str] = list(
             dict(
@@ -277,7 +275,7 @@ class FilePathDataConnector(DataConnector):
                     lambda data_reference_mapped_element: _matching_criterion(
                         batch_definition_list=data_reference_mapped_element[1]
                     ),
-                    self._get_data_references_cache().items(),
+                    data_references.items(),
                 )
             ).keys()
         )
@@ -339,74 +337,68 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         return regex
 
     def _get_data_references_cache(
-        self,
+        self, batching_regex: re.Pattern
     ) -> Dict[str, List[LegacyBatchDefinition] | None]:
-        """
-        This prototypical method populates cache, whose keys are data references and values are "BatchDefinition"
-        objects.  Subsequently, "BatchDefinition" objects generated are amenable to flexible querying and sorting.
+        """Access a map where keys are data references and values are LegacyBatchDefinitions."""
+        regex_parser = RegExParser(
+            regex_pattern=batching_regex,
+            unnamed_regex_group_prefix=self._unnamed_regex_group_prefix,
+        )
+        batch_definitions = self._data_references_cache.get(batching_regex)
+        if batch_definitions:
+            return batch_definitions
 
-        It examines every "data_reference" handle and converts it to zero or more "BatchDefinition" objects, based on
-        partitioning behavior of given subclass (e.g., Regular Expressions for file path based DataConnector
-        implementations).  Type of each "data_reference" is storage dependent.
-        """  # noqa: E501
-        if len(self._data_references_cache) == 0:
-            # Map data_references to batch_definitions.
-            for data_reference in self.get_data_references():
-                mapped_batch_definition_list: List[LegacyBatchDefinition] | None = (
-                    self._map_data_reference_string_to_batch_definition_list_using_regex(
-                        data_reference=data_reference
-                    )
-                )
-                self._data_references_cache[data_reference] = mapped_batch_definition_list
+        # Cache was empty so we need to calculate BatchDefinitions
+        for data_reference in self.get_data_references():
+            batch_definition = self._build_batch_definition(
+                data_reference=data_reference, regex_parser=regex_parser
+            )
+            batch_definitions[data_reference] = [batch_definition]
+        self._data_references_cache[batching_regex] = batch_definitions
 
-        return self._data_references_cache
+        return batch_definitions
 
-    def _get_batch_definition_list_from_data_references_cache(
+    def _get_batch_definitions(
         self,
     ) -> List[LegacyBatchDefinition]:
-        batch_definition_list: List[LegacyBatchDefinition] = [
+        batch_definition_map = self._get_data_references_cache(batching_regex=self._batching_regex)
+        batch_definitions = [
             batch_definitions[0]
-            for batch_definitions in self._get_data_references_cache().values()
+            for batch_definitions in batch_definition_map.values()
             if batch_definitions is not None
         ]
-        return batch_definition_list
+        return batch_definitions
 
-    def _map_data_reference_string_to_batch_definition_list_using_regex(
-        self, data_reference: str
-    ) -> List[LegacyBatchDefinition] | None:
-        batch_identifiers: Optional[IDDict] = (
-            self._convert_data_reference_string_to_batch_identifiers_using_regex(
-                data_reference=data_reference
-            )
+    def _build_batch_definition(
+        self, data_reference: str, regex_parser: RegExParser
+    ) -> LegacyBatchDefinition | None:
+        batch_identifiers: Optional[IDDict] = self._build_batch_identifiers(
+            data_reference=data_reference, regex_parser=regex_parser
         )
         if batch_identifiers is None:
             return None
 
-        # Importing at module level causes circular dependencies.
         from great_expectations.core.batch import LegacyBatchDefinition
 
-        return [
-            LegacyBatchDefinition(
-                datasource_name=self._datasource_name,
-                data_connector_name=_DATA_CONNECTOR_NAME,
-                data_asset_name=self._data_asset_name,
-                batch_identifiers=IDDict(batch_identifiers),
-            )
-        ]
+        return LegacyBatchDefinition(
+            datasource_name=self._datasource_name,
+            data_connector_name=_DATA_CONNECTOR_NAME,
+            data_asset_name=self._data_asset_name,
+            batch_identifiers=IDDict(batch_identifiers),
+        )
 
-    def _convert_data_reference_string_to_batch_identifiers_using_regex(
-        self, data_reference: str
+    def _build_batch_identifiers(
+        self, data_reference: str, regex_parser: RegExParser
     ) -> Optional[IDDict]:
-        # noinspection PyUnresolvedReferences
-        matches: Optional[re.Match] = self._regex_parser.get_matches(target=data_reference)
+        matches: Optional[re.Match] = regex_parser.get_matches(target=data_reference)
         if matches is None:
             return None
 
-        num_all_matched_group_values: int = self._regex_parser.get_num_all_matched_group_values()
+        num_all_matched_group_values: int = regex_parser.get_num_all_matched_group_values()
 
         # Check for `(?P<name>)` named group syntax
         defined_group_name_to_group_index_mapping: Dict[str, int] = (
-            self._regex_parser.get_named_group_name_to_group_index_mapping()
+            regex_parser.get_named_group_name_to_group_index_mapping()
         )
         defined_group_name_indexes: Set[int] = set(
             defined_group_name_to_group_index_mapping.values()

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -357,6 +357,8 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
                 data_reference=data_reference, regex_parser=regex_parser
             )
             if batch_definition:
+                # storing these as a list seems unnecessary; in this implementation
+                # there can only be one or zero BatchDefinitions per data reference
                 batch_definitions[data_reference] = [batch_definition]
             else:
                 batch_definitions[data_reference] = None

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -5,7 +5,7 @@ import logging
 import re
 from abc import abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import IDDict
@@ -137,7 +137,7 @@ class FilePathDataConnector(DataConnector):
         self._get_unfiltered_batch_definition_list_fn = get_unfiltered_batch_definition_list_fn
 
         # This is a dictionary which maps data_references onto batch_requests.
-        self._data_references_cache: Dict[
+        self._data_references_cache: DefaultDict[
             re.Pattern, Dict[str, List[LegacyBatchDefinition] | None]
         ] = defaultdict(dict)
 

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -356,7 +356,10 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
             batch_definition = self._build_batch_definition(
                 data_reference=data_reference, regex_parser=regex_parser
             )
-            batch_definitions[data_reference] = [batch_definition]
+            if batch_definition:
+                batch_definitions[data_reference] = [batch_definition]
+            else:
+                batch_definitions[data_reference] = None
 
         return batch_definitions
 


### PR DESCRIPTION
Previously, the FilePathDataConnector required a `batching_regex` on instantiation, which it uses throughout its lifecycle. The goal here is to rework the code to support passing `batching_regex` as a parameter when transforming a `BatchRequest` into `BatchDefinitions`.

This PR should be a functionally equivalent refactor; the class's `batching_regex` attribute is still the source of truth.

### changes
- `FilePathDataConnector._data_references_cache` changed types from `Dict[str, List[LegacyBatchDefinition] | None]` to `dict[re.Pattern, dict[str, list[LegacyBatchDefinition] | None]]` to allow caching results from multiple `batching_regex`.
