### PR TITLE
[DOCS] Update `add_expectation_configuration` method in Create and edit Expectations

### DIFF
--- a/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
+++ b/docs/docusaurus/versioned_docs/version-0.18/oss/guides/expectations/how_to_create_and_edit_an_expectationsuite_domain_knowledge.py
@@ -58,7 +58,7 @@ expectation_configuration_1 = ExpectationConfiguration(
     },
 )
 # Add the Expectation to the suite
-suite.add_expectation_configuration(
+suite.add_expectation(
     expectation_configuration=expectation_configuration_1
 )
 # </snippet>
@@ -72,7 +72,7 @@ expectation_configuration_2 = ExpectationConfiguration(
     },
     # Note optional comments omitted
 )
-suite.add_expectation_configuration(
+suite.add_expectation(
     expectation_configuration=expectation_configuration_2
 )
 # </snippet>
@@ -91,7 +91,7 @@ expectation_configuration_3 = ExpectationConfiguration(
         }
     },
 )
-suite.add_expectation_configuration(
+suite.add_expectation(
     expectation_configuration=expectation_configuration_3
 )
 # </snippet>
@@ -110,7 +110,7 @@ expectation_configuration_4 = ExpectationConfiguration(
         }
     },
 )
-suite.add_expectation_configuration(
+suite.add_expectation(
     expectation_configuration=expectation_configuration_4
 )
 # </snippet>


### PR DESCRIPTION
In [this Slack conversation](https://greatexpectationslabs.slack.com/archives/C03B8DZCJ07/p1712255423329769), @joshua-stauffer requested that `add_expectation_configuration` method references in the 0.18.X documentation should be changed to `add_expectation` because `add_expectation_configuration` is only available in GX 1.0. This PR implements the requested change. 

## Definition of done
- [X] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [X] Appropriate tests and docs have been updated