### PR TITLE
[MAINTENANCE] Speed up index.html by increasing bootstrap-table version

### DIFF
--- a/great_expectations/render/view/templates/js_script_imports.j2
+++ b/great_expectations/render/view/templates/js_script_imports.j2
@@ -14,6 +14,6 @@
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/bootstrap-table@1.19.1/dist/bootstrap-table.min.js"></script>
-<script src="https://unpkg.com/bootstrap-table@1.19.1/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.22.4/dist/bootstrap-table.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.20.2/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/js/bootstrap-datepicker.min.js"></script>

--- a/great_expectations/render/view/templates/page_minimal.j2
+++ b/great_expectations/render/view/templates/page_minimal.j2
@@ -8,9 +8,9 @@
 
     {# {# Remove this when not debugging: #}
     {# <meta http-equiv="refresh" content="1"/> #}
-    <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.19.1/dist/bootstrap-table.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.22.4/dist/bootstrap-table.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/bootstrap-table@1.19.0/dist/extensions/filter-control/bootstrap-table-filter-control.css">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/bootstrap-table@1.20.2/dist/extensions/filter-control/bootstrap-table-filter-control.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/css/bootstrap-datepicker.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@forevolve/bootstrap-dark@1.1.0/dist/css/bootstrap-prefers-dark.css" />
 


### PR DESCRIPTION
This PR updates the "bootstrap-table" dependency of the index.html page to speed up loading times in the browser.

To provide some numbers:
- loading index.html with ~450 validations/table rows takes >60s until the page is useable, i.e. I can interact with and filter the table [all required contents previously downloaded from S3 Store to local machine to rule out any infrastructural problems]

I could verify that the call to `bootstrapTable` causes the undesirable delay by either...
- reducing the html to a single entry in the table manually OR
- leaving the table as is, but switching to a different version of the loaded "bootstrap-table" script

... which in both cases reduced the loading times significantly [~1s]

There exists a closed issue in the GX repo from last year, which didn't get resolved:
https://github.com/great-expectations/great_expectations/issues/6701

- The increased loading times seem to be existing only in specific "bootstrap-table" versions, i.e. 1.19.x
- Versions of the filter-control >1.20.2 did not turn out to work properly when testing
- I was just not sure if picking matching versions for the base integration and the filtering extension is a better idea, instead of using the latest working versions for both


- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
