### PR TITLE
[MAINTENANCE] Refactor FilePathDataConnector

### DIFF
--- a/great_expectations/datasource/fluent/data_asset/data_connector/dbfs_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/dbfs_data_connector.py
@@ -9,14 +9,9 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector,
 )
-from great_expectations.datasource.fluent.data_asset.data_connector.file_path_data_connector import (  # noqa: E501
-    FilePathDataConnector,
-    file_get_unfiltered_batch_definition_list_fn,
-)
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import LegacyBatchDefinition
-    from great_expectations.datasource.fluent import BatchRequest
+    from great_expectations.alias_types import PathStr
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +39,7 @@ class DBFSDataConnector(FilesystemDataConnector):
         glob_directive: str = "**/*",
         data_context_root_directory: Optional[pathlib.Path] = None,
         file_path_template_map_fn: Optional[Callable] = None,
-        get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
-        ] = file_get_unfiltered_batch_definition_list_fn,
+        whole_directory_path_override: PathStr | None = None,
     ) -> None:
         super().__init__(
             datasource_name=datasource_name,
@@ -56,7 +49,7 @@ class DBFSDataConnector(FilesystemDataConnector):
             glob_directive=glob_directive,
             data_context_root_directory=data_context_root_directory,
             file_path_template_map_fn=file_path_template_map_fn,
-            get_unfiltered_batch_definition_list_fn=get_unfiltered_batch_definition_list_fn,
+            whole_directory_path_override=whole_directory_path_override,
         )
 
     @classmethod
@@ -70,9 +63,7 @@ class DBFSDataConnector(FilesystemDataConnector):
         glob_directive: str = "**/*",
         data_context_root_directory: Optional[pathlib.Path] = None,
         file_path_template_map_fn: Optional[Callable] = None,
-        get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
-        ] = file_get_unfiltered_batch_definition_list_fn,
+        whole_directory_path_override: PathStr | None = None,
     ) -> DBFSDataConnector:
         """Builds "DBFSDataConnector", which links named DataAsset to DBFS.
 
@@ -97,7 +88,7 @@ class DBFSDataConnector(FilesystemDataConnector):
             glob_directive=glob_directive,
             data_context_root_directory=data_context_root_directory,
             file_path_template_map_fn=file_path_template_map_fn,
-            get_unfiltered_batch_definition_list_fn=get_unfiltered_batch_definition_list_fn,
+            whole_directory_path_override=whole_directory_path_override,
         )
 
     # Interface Method

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -195,14 +195,15 @@ class FilePathDataConnector(DataConnector):
     def _get_unfiltered_batch_definition_list(
         self, batch_request: BatchRequest
     ) -> list[LegacyBatchDefinition]:
-        """Get all batch definitions for all files from a data connector using the supplied batch request.
+        """Get all batch definitions for all files from a data connector
+         using the supplied batch request.
 
         Args:
             batch_request: Specifies which batch definitions to get from data connector.
 
         Returns:
             A list of batch definitions from the data connector based on the batch request.
-        """  # noqa: E501
+        """
         if self._whole_directory_path_override:
             # if the override is present, we don't build BatchDefinitions based on a regex,
             # we just make a single BatchDefinition to capture the entire directory
@@ -374,17 +375,6 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
     def _build_batch_identifiers(
         self, data_reference: str, regex_parser: RegExParser
     ) -> Optional[IDDict]:
-        if self._whole_directory_path_override:
-            return self._build_batch_identifiers_whole_directory(
-                self._whole_directory_path_override
-            )
-        return self._build_batch_identifiers_from_data_reference(
-            data_reference=data_reference, regex_parser=regex_parser
-        )
-
-    def _build_batch_identifiers_from_data_reference(
-        self, data_reference: str, regex_parser: RegExParser
-    ) -> Optional[IDDict]:
         matches: Optional[re.Match] = regex_parser.get_matches(target=data_reference)
         if matches is None:
             return None
@@ -420,9 +410,6 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         batch_identifiers = IDDict(group_name_to_group_value_mapping)
 
         return batch_identifiers
-
-    def _build_batch_identifiers_whole_directory(self, data_directory: str) -> IDDict:
-        return IDDict({"path": data_directory})
 
     @abstractmethod
     def _get_full_file_path(self, path: str) -> str:

--- a/great_expectations/datasource/fluent/data_asset/data_connector/filesystem_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/filesystem_data_connector.py
@@ -14,13 +14,9 @@ from great_expectations.datasource.data_connector.util import (
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilePathDataConnector,
 )
-from great_expectations.datasource.fluent.data_asset.data_connector.file_path_data_connector import (  # noqa: E501
-    file_get_unfiltered_batch_definition_list_fn,
-)
 
 if TYPE_CHECKING:
-    from great_expectations.core.batch import LegacyBatchDefinition
-    from great_expectations.datasource.fluent import BatchRequest
+    from great_expectations.alias_types import PathStr
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +35,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         base_directory: Relative path to subdirectory containing files of interest
         glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
         data_context_root_directory: Optional GreatExpectations root directory (if installed on filesystem)
-        file_path_template_map_fn: Format function mapping path to fully-qualified resource on filesystem (optional)
+        whole_directory_path_override: Treat an entire directory as a single Asset
     """  # noqa: E501
 
     asset_level_option_keys: ClassVar[tuple[str, ...]] = ("glob_directive",)
@@ -54,9 +50,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         glob_directive: str = "**/*",
         data_context_root_directory: Optional[pathlib.Path] = None,
         file_path_template_map_fn: Optional[Callable] = None,
-        get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
-        ] = file_get_unfiltered_batch_definition_list_fn,
+        whole_directory_path_override: PathStr | None = None,
     ) -> None:
         self._base_directory = base_directory
         self._glob_directive: str = glob_directive
@@ -67,7 +61,7 @@ class FilesystemDataConnector(FilePathDataConnector):
             data_asset_name=data_asset_name,
             batching_regex=batching_regex,
             file_path_template_map_fn=file_path_template_map_fn,
-            get_unfiltered_batch_definition_list_fn=get_unfiltered_batch_definition_list_fn,
+            whole_directory_path_override=whole_directory_path_override,
         )
 
     @property
@@ -91,9 +85,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         glob_directive: str = "**/*",
         data_context_root_directory: Optional[pathlib.Path] = None,
         file_path_template_map_fn: Optional[Callable] = None,
-        get_unfiltered_batch_definition_list_fn: Callable[
-            [FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]
-        ] = file_get_unfiltered_batch_definition_list_fn,
+        whole_directory_path_override: PathStr | None = None,
     ) -> FilesystemDataConnector:
         """Builds "FilesystemDataConnector", which links named DataAsset to filesystem.
 
@@ -118,7 +110,7 @@ class FilesystemDataConnector(FilePathDataConnector):
             glob_directive=glob_directive,
             data_context_root_directory=data_context_root_directory,
             file_path_template_map_fn=file_path_template_map_fn,
-            get_unfiltered_batch_definition_list_fn=get_unfiltered_batch_definition_list_fn,
+            whole_directory_path_override=whole_directory_path_override,
         )
 
     @classmethod

--- a/great_expectations/datasource/fluent/directory_data_asset.py
+++ b/great_expectations/datasource/fluent/directory_data_asset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch import LegacyBatchDefinition
@@ -10,13 +10,10 @@ from great_expectations.core.id_dict import IDDict
 from great_expectations.datasource.fluent.constants import (
     _DATA_CONNECTOR_NAME,
 )
-from great_expectations.datasource.fluent.data_asset.data_connector.file_path_data_connector import (  # noqa: E501
-    FilePathDataConnector,
-    make_directory_get_unfiltered_batch_definition_list_fn,
-)
 from great_expectations.datasource.fluent.file_path_data_asset import _FilePathDataAsset
 
 if TYPE_CHECKING:
+    from great_expectations.alias_types import PathStr
     from great_expectations.datasource.fluent.batch_request import (
         BatchRequest,
     )
@@ -62,11 +59,10 @@ class _DirectoryDataAssetMixin(_FilePathDataAsset):
         return batch_definition_list
 
     @override
-    def get_unfiltered_batch_definition_list_fn(
+    def get_whole_directory_path_override(
         self,
-    ) -> Callable[[FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]]:
-        """Get the asset specific function for retrieving the unfiltered list of batch definitions."""  # noqa: E501
-        return make_directory_get_unfiltered_batch_definition_list_fn(self.data_directory)
+    ) -> PathStr:
+        return self.data_directory
 
     @override
     def _get_reader_method(self) -> str:

--- a/great_expectations/datasource/fluent/file_path_data_asset.py
+++ b/great_expectations/datasource/fluent/file_path_data_asset.py
@@ -8,7 +8,6 @@ from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Dict,
     List,
@@ -40,10 +39,6 @@ from great_expectations.datasource.fluent.constants import MATCH_ALL_PATTERN
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FILE_PATH_BATCH_SPEC_KEY,
 )
-from great_expectations.datasource.fluent.data_asset.data_connector.file_path_data_connector import (  # noqa: E501
-    FilePathDataConnector,
-    file_get_unfiltered_batch_definition_list_fn,
-)
 from great_expectations.datasource.fluent.data_asset.data_connector.regex_parser import (
     RegExParser,
 )
@@ -65,6 +60,7 @@ from great_expectations.datasource.fluent.spark_generic_partitioners import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.alias_types import PathStr
     from great_expectations.core.batch import BatchMarkers, LegacyBatchDefinition
     from great_expectations.core.id_dict import BatchSpec
     from great_expectations.core.partitioners import Partitioner
@@ -402,11 +398,13 @@ class _FilePathDataAsset(DataAsset):
             ) from e
         raise TestConnectionError(self._test_connection_error_message)
 
-    def get_unfiltered_batch_definition_list_fn(
+    def get_whole_directory_path_override(
         self,
-    ) -> Callable[[FilePathDataConnector, BatchRequest], list[LegacyBatchDefinition]]:
-        """Get the asset specific function for retrieving the unfiltered list of batch definitions."""  # noqa: E501
-        return file_get_unfiltered_batch_definition_list_fn
+    ) -> PathStr | None:
+        """If present, override DataConnector behavior in order to
+        treat an entire directory as a single Asset.
+        """
+        return None
 
     def _get_reader_method(self) -> str:
         raise NotImplementedError(

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.py
@@ -78,7 +78,7 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
             base_directory=self.base_directory,
             glob_directive=glob_directive,
             data_context_root_directory=self.data_context_root_directory,
-            get_unfiltered_batch_definition_list_fn=data_asset.get_unfiltered_batch_definition_list_fn(),
+            whole_directory_path_override=data_asset.get_whole_directory_path_override(),
         )
 
         # build a more specific `_test_connection_error_message`


### PR DESCRIPTION
Some key logic belonging to the `FilePathDataConnector` was previously declared as top level functions, then injected into the class on init, in order to allow callers to choose the functionality they need. This PR refactors that logic to be internal to the DataConnector, and instead exposes a flag to allow callers to select the functionality they require.

This PR should be a functionally equivalent refactor.

## the details
The default behavior of `FilePathDataConnector` is to use a `batching_regex` to generate a `LegacyBatchDefinition` for each data reference found. Some Assets -- specifically those inheriting from `_DirectoryDataAssetMixin` -- want to override this behavior, and instead receive a single `LegacyBatchDefinition` that treats the whole directory as a single Asset. The solution in this PR is to introduce a new parameter to the DataConnector init logic called `whole_directory_path_override: PathStr | None`. Callers who need a single asset can provide the directory as an override flag, and callers who want the standard functionality can pass `None`.

## why bother?
This PR is part of work which refactors the FilePathDataConnector to support passing batching_regex as a parameter when transforming a BatchRequest into BatchDefinitions. At minimum, the functions refactored in this PR will require an updated signature, and it may make sense to reorganize the code within the class. It's easier and safer to do that work when the logic governing to the DataConnector is fully encapsulated within it. Also, the callers of FilePathDataConnector don't actually want to define their own custom logic, so allowing them to pass in a task-critical function breaks the class abstraction unnecessarily.

## previous work
- https://github.com/great-expectations/great_expectations/pull/9704
