### PR TITLE
[FEATURE] Update expectations and checkpoints v1 stores to implement gx_cloud_response_json_to_object_collection

### DIFF
--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -247,8 +247,8 @@ class V1CheckpointStore(Store):
         return self._key_class(key=name)
 
     @override
-    @staticmethod
-    def gx_cloud_response_json_to_object_dict(response_json: dict) -> dict:
+    @classmethod
+    def gx_cloud_response_json_to_object_dict(cls, response_json: dict) -> dict:
         response_data = response_json["data"]
 
         checkpoint_data: dict
@@ -263,8 +263,13 @@ class V1CheckpointStore(Store):
         else:
             checkpoint_data = response_data
 
-        id: str = checkpoint_data["id"]
-        checkpoint_config_dict: dict = checkpoint_data["attributes"]["checkpoint_config"]
+        return cls._convert_raw_json_to_object_dict(checkpoint_data)
+
+    @override
+    @staticmethod
+    def _convert_raw_json_to_object_dict(data: dict) -> dict:
+        id: str = data["id"]
+        checkpoint_config_dict: dict = data["attributes"]["checkpoint_config"]
         checkpoint_config_dict["id"] = id
 
         return checkpoint_config_dict

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -138,8 +138,9 @@ class DatasourceStore(Store):
             return self._schema.loads(value)
 
     @override
-    @staticmethod
+    @classmethod
     def gx_cloud_response_json_to_object_dict(
+        cls,
         response_json: CloudResponsePayloadTD,  # type: ignore[override]
     ) -> dict:
         """
@@ -158,22 +159,7 @@ class DatasourceStore(Store):
 
     @override
     @staticmethod
-    def gx_cloud_response_json_to_object_collection(
-        response_json: CloudResponsePayloadTD,  # type: ignore[override]
-    ) -> list[dict]:
-        """
-        This method takes full json response from GX cloud and outputs a list of dicts appropriate for
-        deserialization into a collection of GX objects
-        """  # noqa: E501
-        logger.debug(f"GE Cloud Response JSON ->\n{pf(response_json, depth=3)}")
-        data = response_json["data"]
-        if not isinstance(data, list):
-            raise TypeError("GX Cloud did not return a collection of Datasources when expected")  # noqa: TRY003
-
-        return [DatasourceStore._convert_raw_json_to_object_dict(d) for d in data]
-
-    @staticmethod
-    def _convert_raw_json_to_object_dict(data: DataPayload) -> dict:
+    def _convert_raw_json_to_object_dict(data: DataPayload) -> dict:  # type: ignore[override]
         datasource_id: str = data["id"]
         datasource_config_dict: dict = data["attributes"]["datasource_config"]
         datasource_config_dict["id"] = datasource_id

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -102,20 +103,38 @@ class Store:
             )
         self._use_fixed_length_key = self._store_backend.fixed_length_key
 
-    @staticmethod
-    def gx_cloud_response_json_to_object_dict(response_json: Dict) -> Dict:
+    @classmethod
+    def gx_cloud_response_json_to_object_dict(cls, response_json: Dict) -> Dict:
         """
         This method takes full json response from GX cloud and outputs a dict appropriate for
         deserialization into a GX object
         """
         return response_json
 
-    @staticmethod
-    def gx_cloud_response_json_to_object_collection(response_json: Dict) -> List[Dict]:
+    @classmethod
+    def gx_cloud_response_json_to_object_collection(cls, response_json: Dict) -> List[Dict]:
         """
         This method takes full json response from GX cloud and outputs a list of dicts appropriate for
         deserialization into a collection of GX objects
         """  # noqa: E501
+        logger.debug(f"GE Cloud Response JSON ->\n{pf(response_json, depth=3)}")
+        data = response_json["data"]
+        if not isinstance(data, list):
+            raise TypeError("GX Cloud did not return a collection of Datasources when expected")  # noqa: TRY003
+
+        return [cls._convert_raw_json_to_object_dict(d) for d in data]
+
+    @staticmethod
+    def _convert_raw_json_to_object_dict(data: dict[str, Any]) -> dict[str, Any]:
+        """Method to convert data from API to raw object dict
+
+        This SHOULD be used by both gx_cloud_response_json_to_object_collection
+        and gx_cloud_response_json_to_object_dict. It is a means of keeping
+        response parsing DRY for different response types, e.g. collections
+        may be shaped like {"data": [item1, item2, ...]} while single items
+        may be shaped like {"data": item}. This allows for pulling out the
+        data key and passing it to the appropriate method for conversion.
+        """
         raise NotImplementedError
 
     def _validate_key(self, key: DataContextKey) -> None:

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -32,6 +32,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _create_checkpoint_config(name: str = "oss_test_checkpoint") -> dict[str, Any]:
+    return {
+        "name": name,
+        "expectation_suite_name": "oss_test_expectation_suite",
+        "validations": [
+            {
+                "expectation_suite_name": "taxi.demo_pass",
+            },
+            {
+                "batch_request": {
+                    "datasource_name": "oss_test_datasource",
+                    "data_connector_name": "oss_test_data_connector",
+                    "data_asset_name": "users",
+                },
+            },
+        ],
+    }
+
+
+_CHECKPOINT_ID = "7b5e962c-3c67-4a6d-b311-b48061d52103"
+_CHECKPOINT_CONFIG = _create_checkpoint_config()
+_ANOTHER_CHECKPOINT_CONFIG = _create_checkpoint_config("other name")
+
+
 @pytest.fixture
 def checkpoint_store_with_mock_backend(
     mocker: MockerFixture,
@@ -206,48 +230,20 @@ def test_checkpoint_store(empty_data_context):
     assert len(checkpoint_store.list_keys()) == 0
 
 
-@pytest.mark.cloud
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "response_json, expected, error_type",
     [
         pytest.param(
             {
                 "data": {
-                    "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
-                    "attributes": {
-                        "checkpoint_config": {
-                            "name": "oss_test_checkpoint",
-                            "expectation_suite_name": "oss_test_expectation_suite",
-                            "validations": [
-                                {
-                                    "expectation_suite_name": "taxi.demo_pass",
-                                },
-                                {
-                                    "batch_request": {
-                                        "datasource_name": "oss_test_datasource",
-                                        "data_connector_name": "oss_test_data_connector",
-                                        "data_asset_name": "users",
-                                    },
-                                },
-                            ],
-                        }
-                    },
+                    "id": _CHECKPOINT_ID,
+                    "attributes": {"checkpoint_config": _CHECKPOINT_CONFIG},
                 }
             },
             {
-                "expectation_suite_name": "oss_test_expectation_suite",
-                "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
-                "name": "oss_test_checkpoint",
-                "validations": [
-                    {"expectation_suite_name": "taxi.demo_pass"},
-                    {
-                        "batch_request": {
-                            "data_asset_name": "users",
-                            "data_connector_name": "oss_test_data_connector",
-                            "datasource_name": "oss_test_datasource",
-                        },
-                    },
-                ],
+                "id": _CHECKPOINT_ID,
+                **_CHECKPOINT_CONFIG,
             },
             None,
             id="single_config",
@@ -256,43 +252,12 @@ def test_checkpoint_store(empty_data_context):
         pytest.param(
             {
                 "data": [
-                    {
-                        "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
-                        "attributes": {
-                            "checkpoint_config": {
-                                "name": "oss_test_checkpoint",
-                                "expectation_suite_name": "oss_test_expectation_suite",
-                                "validations": [
-                                    {
-                                        "expectation_suite_name": "taxi.demo_pass",
-                                    },
-                                    {
-                                        "batch_request": {
-                                            "datasource_name": "oss_test_datasource",
-                                            "data_connector_name": "oss_test_data_connector",
-                                            "data_asset_name": "users",
-                                        },
-                                    },
-                                ],
-                            }
-                        },
-                    }
+                    {"id": _CHECKPOINT_ID, "attributes": {"checkpoint_config": _CHECKPOINT_CONFIG}}
                 ]
             },
             {
-                "expectation_suite_name": "oss_test_expectation_suite",
-                "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
-                "name": "oss_test_checkpoint",
-                "validations": [
-                    {"expectation_suite_name": "taxi.demo_pass"},
-                    {
-                        "batch_request": {
-                            "data_asset_name": "users",
-                            "data_connector_name": "oss_test_data_connector",
-                            "datasource_name": "oss_test_datasource",
-                        },
-                    },
-                ],
+                "id": _CHECKPOINT_ID,
+                **_CHECKPOINT_CONFIG,
             },
             None,
             id="single_config_in_list",

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -32,30 +32,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _create_checkpoint_config(name: str = "oss_test_checkpoint") -> dict[str, Any]:
-    return {
-        "name": name,
-        "expectation_suite_name": "oss_test_expectation_suite",
-        "validations": [
-            {
-                "expectation_suite_name": "taxi.demo_pass",
-            },
-            {
-                "batch_request": {
-                    "datasource_name": "oss_test_datasource",
-                    "data_connector_name": "oss_test_data_connector",
-                    "data_asset_name": "users",
-                },
-            },
-        ],
-    }
-
-
-_CHECKPOINT_ID = "7b5e962c-3c67-4a6d-b311-b48061d52103"
-_CHECKPOINT_CONFIG = _create_checkpoint_config()
-_ANOTHER_CHECKPOINT_CONFIG = _create_checkpoint_config("other name")
-
-
 @pytest.fixture
 def checkpoint_store_with_mock_backend(
     mocker: MockerFixture,
@@ -230,20 +206,48 @@ def test_checkpoint_store(empty_data_context):
     assert len(checkpoint_store.list_keys()) == 0
 
 
-@pytest.mark.unit
+@pytest.mark.cloud
 @pytest.mark.parametrize(
     "response_json, expected, error_type",
     [
         pytest.param(
             {
                 "data": {
-                    "id": _CHECKPOINT_ID,
-                    "attributes": {"checkpoint_config": _CHECKPOINT_CONFIG},
+                    "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                    "attributes": {
+                        "checkpoint_config": {
+                            "name": "oss_test_checkpoint",
+                            "expectation_suite_name": "oss_test_expectation_suite",
+                            "validations": [
+                                {
+                                    "expectation_suite_name": "taxi.demo_pass",
+                                },
+                                {
+                                    "batch_request": {
+                                        "datasource_name": "oss_test_datasource",
+                                        "data_connector_name": "oss_test_data_connector",
+                                        "data_asset_name": "users",
+                                    },
+                                },
+                            ],
+                        }
+                    },
                 }
             },
             {
-                "id": _CHECKPOINT_ID,
-                **_CHECKPOINT_CONFIG,
+                "expectation_suite_name": "oss_test_expectation_suite",
+                "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                "name": "oss_test_checkpoint",
+                "validations": [
+                    {"expectation_suite_name": "taxi.demo_pass"},
+                    {
+                        "batch_request": {
+                            "data_asset_name": "users",
+                            "data_connector_name": "oss_test_data_connector",
+                            "datasource_name": "oss_test_datasource",
+                        },
+                    },
+                ],
             },
             None,
             id="single_config",
@@ -252,12 +256,43 @@ def test_checkpoint_store(empty_data_context):
         pytest.param(
             {
                 "data": [
-                    {"id": _CHECKPOINT_ID, "attributes": {"checkpoint_config": _CHECKPOINT_CONFIG}}
+                    {
+                        "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                        "attributes": {
+                            "checkpoint_config": {
+                                "name": "oss_test_checkpoint",
+                                "expectation_suite_name": "oss_test_expectation_suite",
+                                "validations": [
+                                    {
+                                        "expectation_suite_name": "taxi.demo_pass",
+                                    },
+                                    {
+                                        "batch_request": {
+                                            "datasource_name": "oss_test_datasource",
+                                            "data_connector_name": "oss_test_data_connector",
+                                            "data_asset_name": "users",
+                                        },
+                                    },
+                                ],
+                            }
+                        },
+                    }
                 ]
             },
             {
-                "id": _CHECKPOINT_ID,
-                **_CHECKPOINT_CONFIG,
+                "expectation_suite_name": "oss_test_expectation_suite",
+                "id": "7b5e962c-3c67-4a6d-b311-b48061d52103",
+                "name": "oss_test_checkpoint",
+                "validations": [
+                    {"expectation_suite_name": "taxi.demo_pass"},
+                    {
+                        "batch_request": {
+                            "data_asset_name": "users",
+                            "data_connector_name": "oss_test_data_connector",
+                            "datasource_name": "oss_test_datasource",
+                        },
+                    },
+                ],
             },
             None,
             id="single_config_in_list",

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -646,7 +646,7 @@ def test_gx_cloud_response_json_to_object_dict(
         assert actual == expected
 
 
-@pytest.mark.cloud
+@pytest.mark.unit
 def test_gx_cloud_response_json_to_object_collection():
     response_json = {
         "data": [

--- a/tests/data_context/store/test_expectations_store.py
+++ b/tests/data_context/store/test_expectations_store.py
@@ -179,86 +179,53 @@ def test_expectations_store_report_same_id_with_same_configuration_TupleFilesyst
     assert gen_directory_tree_str(project_path) == initialized_directory_tree_with_store_backend_id
 
 
-@pytest.mark.cloud
+def _create_suite_config(name: str, id: str, expectations: list[dict] | None = None) -> dict:
+    return {
+        "id": id,
+        "name": name,
+        "expectations": expectations or [],
+        "meta": {},
+        "notes": None,
+    }
+
+
+_SUITE_CONFIG = _create_suite_config("my_suite", "03d61d4e-003f-48e7-a3b2-f9f842384da3")
+_SUITE_CONFIG_WITH_EXPECTATIONS = _create_suite_config(
+    "my_suite_with_expectations",
+    "03d61d4e-003f-48e7-a3b2-f9f842384da3",
+    [
+        {
+            "expectation_type": "expect_column_to_exist",
+            "id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
+            "kwargs": {"column": "infinities"},
+            "meta": {},
+            "expectation_context": None,
+            "rendered_content": [],
+        }
+    ],
+)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "response_json, expected, error_type",
     [
         pytest.param(
-            {
-                "data": {
-                    "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                    "name": "my_suite",
-                    "expectations": [],
-                    "meta": {},
-                    "notes": None,
-                }
-            },
-            {
-                "name": "my_suite",
-                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                "expectations": [],
-                "meta": {},
-                "notes": None,
-            },
+            {"data": _SUITE_CONFIG},
+            _SUITE_CONFIG,
             None,
             id="single_config",
         ),
         pytest.param({"data": []}, None, ValueError, id="empty_payload"),
         pytest.param(
-            {
-                "data": [
-                    {
-                        "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                        "name": "my_suite",
-                        "expectations": [],
-                        "meta": {},
-                        "notes": None,
-                    }
-                ]
-            },
-            {
-                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                "name": "my_suite",
-                "expectations": [],
-                "meta": {},
-                "notes": None,
-            },
+            {"data": [_SUITE_CONFIG]},
+            _SUITE_CONFIG,
             None,
             id="single_config_in_list",
         ),
         pytest.param(
-            {
-                "data": {
-                    "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                    "name": "my_suite",
-                    "expectations": [
-                        {
-                            "expectation_type": "expect_column_to_exist",
-                            "id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
-                            "kwargs": {"column": "infinities", "result_format": None},
-                            "meta": {},
-                        }
-                    ],
-                    "meta": {},
-                    "notes": None,
-                }
-            },
-            {
-                "name": "my_suite",
-                "id": "03d61d4e-003f-48e7-a3b2-f9f842384da3",
-                "expectations": [
-                    {
-                        "expectation_type": "expect_column_to_exist",
-                        "id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
-                        "kwargs": {"column": "infinities"},
-                        "meta": {},
-                        "expectation_context": None,
-                        "rendered_content": [],
-                    }
-                ],
-                "meta": {},
-                "notes": None,
-            },
+            {"data": _SUITE_CONFIG_WITH_EXPECTATIONS},
+            _SUITE_CONFIG_WITH_EXPECTATIONS,
             None,
             id="null_result_format",
         ),
@@ -273,6 +240,21 @@ def test_gx_cloud_response_json_to_object_dict(
     else:
         actual = ExpectationsStore.gx_cloud_response_json_to_object_dict(response_json)
         assert actual == expected
+
+
+@pytest.mark.unit
+def test_gx_cloud_response_json_to_object_collection():
+    response_json = {
+        "data": [
+            _SUITE_CONFIG,
+            _SUITE_CONFIG_WITH_EXPECTATIONS,
+        ]
+    }
+
+    result = ExpectationsStore.gx_cloud_response_json_to_object_collection(response_json)
+
+    expected = [_SUITE_CONFIG, _SUITE_CONFIG_WITH_EXPECTATIONS]
+    assert result == expected
 
 
 @pytest.mark.unit

--- a/tests/data_context/store/test_v1_checkpoint_store.py
+++ b/tests/data_context/store/test_v1_checkpoint_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import pytest
@@ -198,27 +198,31 @@ def test_get_key_cloud(cloud_backed_store: V1CheckpointStore):
     assert key.resource_name == "my_checkpoint"  # type: ignore[union-attr]
 
 
+def _create_checkpoint_config(name: str, id: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "validation_definitions": [
+            {"name": "my_first_validation", "id": "a58816-64c8-46cb-8f7e-03c12cea1d67"},
+            {"name": "my_second_validation", "id": "139ab16-64c8-46cb-8f7e-03c12cea1d67"},
+        ],
+        "actions": [
+            {
+                "name": "my_slack_action",
+                "slack_webhook": "https://hooks.slack.com/services/ABC123/DEF456/XYZ789",
+                "notify_on": "all",
+                "notify_with": ["my_data_docs_site"],
+                "renderer": {
+                    "class_name": "SlackRenderer",
+                },
+            }
+        ],
+        "result_format": "SUMMARY",
+        "id": id,
+    }
+
+
 _CHECKPOINT_ID = "a4sdfd-64c8-46cb-8f7e-03c12cea1d67"
-_CHECKPOINT_CONFIG = {
-    "name": "my_checkpoint",
-    "validation_definitions": [
-        {"name": "my_first_validation", "id": "a58816-64c8-46cb-8f7e-03c12cea1d67"},
-        {"name": "my_second_validation", "id": "139ab16-64c8-46cb-8f7e-03c12cea1d67"},
-    ],
-    "actions": [
-        {
-            "name": "my_slack_action",
-            "slack_webhook": "https://hooks.slack.com/services/ABC123/DEF456/XYZ789",
-            "notify_on": "all",
-            "notify_with": ["my_data_docs_site"],
-            "renderer": {
-                "class_name": "SlackRenderer",
-            },
-        }
-    ],
-    "result_format": "SUMMARY",
-    "id": _CHECKPOINT_ID,
-}
+_CHECKPOINT_CONFIG = _create_checkpoint_config("my_checkpoint", _CHECKPOINT_ID)
 
 
 @pytest.mark.unit
@@ -255,6 +259,35 @@ def test_gx_cloud_response_json_to_object_dict_success(response_json: dict):
     actual = V1CheckpointStore.gx_cloud_response_json_to_object_dict(response_json)
     expected = {**_CHECKPOINT_CONFIG, "id": _CHECKPOINT_ID}
     assert actual == expected
+
+
+@pytest.mark.unit
+def test_gx_cloud_response_json_to_object_collection():
+    id_a = "a4sdfd-64c8-46cb-8f7e-03c12cea1d67"
+    id_b = "a4sdfd-64c8-46cb-8f7e-03c12cea1d68"
+    config_a = _create_checkpoint_config("my_checkpoint_a", "something else?")
+    config_b = _create_checkpoint_config("my_checkpoint_b", id_b)
+    response_json = {
+        "data": [
+            {
+                "id": id_a,
+                "attributes": {
+                    "checkpoint_config": config_a,
+                },
+            },
+            {
+                "id": id_b,
+                "attributes": {
+                    "checkpoint_config": config_b,
+                },
+            },
+        ],
+    }
+
+    result = V1CheckpointStore.gx_cloud_response_json_to_object_collection(response_json)
+
+    expected = [{**config_a, "id": id_a}, {**config_b, "id": id_b}]
+    assert result == expected
 
 
 @pytest.mark.cloud

--- a/tests/data_context/store/test_v1_checkpoint_store.py
+++ b/tests/data_context/store/test_v1_checkpoint_store.py
@@ -221,7 +221,7 @@ _CHECKPOINT_CONFIG = {
 }
 
 
-@pytest.mark.cloud
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "response_json",
     [


### PR DESCRIPTION
## Goals
* Unlock the ability for our existing factories to implement `all`, which depends on their stores' `get_all`, which in turn relies on the stores' `gx_cloud_response_json_to_object_collection`
* Somewhat formalize a pattern that we can adopt more widely about how to do this

## Implementation
* Move `gx_cloud_response_json_to_object_collection` into the parent store
* Put a not implemented `_convert_raw_json_to_object_dict` in the parent store
* Override `_convert_raw_json_to_object_dict` in the 2 new stores we care about

## What this does not do
* We have a factory for `ValidationDefinition`, but we cannot yet implement `gx_cloud_response_json_to_object_collection` for that store because we don't yet have a REST endpoint
* This also leaves most stores in a state where they don't have the functionality implemented. They will get a `NotImplemented` error when calling `get_all`, but that behavior is the same as before (except now it raises from one step deeper in the call stack, in `_convert_raw_json_to_object_dict`
* Totally fix our inconsistencies. We should eventually move this logic into the cloud store backend, but we aren't there today.

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
