### PR TITLE
[MAINTENANCE] Provide default empty action list in V1 Checkpoint

### DIFF
--- a/great_expectations/checkpoint/v1_checkpoint.py
+++ b/great_expectations/checkpoint/v1_checkpoint.py
@@ -16,7 +16,7 @@ from great_expectations.checkpoint.actions import (
     StoreValidationResultAction,
     UpdateDataDocsAction,
 )
-from great_expectations.compatibility.pydantic import BaseModel, root_validator, validator
+from great_expectations.compatibility.pydantic import BaseModel, Field, root_validator, validator
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,  # noqa: TCH001
 )
@@ -67,7 +67,7 @@ class Checkpoint(BaseModel):
 
     name: str
     validation_definitions: List[ValidationDefinition]
-    actions: List[CheckpointAction]
+    actions: List[CheckpointAction] = Field(default_factory=list)
     result_format: ResultFormat = ResultFormat.SUMMARY
     id: Union[str, None] = None
 

--- a/tests/checkpoint/test_v1_checkpoint.py
+++ b/tests/checkpoint/test_v1_checkpoint.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 @pytest.mark.unit
 def test_checkpoint_no_validation_definitions_raises_error():
     with pytest.raises(ValueError) as e:
-        Checkpoint(name="my_checkpoint", validation_definitions=[], actions=[])
+        Checkpoint(name="my_checkpoint", validation_definitions=[])
 
     assert "Checkpoint must contain at least one validation definition" in str(e.value)
 
@@ -62,7 +62,6 @@ def test_checkpoint_save_success(mocker: MockerFixture):
     checkpoint = Checkpoint(
         name="my_checkpoint",
         validation_definitions=[mocker.Mock(spec=ValidationDefinition)],
-        actions=[],
     )
     store_key = context.v1_checkpoint_store.get_key.return_value
     checkpoint.save()
@@ -477,7 +476,7 @@ class TestCheckpointResult:
     @pytest.mark.unit
     def test_checkpoint_run_no_actions(self, validation_definition: ValidationDefinition):
         checkpoint = Checkpoint(
-            name=self.checkpoint_name, validation_definitions=[validation_definition], actions=[]
+            name=self.checkpoint_name, validation_definitions=[validation_definition]
         )
         result = checkpoint.run()
 
@@ -515,7 +514,7 @@ class TestCheckpointResult:
         self, validation_definition: ValidationDefinition
     ):
         checkpoint = Checkpoint(
-            name=self.checkpoint_name, validation_definitions=[validation_definition], actions=[]
+            name=self.checkpoint_name, validation_definitions=[validation_definition]
         )
         batch_parameters = {"my_param": "my_value"}
         expectation_parameters = {"my_other_param": "my_other_value"}
@@ -640,7 +639,7 @@ class TestCheckpointResult:
         )
 
         checkpoint = Checkpoint(
-            name=self.checkpoint_name, validation_definitions=[validation_definition], actions=[]
+            name=self.checkpoint_name, validation_definitions=[validation_definition]
         )
         result = checkpoint.run()
 

--- a/tests/core/factory/test_checkpoint_factory.py
+++ b/tests/core/factory/test_checkpoint_factory.py
@@ -19,7 +19,7 @@ def test_checkpoint_factory_get_uses_store_get(mocker: MockerFixture):
     store.has_key.return_value = True
     key = store.get_key.return_value
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
     store.get.return_value = checkpoint
     factory = CheckpointFactory(store=store)
@@ -40,7 +40,7 @@ def test_checkpoint_factory_get_raises_error_on_missing_key(mocker: MockerFixtur
     store = mocker.MagicMock(spec=CheckpointStore)
     store.has_key.return_value = False
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
     store.get.return_value = checkpoint
     factory = CheckpointFactory(store=store)
@@ -63,7 +63,7 @@ def test_checkpoint_factory_add_uses_store_add(mocker: MockerFixture):
     store.get.return_value = None
     factory = CheckpointFactory(store=store)
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
     store.get.return_value = checkpoint
 
@@ -82,7 +82,7 @@ def test_checkpoint_factory_add_raises_for_duplicate_key(mocker: MockerFixture):
     store.has_key.return_value = True
     factory = CheckpointFactory(store=store)
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
 
     # Act
@@ -105,7 +105,7 @@ def test_checkpoint_factory_delete_uses_store_remove_key(mocker: MockerFixture):
     key = store.get_key.return_value
     factory = CheckpointFactory(store=store)
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
 
     # Act
@@ -125,7 +125,7 @@ def test_checkpoint_factory_delete_raises_for_missing_checkpoint(mocker: MockerF
     store.has_key.return_value = False
     factory = CheckpointFactory(store=store)
     checkpoint = Checkpoint(
-        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)], actions=[]
+        name=name, validation_definitions=[mocker.Mock(spec=ValidationDefinition)]
     )
 
     # Act
@@ -172,7 +172,6 @@ def _test_checkpoint_factory_add_success(context):
         validation_definitions=[
             ValidationDefinition(name="validation_def", data=batch_def, suite=suite)
         ],
-        actions=[],
     )
     with pytest.raises(DataContextError, match=f"Checkpoint with name {name} was not found."):
         context.checkpoints.get(name)
@@ -208,7 +207,6 @@ def _test_checkpoint_factory_delete_success(context):
             validation_definitions=[
                 ValidationDefinition(name="validation_def", data=batch_def, suite=suite)
             ],
-            actions=[],
         )
     )
 


### PR DESCRIPTION
User should not have to pass `actions=[]` if they don't want any actions

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
